### PR TITLE
Add tier to calc prop

### DIFF
--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -1,7 +1,7 @@
 {
-    "title": "FASTA file",
-    "description": "Schema for submitting metadata for a FASTA file.",
-    "id": "/profiles/file_fasta.json",
+    "title": "Processed file",
+    "description": "Schema for submitting metadata for a processed file.",
+    "id": "/profiles/file_processed.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": ["award", "lab"],

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -57,7 +57,8 @@ class Biosource(Item):
         "description": "Specific name of the biosource.",
         "type": "string",
     })
-    def biosource_name(self, request, biosource_type, individual=None, cell_line=None, tissue=None):
+    def biosource_name(self, request, biosource_type, individual=None,
+                       cell_line=None, cell_line_tier=None, tissue=None):
         cell_line_types = ['immortalized cell line', 'primary cell', 'in vitro differentiated cells',
                            'induced pluripotent stem cell line', 'stem cell']
         if biosource_type == "tissue":
@@ -65,6 +66,9 @@ class Biosource(Item):
                 return tissue
         elif biosource_type in cell_line_types:
             if cell_line:
+                if cell_line_tier:
+                    if cell_line_tier != 'Unclassified':
+                        return cell_line + '(' + cell_line_tier + ')'
                 return cell_line
         elif biosource_type == "whole organisms":
             if individual:

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -68,7 +68,7 @@ class Biosource(Item):
             if cell_line:
                 if cell_line_tier:
                     if cell_line_tier != 'Unclassified':
-                        return cell_line + '(' + cell_line_tier + ')'
+                        return cell_line + ' (' + cell_line_tier + ')'
                 return cell_line
         elif biosource_type == "whole organisms":
             if individual:


### PR DESCRIPTION
Because we have cell lines from specific lots that will be considered Tier 1 or Tier 2 but those cell lines have been used in previous experiments before this designation - eg. GM12878 used in Rao et al. vs. newly submitted experiments that will use Tier 1 GM12878 I modified the calculated property that generates biosource_name so that if a cell line is one of the tiered ones the Tier is included in the biosource_name so that users can easily distinguish this.