### PR TITLE
The id field in the quality_metric_fastqc did not match the schema na…

### DIFF
--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -1,7 +1,7 @@
 {
     "title": "Processed file from workflow runs",
     "description": "Schema for submitting metadata for a FASTA file.",
-    "id": "/profiles/file_pr0cessed.json",
+    "id": "/profiles/file_processed.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": ["award", "lab"],

--- a/src/encoded/schemas/quality_metric_fastqc.json
+++ b/src/encoded/schemas/quality_metric_fastqc.json
@@ -1,6 +1,6 @@
 {
     "description": "Schema for reporting the specific calculation of an quality metrics",
-    "id": "/profiles/fastqc_quality_metric.json",
+    "id": "/profiles/quality_metric_fastqc.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [],

--- a/src/encoded/tests/test_schemas.py
+++ b/src/encoded/tests/test_schemas.py
@@ -75,6 +75,14 @@ def test_load_schema(schema, master_mixins, registry):
         verify_mixins(loaded_schema, master_mixins)
 
     if schema not in ['namespaces.json', 'mixins.json']:
+        # check that schema.id is same as /profiles/schema
+        idtag = loaded_schema['id']
+        idtag = idtag.replace('/profiles/', '')
+        # special case for access_key.json
+        if schema == 'access_key.json':
+            idtag = idtag.replace('_admin', '')
+        assert schema == idtag
+
         # check for pluralized and camel cased in collection_names
         val = None
         for name in collection_names:


### PR DESCRIPTION
…me - fixed and wrote a test to check that all schema file names and ids match

Just a quick fix - I'm finding these kind of things as I'm working on API documentation and that work is in a branch of Submit4DN.  So creating fourfront branches specific for these straightforward fixes.    