### PR TITLE
FF-702

### DIFF
--- a/base.ini
+++ b/base.ini
@@ -4,7 +4,7 @@ create_tables = true
 sqlalchemy.url = postgresql:///encoded
 tm.attempts = 3
 file_upload_bucket = encoded-4dn-files
-#file_upload_profile_name = encoded-4dn-files 
+#file_upload_profile_name = encoded-4dn-files
 # this really shouldn't be used with development, only uncomment if your sure
 system_bucket = elasticbeanstalk-encoded-4dn-system
 elasticsearch.server = localhost:9200
@@ -36,7 +36,7 @@ multiauth.policy.accesskey.base = encoded.authentication.BasicAuthAuthentication
 multiauth.policy.accesskey.check = encoded.authentication.basic_auth_check
 
 multiauth.policy.auth0.use = encoded.authentication.NamespacedAuthenticationPolicy
-multiauth.policy.auth0.namespace = auth0 
+multiauth.policy.auth0.namespace = auth0
 multiauth.policy.auth0.base = encoded.authentication.Auth0AuthenticationPolicy
 
 auth0.siteName = 4DN DCC Submission

--- a/development.ini
+++ b/development.ini
@@ -7,11 +7,12 @@
 use = config:base.ini#app
 sqlalchemy.url = postgresql://postgres@:5432/postgres?host=/tmp/snovault/pgdata
 snp_search.server = localhost:9200
+blob_bucket = encoded-4dn-blobs
 load_test_only = true
 create_tables = true
 testing = true
 postgresql.statement_timeout = 20
-indexer.processes = 
+indexer.processes =
 
 pyramid.reload_templates = true
 pyramid.debug_authorization = false

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -258,6 +258,11 @@
                 "height": {
                     "title": "Image height",
                     "type": "integer"
+                },
+                "blob_id":{
+                    "title": "Blob ID",
+                    "type": "string",
+                    "internal_comment": "blob storage ID. Use to like with s3/rds"
                 }
             }
         }


### PR DESCRIPTION
Added blob_id to attachment mixin schema. Also set up development.ini so that local deployment uses encoded-4dn-blobs s3 bucket for blob (attachment) storage. Pairs with FF-702 snovault PR, which was merged in new_indexing_embedding.