### PR TITLE
FF-913

### DIFF
--- a/src/encoded/schemas/experiment_set.json
+++ b/src/encoded/schemas/experiment_set.json
@@ -79,14 +79,17 @@
         }
     },
     "facets": {
+        "award.project": {
+            "title": "Project"
+        },
+        "publications_of_set.display_title": {
+            "title": "Publication"
+        },
         "experimentset_type": {
             "title": "Set Type"
         },
         "experiments_in_set.experiment_type": {
             "title": "Experiment Type"
-        },
-        "award.project": {
-            "title": "Project"
         },
         "experiments_in_set.biosample.biosource.individual.organism.name": {
             "title": "Organism"
@@ -108,9 +111,6 @@
         },
         "lab.title": {
             "title": "Lab"
-        },
-        "publications_of_set.display_title": {
-            "title": "Publication"
         }
     },
     "columns": {

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -155,7 +155,7 @@ def search(context, request, search_type=None, return_generator=False, forced_ty
 
 
 @view_config(route_name='browse', request_method='GET', permission='search')
-def browse(context, request, search_type=None, return_generator=False):
+def browse(context, request, search_type='ExperimentSetReplicate', return_generator=False):
     """
     Simply use search results for browse view
     """

--- a/src/encoded/static/components/navigation.js
+++ b/src/encoded/static/components/navigation.js
@@ -307,6 +307,7 @@ class SearchBar extends React.Component{
             <form className="navbar-form navbar-right" action="/search/">
                 <input className="form-control search-query" id="navbar-search" type="search" placeholder="Search"
                     ref="q" name="q" defaultValue={searchQuery} key={searchQuery} />
+                <input id="type-select" type="hidden" ref="type" name="type" value="ExperimentSetReplicate"/>
             </form>
         );
     }

--- a/src/encoded/tests/test_types_user.py
+++ b/src/encoded/tests/test_types_user.py
@@ -15,7 +15,7 @@ def user_w_lab(testapp, lab):
     res = testapp.post_json('/user', item)
     return testapp.get(res.location).json
 
-def test_user_subscriptions(submitter, admin, user_w_lab):
+def test_user_subscriptions(submitter, admin, user_w_lab, lab):
     # submitter has submits_for but no lab
     assert 'submits_for' in submitter
     assert len(submitter['subscriptions']) == 1
@@ -23,7 +23,7 @@ def test_user_subscriptions(submitter, admin, user_w_lab):
     # user_w_lab has lab but no submits_for
     assert 'lab' in user_w_lab
     assert len(user_w_lab['subscriptions']) == 1
-    assert user_w_lab['subscriptions'][0]['title'] == 'My lab'
+    assert user_w_lab['subscriptions'][0]['title'] == lab['title']
     # admin has no submits_for and no lab, thus should have no subscriptions
     assert 'lab' not in admin
     assert admin['submits_for'] == []
@@ -37,7 +37,7 @@ def test_subscriptions_dont_duplicate_on_update(registry, lab, user_w_lab):
         'last_name': 'McUser',
         'email': 'user@mcuser.org',
         'status': 'current',
-        'subscriptions': [{'url': '?lab.link_id=~labs~encode-lab~&sort=-date_created', 'title': 'My lab'}]
+        'subscriptions': [{'url': '?lab.link_id=~labs~encode-lab~&sort=-date_created', 'title': 'ENCODE lab'}]
     }
     test_user = User.create(registry, None, user_data)
     assert len(test_user.properties['subscriptions']) == 1


### PR DESCRIPTION
Carl's portal polishing tasks:
* Project and Publication should be first facets [Carl]
* https://testportal.4dnucleome.org/browse should lead to browse experiment sets. [Carl]
search bar redirects to type=ExperimentSetReplicate [Carl]
* “My lab” is uninformative, especially if I have multiple labs. The name of the lab would be more useful. [Carl]
* Not-signed-in, I see submitter as a link on Item page. [Carl] (fixed by snovault branch default_embed_principals)