### PR TITLE
FF-417 : Ignore facets on expsetview if using term which isn't applicable

### DIFF
--- a/src/encoded/static/components/browse.js
+++ b/src/encoded/static/components/browse.js
@@ -430,7 +430,7 @@ var ResultTable = browse.ResultTable = React.createClass({
             sortReverse: false,
             overflowingRight : false,
             facets : FacetList.adjustedFacets(this.props.context.facets),
-            ignoredFilters : FacetList.findIgnoredFilters(
+            ignoredFilters : FacetList.findIgnoredFiltersByMissingFacets(
                 FacetList.adjustedFacets(this.props.context.facets),
                 this.props.expSetFilters
             )
@@ -457,7 +457,7 @@ var ResultTable = browse.ResultTable = React.createClass({
             newState.facets = FacetList.adjustedFacets(newProps.context.facets);
         }
         if (this.props.expSetFilters !== newProps.expSetFilters || newState.facets){
-            newState.ignoredFilters = FacetList.findIgnoredFilters(
+            newState.ignoredFilters = FacetList.findIgnoredFiltersByMissingFacets(
                 FacetList.adjustedFacets(newProps.context.facets),
                 newProps.expSetFilters
             );

--- a/src/encoded/static/components/browse.js
+++ b/src/encoded/static/components/browse.js
@@ -126,7 +126,7 @@ var ExperimentSetRow = module.exports.ExperimentSetRow = React.createClass({
 
     render: function() {
 
-        var fileDetailContainer = getFileDetailContainer(this.props.experimentArray, this.props.passExperiments)
+        var fileDetailContainer = getFileDetailContainer(this.props.experimentArray, this.props.passExperiments);
         var fileDetail = fileDetailContainer.fileDetail;
         var emptyExps = fileDetailContainer.emptyExps;
 

--- a/src/encoded/static/components/browse.js
+++ b/src/encoded/static/components/browse.js
@@ -90,21 +90,6 @@ var ExperimentSetRow = module.exports.ExperimentSetRow = React.createClass({
         };
     },
 
-    fileDetailContainer : null,
-
-    componentWillMount : function(){
-        // Cache to prevent re-executing on re-renders.
-        this.fileDetailContainer = getFileDetailContainer(this.props.experimentArray, this.props.passExperiments);
-    },
-
-    componentWillUpdate : function(nextProps, nextState){
-        if (nextProps.experimentArray !== this.props.experimentArray || nextProps.passExperiments !== this.props.passExperiments){
-            this.fileDetailContainer = getFileDetailContainer(nextProps.experimentArray, nextProps.passExperiments);
-        }
-
-
-    },
-
     componentWillReceiveProps: function(nextProps) {
 
         if(this.props.expSetFilters !== nextProps.expSetFilters){
@@ -141,8 +126,9 @@ var ExperimentSetRow = module.exports.ExperimentSetRow = React.createClass({
 
     render: function() {
 
-        var fileDetail = this.fileDetailContainer.fileDetail;
-        var emptyExps = this.fileDetailContainer.emptyExps;
+        var fileDetailContainer = getFileDetailContainer(this.props.experimentArray, this.props.passExperiments)
+        var fileDetail = fileDetailContainer.fileDetail;
+        var emptyExps = fileDetailContainer.emptyExps;
 
         var files = Object.keys(fileDetail);
         // unused for now... when format selection is added back in, adapt code below:
@@ -219,7 +205,7 @@ var ExperimentSetRow = module.exports.ExperimentSetRow = React.createClass({
                                     'File Type',
                                     'File Info'
                                 ]}
-                                fileDetailContainer={this.fileDetailContainer}
+                                fileDetailContainer={fileDetailContainer}
                                 parentController={this}
                                 expSetFilters={this.props.expSetFilters}
                                 facets={this.props.facets /* Not req'd here as using pre-completed fileDetailContainer' */ }

--- a/src/encoded/static/components/experiment-set-view.js
+++ b/src/encoded/static/components/experiment-set-view.js
@@ -7,7 +7,7 @@ var { ExperimentsTable, getFileDetailContainer } = require('./experiments-table'
 var _ = require('underscore');
 var { SubIPanel, DescriptorField, tipsFromSchema } = require('./item');
 var FacetList = require('./facetlist');
-var { ajaxLoad, textContentWidth, gridContainerWidth, isServerSide, DateUtility, console } = require('./objectutils');
+var { ajaxLoad, textContentWidth, gridContainerWidth, isServerSide, DateUtility, console, getNestedProperty } = require('./objectutils');
 var FormattedInfoBlock = require('./formatted-info-block');
 
 /**
@@ -21,7 +21,6 @@ var ExperimentSetView = module.exports.ExperimentSetView = React.createClass({
         context : React.PropTypes.object,
         expSetFilters : React.PropTypes.object,     // Set via app.js <ContentView...>
         expIncompleteFacets : React.PropTypes.array,
-        // facets = initially blank, but stored here to be shared between ExperimentsTable & FacetList; MUTABLE
         facets : React.PropTypes.array
     },
 
@@ -31,7 +30,7 @@ var ExperimentSetView = module.exports.ExperimentSetView = React.createClass({
 
     getDefaultProps : function(){
         return {
-            facets : null // MUTABLE ARRAY
+            facets : null
         };
     },
 
@@ -75,9 +74,9 @@ var ExperimentSetView = module.exports.ExperimentSetView = React.createClass({
             this.setState({
                 selectedFiles: new Set()
             });
-            this.updateFileDetailAndCachedCounts(false);
+            this.updateFileDetailAndCachedCounts(false, nextProps);
         } else if (this.props.context.experiments_in_set !== nextProps.context.experiments_in_set){
-            this.updateFileDetailAndCachedCounts(true);
+            this.updateFileDetailAndCachedCounts(true, nextProps);
         }
 
         /* For debugging
@@ -89,17 +88,22 @@ var ExperimentSetView = module.exports.ExperimentSetView = React.createClass({
 
     },
 
-    /** Same functionality as exists in ExperimentsTable */
-    updateFileDetailAndCachedCounts : function(updateTotals = false){
+    /** Same functionality as exists in ExperimentsTable, but with different method to get ignoredFilters */
+    updateFileDetailAndCachedCounts : function(updateTotals = false, props = this.props){
 
         // Set fileDetailContainer
-        var passExperiments = null, ignoredFilters = null, experimentArray = this.props.context.experiments_in_set;
+        var passExperiments = null, ignoredFilters = null, experimentArray = props.context.experiments_in_set;
 
-        if (!passExperiments && this.props.expSetFilters) {
-            if (this.props.facets && this.props.facets.length > 0) {
-                ignoredFilters = FacetList.findIgnoredFilters(this.props.facets, this.props.expSetFilters);
+        if (props.expSetFilters) {
+            if (props.facets && props.facets.length > 0) {
+                ignoredFilters = FacetList.findIgnoredFiltersByMissingFacets(props.facets, props.expSetFilters);
+            } else {
+                // Ignore filters if none in current experiment_set match it so that if coming from 
+                // another page w/ filters enabled and deselect own 'static'/single term, it isn't blank.
+                ignoredFilters = FacetList.findIgnoredFiltersByStaticTerms(experimentArray, props.expSetFilters);
+                console.log('ignoredFilters', ignoredFilters);
             }
-            passExperiments = FacetList.siftExperiments(experimentArray, this.props.expSetFilters, ignoredFilters);
+            passExperiments = FacetList.siftExperiments(experimentArray, props.expSetFilters, ignoredFilters);
         }
         
         this.fileDetailContainer = getFileDetailContainer(experimentArray, passExperiments);
@@ -312,7 +316,7 @@ var ExperimentSetHeader = React.createClass({
         if (!('date_created' in this.props.context)) return <span><i></i></span>;
         return (
             <span>
-                <i className="icon sbt-calendar"></i>&nbsp; Added 
+                <i className="icon sbt-calendar"></i>&nbsp; Added{' '}
                 <DateUtility.LocalizedTime timestamp={this.props.context.date_created} formatType='date-time-md' dateTimeSeparator=" at " />
             </span>
         );

--- a/src/encoded/static/components/experiment-set-view.js
+++ b/src/encoded/static/components/experiment-set-view.js
@@ -99,9 +99,8 @@ var ExperimentSetView = module.exports.ExperimentSetView = React.createClass({
                 ignoredFilters = FacetList.findIgnoredFiltersByMissingFacets(props.facets, props.expSetFilters);
             } else {
                 // Ignore filters if none in current experiment_set match it so that if coming from 
-                // another page w/ filters enabled and deselect own 'static'/single term, it isn't blank.
+                // another page w/ filters enabled (i.e. browse) and deselect own 'static'/single term, it isn't empty.
                 ignoredFilters = FacetList.findIgnoredFiltersByStaticTerms(experimentArray, props.expSetFilters);
-                console.log('ignoredFilters', ignoredFilters);
             }
             passExperiments = FacetList.siftExperiments(experimentArray, props.expSetFilters, ignoredFilters);
         }

--- a/src/encoded/static/components/experiments-table.js
+++ b/src/encoded/static/components/experiments-table.js
@@ -193,7 +193,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
 
         if (!passExperiments && props.expSetFilters) {
             if (props.facets && props.facets.length > 0) {
-                ignoredFilters = FacetList.findIgnoredFilters(props.facets, props.expSetFilters);
+                ignoredFilters = FacetList.findIgnoredFiltersByMissingFacets(props.facets, props.expSetFilters);
             }
             passExperiments = FacetList.siftExperiments(props.experimentArray, props.expSetFilters, ignoredFilters);
         }

--- a/src/encoded/static/components/facetlist.js
+++ b/src/encoded/static/components/facetlist.js
@@ -391,15 +391,15 @@ var FacetList = module.exports = React.createClass({
                 var eliminated = false;
                 for(var k=0; k < filterKeys.length; k++){
                     var refinedFilterSet;
-                    if (ignored instanceof Set && ignored.has(filterKeys[k])) { // We ignore facet completely.
-                        refinedFilterSet = new Set(); // Blank set
-                    } else if (typeof ignored === 'object' && ignored[filterKeys[k]] && ignored[filterKeys[k]].size > 0){
-                        // remove the ignored filters by using the difference between sets
-                        var difference = new Set([...filters[filterKeys[k]]].filter(x => !ignored[filterKeys[k]].has(x)));
-                        refinedFilterSet = difference;
-                    }else{
-                        refinedFilterSet = filters[filterKeys[k]];
+                    if (ignored !== null) {
+                        if (ignored instanceof Set && ignored.has(filterKeys[k])) { // We ignore facet completely.
+                            refinedFilterSet = new Set(); // Blank set
+                        } else if (typeof ignored === 'object' && ignored[filterKeys[k]] && ignored[filterKeys[k]].size > 0){
+                            // remove the ignored filters by using the difference between sets
+                            refinedFilterSet = new Set([...filters[filterKeys[k]]].filter(x => !ignored[filterKeys[k]].has(x)));
+                        }
                     }
+                    if (typeof refinedFilterSet === 'undefined') refinedFilterSet = filters[filterKeys[k]];
                     if(eliminated){
                         break;
                     }

--- a/src/encoded/static/components/facetlist.js
+++ b/src/encoded/static/components/facetlist.js
@@ -3,7 +3,7 @@ var url = require('url');
 var queryString = require('query-string');
 var _ = require('underscore');
 var store = require('../store');
-var { ajaxLoad, getNestedProperty, console } = require('./objectutils');
+var { ajaxLoad, getNestedProperty, flattenArrays, console } = require('./objectutils');
 
 
 /**
@@ -154,11 +154,9 @@ var ExpTerm = React.createClass({
             () => {
                 this.props.changeFilters(
                     this.props.facet.field,
-                    this.props.term.key,
-                    ()=> {
-                        this.setState({ filtering : false })
-                    }
-                )
+                    this.props.term.key
+                );
+                this.setState({ filtering : false });
             }
         );
     },
@@ -393,7 +391,11 @@ var FacetList = module.exports = React.createClass({
                 var eliminated = false;
                 for(var k=0; k < filterKeys.length; k++){
                     var refinedFilterSet;
-                    if(ignored && ignored[filterKeys[k]] && ignored[filterKeys[k]].size > 0){
+                    //console.log('FILTERKEYS', ignored, filterKeys[k], filters);
+                    if (ignored instanceof Set && ignored.has(filterKeys[k])) { // We ignore facet completely.
+                        refinedFilterSet = new Set(); // Blank set
+                        //console.log('YAY IS SET');
+                    } else if (typeof ignored === 'object' && ignored[filterKeys[k]] && ignored[filterKeys[k]].size > 0){
                         // remove the ignored filters by using the difference between sets
                         var difference = new Set([...filters[filterKeys[k]]].filter(x => !ignored[filterKeys[k]].has(x)));
                         refinedFilterSet = difference;
@@ -509,11 +511,10 @@ var FacetList = module.exports = React.createClass({
          * 
          * @return {Object} The filters which are ignored. Object looks like expSetFilters.
          */
-        findIgnoredFilters : function(facets, expSetFilters){
+        findIgnoredFiltersByMissingFacets : function(facets, expSetFilters){
             var ignoredFilters = {};
             for(var i=0; i < facets.length; i++){
                 var ignoredSet = new Set();
-                
                 if(expSetFilters[facets[i].field]){
                     for(let expFilter of expSetFilters[facets[i].field]){
                         var found = false;
@@ -535,6 +536,42 @@ var FacetList = module.exports = React.createClass({
             }
             if (Object.keys(ignoredFilters).length) console.log("Found Ignored Filters: ", ignoredFilters);
             return ignoredFilters;
+        },
+
+        /**
+         * Find filters which to ignore based on if all experiments in experimentArray which are being filtered
+         * have the same term for that selected filter. Geared towards usage by ExperimentSetView.
+         * 
+         * @param {Object[]} experimentArray - Experiments which are being filtered.
+         * @param {Object} expSetFilters - Object containing facet field name as key and set of terms to filter by as value.
+         * @param {string} [expsOrSets] - Whether are filtering experiments or sets, in order to standardize facet names.
+         */
+        findIgnoredFiltersByStaticTerms : function(experimentArray, expSetFilters, expsOrSets = 'experiments'){
+            
+            return new Set(
+                Object.keys(expSetFilters).filter((selectedFacet, i)=>{ // Get facets/filters w/ only 1 applicable term
+
+                    // Filter facets by those whose term value is same in all experiments
+                    return flattenArrays(
+                        // getNestedProperty returns array(s) if property is nested within array(s), so we needa flatten to get list of terms.
+                        experimentArray.map((experiment, j)=>{
+                            var termVal = getNestedProperty(
+                                experiment,
+                                ExpTerm.standardizeFieldKey(selectedFacet, expsOrSets, true)
+                            );
+                            if (Array.isArray(termVal)){ // Only include terms by which we're filtering
+                                return termVal.filter((term) => expSetFilters[selectedFacet].has(term));
+                            }
+                            return termVal;
+                        })
+                    ).filter((experimentTermValue, j, allTermValues)=>{ 
+                        // Reduce to unique term vals (indexOf returns first index, so if is repeat occurance, returns false)
+                        return allTermValues.indexOf(experimentTermValue) === j;
+                    })
+                    .length < 2;
+                    
+                })
+            );
         },
 
         /** 
@@ -692,7 +729,7 @@ var FacetList = module.exports = React.createClass({
             this.loadFacets(() => {
                 FacetList.fillFacetTermsAndCountFromExps(this.facets, this.props.experimentSetListJSON);
                 if (!this.props.ignoredFilters) {
-                    this.ignoredFilters = FacetList.findIgnoredFilters(this.facets, this.props.expSetFilters);
+                    this.ignoredFilters = FacetList.findIgnoredFiltersByMissingFacets(this.facets, this.props.expSetFilters);
                 } // else: @see getInitialState
             });
         } // else if (this.state.usingProvidedFacets === false && this.state.facetsLoaded) : @see componentWillMount
@@ -740,7 +777,7 @@ var FacetList = module.exports = React.createClass({
             }
 
             if (!this.props.ignoredFilters && (this.state.usingProvidedFacets === true || this.state.facetsLoaded)){
-                this.ignoredFilters = FacetList.findIgnoredFilters(this.facets, this.props.expSetFilters);
+                this.ignoredFilters = FacetList.findIgnoredFiltersByMissingFacets(this.facets, this.props.expSetFilters);
             } // else: See @componentDidMount > this.loadFacets() callback param
         }
     },
@@ -812,15 +849,10 @@ var FacetList = module.exports = React.createClass({
                 newObj = Object.assign({}, this.props.expSetFilters);
                 delete newObj[field];
             }
-
-            var unsubscribe = store.subscribe(()=>{
-                unsubscribe();
-                if (typeof callback === 'function') setTimeout(callback, 0);
-            });
-
             store.dispatch({
                 type : {'expSetFilters' : newObj}
             });
+            if (typeof callback === 'function') setTimeout(callback, 0);
 
         }.bind(this), 1);
     },

--- a/src/encoded/static/components/facetlist.js
+++ b/src/encoded/static/components/facetlist.js
@@ -390,17 +390,13 @@ var FacetList = module.exports = React.createClass({
             for(let experiment of passExperiments){
                 var eliminated = false;
                 for(var k=0; k < filterKeys.length; k++){
-                    var refinedFilterSet;
-                    if (ignored !== null) {
-                        if (ignored instanceof Set && ignored.has(filterKeys[k])) { // We ignore facet completely.
-                            refinedFilterSet = new Set(); // Blank set
-                        } else if (typeof ignored === 'object' && ignored[filterKeys[k]] && ignored[filterKeys[k]].size > 0){
-                            // remove the ignored filters by using the difference between sets
-                            refinedFilterSet = new Set([...filters[filterKeys[k]]].filter(x => !ignored[filterKeys[k]].has(x)));
-                        }
+                    var refinedFilterSet = null;
+                    if (ignored && typeof ignored === 'object' && ignored[filterKeys[k]] && ignored[filterKeys[k]].size > 0){
+                        // remove the ignored filters by using the difference between sets
+                        refinedFilterSet = new Set([...filters[filterKeys[k]]].filter(x => !ignored[filterKeys[k]].has(x)));
                     }
-                    if (typeof refinedFilterSet === 'undefined') refinedFilterSet = filters[filterKeys[k]];
-                    if(eliminated){
+                    if (refinedFilterSet === null) refinedFilterSet = filters[filterKeys[k]];
+                    if (eliminated){
                         break;
                     }
                     var valueProbe = experiment;
@@ -545,12 +541,12 @@ var FacetList = module.exports = React.createClass({
          * @param {string} [expsOrSets] - Whether are filtering experiments or sets, in order to standardize facet names.
          */
         findIgnoredFiltersByStaticTerms : function(experimentArray, expSetFilters, expsOrSets = 'experiments'){
-            
-            return new Set(
-                Object.keys(expSetFilters).filter((selectedFacet, i)=>{ // Get facets/filters w/ only 1 applicable term
+            var ignored = {};
+            Object.keys(expSetFilters).forEach((selectedFacet, i)=>{ // Get facets/filters w/ only 1 applicable term
 
-                    // Filter facets by those whose term value is same in all experiments
-                    return flattenArrays(
+                // Unique terms in all experiments per filter
+                if (
+                    flattenArrays(
                         // getNestedProperty returns array(s) if property is nested within array(s), so we needa flatten to get list of terms.
                         experimentArray.map((experiment, j)=>{
                             var termVal = getNestedProperty(
@@ -565,11 +561,13 @@ var FacetList = module.exports = React.createClass({
                     ).filter((experimentTermValue, j, allTermValues)=>{ 
                         // Reduce to unique term vals (indexOf returns first index, so if is repeat occurance, returns false)
                         return allTermValues.indexOf(experimentTermValue) === j;
-                    })
-                    .length < 2;
+                    }).length < 2
+                ) {
+                    ignored[selectedFacet] = expSetFilters[selectedFacet]; // Ignore all terms in filter.
+                }
 
-                })
-            );
+            });
+            return ignored;
         },
 
         /** 

--- a/src/encoded/static/components/facetlist.js
+++ b/src/encoded/static/components/facetlist.js
@@ -391,10 +391,8 @@ var FacetList = module.exports = React.createClass({
                 var eliminated = false;
                 for(var k=0; k < filterKeys.length; k++){
                     var refinedFilterSet;
-                    //console.log('FILTERKEYS', ignored, filterKeys[k], filters);
                     if (ignored instanceof Set && ignored.has(filterKeys[k])) { // We ignore facet completely.
                         refinedFilterSet = new Set(); // Blank set
-                        //console.log('YAY IS SET');
                     } else if (typeof ignored === 'object' && ignored[filterKeys[k]] && ignored[filterKeys[k]].size > 0){
                         // remove the ignored filters by using the difference between sets
                         var difference = new Set([...filters[filterKeys[k]]].filter(x => !ignored[filterKeys[k]].has(x)));
@@ -569,7 +567,7 @@ var FacetList = module.exports = React.createClass({
                         return allTermValues.indexOf(experimentTermValue) === j;
                     })
                     .length < 2;
-                    
+
                 })
             );
         },

--- a/src/encoded/static/components/objectutils.js
+++ b/src/encoded/static/components/objectutils.js
@@ -309,6 +309,20 @@ var getNestedProperty = module.exports.getNestedProperty = function(object, prop
 
 };
 
+/**
+ * Flatten any level/depth of arrays (e.g. as might be returned from @see getNestedProperty
+ * if getting a property nested within array(s)) into a single one. Does not support
+ * objects or sets, just arrays.
+ * 
+ * @param {*[]} arr - An array containing other arrays to flatten.
+ * @return {*[]} - A shallow, flattened array.
+ */
+var flattenArrays = module.exports.flattenArrays = function(arr){
+    if (arr.length > 0 && Array.isArray(arr[0])){
+        return arr.reduce((a,b) => a.concat(flattenArrays(b)), []);
+    } else return arr;
+}
+
 
 var DateUtility = module.exports.DateUtility = (function(){
 


### PR DESCRIPTION
E.g. coming from Browse page with multiple terms from one facet selected to ExpSetView where all Exps share a single term from that facet, so if deselect that single term on ExpSetView, experiments don't disappear due to other non-applicable term still being active.