### PR TITLE
Browse table fix

### DIFF
--- a/src/encoded/static/components/experiments-table.js
+++ b/src/encoded/static/components/experiments-table.js
@@ -646,8 +646,10 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                             pairsObj[file['@id']] = { '1' : file };
                         } else if (Array.isArray(file.related_files)) {
                             _.each(file.related_files, function(related){
-                                if (pairsObj[related.file['@id']]) {
-                                    pairsObj[related.file['@id']][file.paired_end + ''] = file;
+                                // Handle if related_files.file is embedded obj w/ @id or if is link (an @id itself).
+                                var relatedFileID = (related.file && related.file['@id']) || related.file;
+                                if (pairsObj[relatedFileID]) {
+                                    pairsObj[relatedFileID][file.paired_end + ''] = file;
                                 } else {
                                     file.unpaired = true; // Mark file as unpaired
                                 }

--- a/src/encoded/static/components/experiments-table.js
+++ b/src/encoded/static/components/experiments-table.js
@@ -9,9 +9,9 @@ var { isServerSide, console } = require('./objectutils');
 /**
  * To be used within Experiments Set View/Page, or
  * within a collapsible row on the browse page.
- * 
+ *
  * Shows experiments only, not experiment sets.
- * 
+ *
  * Allows either table component itself to control state of "selectedFiles"
  * or for a parentController (passed in as a prop) to take over management
  * of "selectedFiles" Set and "checked", for integration with other pages/UI.
@@ -24,21 +24,21 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
         /* List of headers which are created/controlled by component (not customizable), by experimentset_type */
         builtInHeaders : function(expSetType = 'replicate'){
             switch (expSetType){
-                case 'replicate' : 
+                case 'replicate' :
                     return [
                         { className: 'biosample', title: 'Biosample Accession' },
                         { className: 'experiment', title: 'Experiment Accession' },
                         { className: 'file-pair', title: 'File Pair', visibleTitle : <i className="icon icon-download"></i> },
                         { className: 'file', title: 'File Accession' },
                     ];
-                default: 
+                default:
                     return [
                         { className: 'biosample', title: 'Biosample Accession' },
                         { className: 'experiment', title: 'Experiment Accession'},
                         { className: 'file', title: 'File Accession' },
                     ];
             }
-            
+
         },
 
         /* Returns undefined if not set */
@@ -64,7 +64,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
             }
         },
 
-        /** 
+        /**
          * Calculate amount of experiments out of provided experiments which match currently-set filters.
          * Use only for front-end faceting, e.g. on Exp-Set View page where all experiments are provided,
          * NOT (eventually) for /browse/ page where faceting results will be controlled by back-end.
@@ -95,7 +95,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                     ignoredFilters = FacetList.findIgnoredFiltersByMissingFacets(facets, filters);
                 }
             } else if (getIgnoredFiltersMethod === 'single-term') {
-                // Ignore filters if none in current experiment_set match it so that if coming from 
+                // Ignore filters if none in current experiment_set match it so that if coming from
                 // another page w/ filters enabled (i.e. browse) and deselect own 'static'/single term, it isn't empty.
                 ignoredFilters = FacetList.findIgnoredFiltersByStaticTerms(allExperiments, filters);
             }
@@ -283,13 +283,13 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                         }
                         return (
                             <div className={"name col-" + this.props.columnClass} style={style}>
-                                { this.props.label ? 
+                                { this.props.label ?
                                     ExperimentsTable.StackedBlock.Name.renderBlockLabel(
                                         this.props.label.title,
                                         this.props.label.subtitle,
                                         false,
                                         this.props.label.subtitleVisible === true ? 'subtitle-visible' : null
-                                    ) 
+                                    )
                                 : null }
                                 { this.adjustedChildren() }
                             </div>
@@ -308,7 +308,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                                 handleCollapseToggle : React.PropTypes.func
                                 // + those from parent .List
                             },
-                            
+
                             shouldComponentUpdate : function(nextProps){
                                 if (this.props.collapsed !== nextProps.collapsed) return true;
                                 if (this.props.currentlyCollapsing !== nextProps.currentlyCollapsing) return true;
@@ -321,8 +321,8 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
 
                                 if (this.props.collapsibleChildren.length === 0) return null;
 
-                                var collapsedMsg = this.props.collapsed && 
-                                (this.props.currentlyCollapsing ? 
+                                var collapsedMsg = this.props.collapsed &&
+                                (this.props.currentlyCollapsing ?
                                     (this.props.currentlyCollapsing === this.props.parentID ? false : true)
                                     :
                                     true
@@ -408,9 +408,9 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
 
                     handleCollapseToggle : function(){
                         if (this.props.expTable && this.props.expTable.state && !this.props.expTable.state.collapsing){
-                            this.props.expTable.setState({ 
+                            this.props.expTable.setState({
                                 'collapsing' : this.props.rootList ? 'root' :
-                                    this.props.parentID || this.props.className || true 
+                                    this.props.parentID || this.props.className || true
                             }, ()=>{
                                 this.setState({ 'collapsed' : !this.state.collapsed });
                             });
@@ -578,14 +578,14 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                 )
             },
 
-            /** 
+            /**
              *  Partial Funcs (probably don't use these unless composing a function)
              */
 
             combineWithReplicateNumbers : function(experimentsWithReplicateNums, fullExperimentData){
                 if (!Array.isArray(experimentsWithReplicateNums)) return false;
                 return _(experimentsWithReplicateNums).chain()
-                    .map(function(r){ 
+                    .map(function(r){
                         return {
                             'tec_rep_no' : r.tec_rep_no || null,
                             'bio_rep_no' : r.bio_rep_no || null,
@@ -614,8 +614,8 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                     if (Array.isArray(exp.files)){
                         return ExperimentsTable.funcs.findUnpairedFiles(exp.files);
                     } else if (
-                        Array.isArray(exp.filesets) && 
-                        exp.filesets.length > 0 && 
+                        Array.isArray(exp.filesets) &&
+                        exp.filesets.length > 0 &&
                         Array.isArray(exp.filesets[0].files_in_set)
                     ){
                         return ExperimentsTable.funcs.findUnpairedFiles(
@@ -646,8 +646,8 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                             pairsObj[file['@id']] = { '1' : file };
                         } else if (Array.isArray(file.related_files)) {
                             _.each(file.related_files, function(related){
-                                if (pairsObj[related.file]) {
-                                    pairsObj[related.file][file.paired_end + ''] = file;
+                                if (pairsObj[related.file['@id']]) {
+                                    pairsObj[related.file['@id']][file.paired_end + ''] = file;
                                 } else {
                                     file.unpaired = true; // Mark file as unpaired
                                 }
@@ -674,8 +674,8 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                     if (Array.isArray(exp.files)){
                         file_pairs = ExperimentsTable.funcs.groupFilesByPairs(exp.files);
                     } else if (
-                        Array.isArray(exp.filesets) && 
-                        exp.filesets.length > 0 && 
+                        Array.isArray(exp.filesets) &&
+                        exp.filesets.length > 0 &&
                         Array.isArray(exp.filesets[0].files_in_set)
                     ){
                         file_pairs = ExperimentsTable.funcs.groupFilesByPairs(
@@ -741,13 +741,13 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
         selectedFiles : React.PropTypes.instanceOf(Set),
         parentController : function(props, propName, componentName){
             // Custom validation
-            if (props[propName] && 
+            if (props[propName] &&
                 (!(props[propName].state.selectedFiles instanceof Set))
             ){
                 return new Error('parentController must be a React Component passed in as "this", with "selectedFiles" (Set) and "checked" (bool) in its state.');
-            } 
+            }
         },
-        keepCounts : React.PropTypes.bool // Whether to run updateCachedCounts and store output in this.counts (get from instance if ref, etc.) 
+        keepCounts : React.PropTypes.bool // Whether to run updateCachedCounts and store output in this.counts (get from instance if ref, etc.)
     },
 
     getDefaultProps : function(){
@@ -762,7 +762,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
     },
 
     cache : null,
-    
+
     getInitialState: function() {
         this.cache = {
             origColumnWidths : null,
@@ -775,8 +775,8 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
             mounted : false
         };
         if (!(
-            this.props.parentController && 
-            this.props.parentController.state && 
+            this.props.parentController &&
+            this.props.parentController.state &&
             this.props.parentController.state.selectedFiles
         )) initialState.selectedFiles = new Set();
         return initialState;
@@ -810,7 +810,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
         var newColWidths = origColumnWidths.map(function(c){
             return Math.floor(c * scale);
         });
-        
+
         // Adjust first column by few px to fit perfectly.
         var totalNewColsWidth = _.reduce(newColWidths, function(m,v){ return m + v }, 0);
         var remainder = availableWidth - totalNewColsWidth;
@@ -882,7 +882,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
     selectedFiles : function(){
         //if (this.props.selectedFiles) {
         //    return this.props.selectedFiles;
-        if (this.props.parentController && this.props.parentController.state.selectedFiles){ 
+        if (this.props.parentController && this.props.parentController.state.selectedFiles){
             return this.props.parentController.state.selectedFiles;
         } else if (this.state.selectedFiles){
             return this.state.selectedFiles;
@@ -891,8 +891,8 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
     },
 
     handleFileUpdate: function (uuid, add=true){
-        
-        var selectedFiles = this.selectedFiles(); 
+
+        var selectedFiles = this.selectedFiles();
         if (!selectedFiles) return null;
 
         if(add){
@@ -913,23 +913,23 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                 'selectedFiles': selectedFiles
             });
         }
-        
+
     },
 
     renderExperimentBlock : function(exp,i){
         this.cache.oddExpRow = !this.cache.oddExpRow;
-        
+
         var contentsClassName = Array.isArray(exp.file_pairs) ? 'file-pairs' : 'files';
 
         return (
-            <ExperimentsTable.StackedBlock 
+            <ExperimentsTable.StackedBlock
                 key={exp['@id']}
                 hideNameOnHover={true}
                 columnClass="experiment"
-                label={{ 
+                label={{
                     title : 'Experiment',
                     subtitle : (
-                        exp.tec_rep_no ? 'Tech Replicate ' + exp.tec_rep_no : 
+                        exp.tec_rep_no ? 'Tech Replicate ' + exp.tec_rep_no :
                             exp.experiment_type ? exp.experiment_type : null
                     ),
                     subtitleVisible: true
@@ -940,8 +940,8 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                 <ExperimentsTable.StackedBlock.Name relativePosition={ExperimentsTable.funcs.fileCount(exp) > 6}>
                     <a href={ exp['@id'] || '#' } className="name-title mono-text">{ exp.accession }</a>
                 </ExperimentsTable.StackedBlock.Name>
-                <ExperimentsTable.StackedBlock.List 
-                    className={contentsClassName} 
+                <ExperimentsTable.StackedBlock.List
+                    className={contentsClassName}
                     title={contentsClassName === 'file-pairs' ? 'File Pairs' : 'Files'}
                 >
                     { contentsClassName === 'file-pairs' ? /* File Pairs Exist */
@@ -953,7 +953,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                                 columnHeaders={this.customColumnHeaders()}
                                 handleFileUpdate={this.handleFileUpdate}
                                 label={ exp.file_pairs.length > 1 ?
-                                    { title : "Pair " + (i + 1) } : { title : "Pair" } 
+                                    { title : "Pair " + (i + 1) } : { title : "Pair" }
                                 }
                             />
                         )
@@ -1003,7 +1003,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                 id={'bio-' + (expsWithBiosample[0].biosample.bio_rep_no || i + 1)}
                 label={{
                     title : 'Biosample',
-                    subtitle : expsWithBiosample[0].biosample.bio_rep_no ? 
+                    subtitle : expsWithBiosample[0].biosample.bio_rep_no ?
                         'Bio Replicate ' + expsWithBiosample[0].biosample.bio_rep_no
                         :
                         expsWithBiosample[0].biosample.biosource_summary,
@@ -1026,20 +1026,20 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                     showMoreExtTitle={
                         expsWithBiosample.length > 5 ?
                             'with ' + (
-                                _.all(expsWithBiosample.slice(3), function(exp){ 
-                                    return exp.file_pairs !== 'undefined' 
+                                _.all(expsWithBiosample.slice(3), function(exp){
+                                    return exp.file_pairs !== 'undefined'
                                 }) ? /* Do we have filepairs for all exps? */
                                     _.flatten(_.pluck(expsWithBiosample.slice(3), 'file_pairs'), true).length +
                                     ' File Pairs'
                                     :
-                                    ExperimentsTable.funcs.fileCountFromExperiments(expsWithBiosample.slice(3)) + 
+                                    ExperimentsTable.funcs.fileCountFromExperiments(expsWithBiosample.slice(3)) +
                                     ' Files'
                             )
                             :
                             null
                     }
                 />
-                
+
             </ExperimentsTable.StackedBlock>
         );
     },
@@ -1057,7 +1057,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
      * |             Experiment ___________________________|
      * |                         File   File Detail Columns|
      * |___________________________________________________|
-     * 
+     *
      * Much of styling/layouting is defined in CSS.
      */
     renderRootStackedBlockListOfBiosamplesWithExperiments : function(experimentsGroupedByBiosample){
@@ -1090,7 +1090,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                 ExperimentsTable.funcs.groupFilesByPairsForEachExperiment,
                 ExperimentsTable.funcs.combineWithReplicateNumbers
             );
-            
+
             return (
                 <div className="body clearfix">
                     { experimentsGroupedByBiosample(this.props.replicateExpsArray, this.props.experimentArray) }
@@ -1134,7 +1134,7 @@ var ExperimentsTable = module.exports.ExperimentsTable = React.createClass({
                 <div className="headers expset-headers" ref="header">
                     { this.columnHeaders().map(renderHeader) }
                 </div>
-                { this.props.experimentSetType && typeof this.renderers[this.props.experimentSetType] === 'function' ? 
+                { this.props.experimentSetType && typeof this.renderers[this.props.experimentSetType] === 'function' ?
                     this.renderers[this.props.experimentSetType].call(this) : this.renderers.default.call(this) }
             </div>
         );
@@ -1225,7 +1225,7 @@ var FilePairBlock = React.createClass({
             <div className="s-block file-pair">
                 { nameColumn.call(this) }
                 <div className="files s-block-list">
-                    { Array.isArray(this.props.files) ? 
+                    { Array.isArray(this.props.files) ?
                         this.props.files.map(this.renderFileEntryBlock)
                         :
                         <FileEntryBlock file={null} columnHeaders={ this.props.columnHeaders } colWidthStyles={this.props.colWidthStyles} />
@@ -1261,7 +1261,7 @@ var FileEntryBlock  = React.createClass({
     handleCheck: function() {
         this.updateFileChecked(!this.isChecked());
     },
-    
+
     filledFileRow : function (file = this.props.file){
         var row = [];
         var cols = this.props.columnHeaders;
@@ -1272,7 +1272,7 @@ var FileEntryBlock  = React.createClass({
             var className = baseClassName + ' col-' + cols[i].className + ' detail-col-' + i;
             var title = cols[i].valueTitle || cols[i].title;
 
-            if (!file || !file['@id']) { 
+            if (!file || !file['@id']) {
                 row.push(<div key={"file-detail-empty-" + i} className={className + i} style={baseStyle}></div>);
                 continue;
             }
@@ -1356,7 +1356,7 @@ var FileEntryBlock  = React.createClass({
                     'col-file'
                 );
             }
-            
+
             if (Array.isArray(this.props.columnHeaders)) {
                 var headerTitles = _.pluck(this.props.columnHeaders, 'title');
                 if (
@@ -1366,7 +1366,7 @@ var FileEntryBlock  = React.createClass({
                     return ExperimentsTable.StackedBlock.Name.renderBlockLabel(
                         'File', this.props.file.file_type || this.props.file.file_format, false, 'col-file'
                     );
-                } 
+                }
                 if (
                     this.props.file.instrument &&
                     _.intersection(headerTitles,['Instrument', 'File Instrument']).length === 0
@@ -1376,7 +1376,7 @@ var FileEntryBlock  = React.createClass({
                     );
                 }
             }
-            
+
             return ExperimentsTable.StackedBlock.Name.renderBlockLabel('File', null, false, 'col-file');
         }
 
@@ -1408,7 +1408,7 @@ var FileEntryBlock  = React.createClass({
 
 /**
  * Returns an object containing fileDetail and emptyExps.
- * 
+ *
  * @param {Object[]} experimentArray - Array of experiments in set. Required.
  * @param {Set} [passedExperiments=null] - Set of experiments which match filter(s).
  * @return {Object} JS object containing two keys with arrays: 'fileDetail' of experiments with formatted details and 'emptyExps' with experiments with no files.
@@ -1496,7 +1496,7 @@ var getFileDetailContainer = module.exports.getFileDetailContainer = function(ex
 
 var FileEntry = React.createClass({
 
-    // TODO (ideally): Functionality to customize columns (e.g. pass in a schema instead of list of 
+    // TODO (ideally): Functionality to customize columns (e.g. pass in a schema instead of list of
     // column names, arrange fields appropriately under them).
 
     getInitialState: function() {
@@ -1575,14 +1575,14 @@ var FileEntry = React.createClass({
             for (var i = 0; i < columnHeadersShortened.length; i++){
 
                 if (columnHeadersShortened[i] == 'File Accession'){
-                    if (!exists) { 
+                    if (!exists) {
                         f.push(<td>No files</td>);
                         continue;
-                    } 
+                    }
                     f.push(<td><a href={file['@id'] || ''}>{file.accession || file.uuid || file['@id']}</a></td>);
                 }
 
-                if (!exists) { 
+                if (!exists) {
                     f.push(<td></td>);
                     continue;
                 }
@@ -1647,7 +1647,7 @@ var FileEntry = React.createClass({
             relatedFile = relationship.data;
         }
 
-        var fileInfo = this.fastQFilePairRow(file, relatedFile); 
+        var fileInfo = this.fastQFilePairRow(file, relatedFile);
         // Maybe later can do like switch...case for which function to run (fastQFilePairRow or other)
         // to fill fileInfo according to type of file or experiment type.
         var fileOne = fileInfo.fileOne;
@@ -1670,7 +1670,7 @@ var FileEntry = React.createClass({
                 </td>
             );
         //}
-        
+
         return(
             <tbody>
                 <tr className='expset-sublist-entry'>
@@ -1678,7 +1678,7 @@ var FileEntry = React.createClass({
                         <td rowSpan="2" className="expset-exp-cell expset-checkbox-cell">
                             <Checkbox validationState='warning' checked={this.state.checked} name="file-checkbox" id={fileID} className='expset-checkbox-sub' onChange={this.handleCheck}/>
                         </td>
-                    : 
+                    :
                         <td rowSpan="2" className="expset-exp-cell expset-checkbox-cell">
                             <Checkbox checked={false} disabled={true} className='expset-checkbox-sub' />
                         </td>

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -71,6 +71,8 @@ class ExperimentSet(Item):
                 "experiments_in_set.biosample.treatments",
                 "experiments_in_set.biosample.biosource.individual.organism",
                 "experiments_in_set.files",
+                "experiments_in_set.files.related_files.relationship_type",
+                "experiments_in_set.files.related_files.file",
                 "experiments_in_set.filesets",
                 "experiments_in_set.filesets.files_in_set",
                 "experiments_in_set.digestion_enzyme"]


### PR DESCRIPTION
Small fixes in types/experiment_set.py and experiments-table to make tables correctly display file pairs on browse.