### PR TITLE
'Create/Add' Button Permissions & Collection-Type-Selection

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -199,7 +199,7 @@ def get_available_facets(context, request, search_type=None):
 
 def get_collection_actions(request, type_info):
     collection = request.registry[COLLECTIONS].get(type_info.name)
-    if collection: # We don't find a collection if type=Item, for example.
+    if collection and hasattr(collection, 'actions'):
         return collection.actions(request)
     else:
         return None

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -150,10 +150,7 @@ def search(context, request, search_type=None, return_generator=False, forced_ty
             result['@graph'] = list(graph)
             return result
 
-
-    if types[doc_types[0]].name in request.registry[COLLECTIONS]:
-        result['actions'] = request.registry[COLLECTIONS][types[doc_types[0]].name].actions(request)
-
+    result['actions'] = get_collection_actions(request, types[doc_types[0]])
     result['@graph'] = list(graph)
     return result
 
@@ -198,6 +195,14 @@ def get_available_facets(context, request, search_type=None):
         })
 
     return result
+
+
+def get_collection_actions(request, type_info):
+    collection = request.registry[COLLECTIONS].get(type_info.name)
+    if collection: # We don't find a collection if type=Item, for example.
+        return collection.actions(request)
+    else:
+        return None
 
 
 def get_pagination(request):

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -150,6 +150,7 @@ def search(context, request, search_type=None, return_generator=False, forced_ty
             result['@graph'] = list(graph)
             return result
 
+
     if types[doc_types[0]].name in request.registry[COLLECTIONS]:
         result['actions'] = request.registry[COLLECTIONS][types[doc_types[0]].name].actions(request)
 

--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -127,6 +127,9 @@ def search(context, request, search_type=None, return_generator=False, forced_ty
         params.append(('limit', 'all'))
         result['all'] = '%s?%s' % (request.resource_path(context), urlencode(params))
 
+    # add actions (namely 'add')
+    result['actions'] = get_collection_actions(request, types[doc_types[0]])
+
     if not result['total']:
         # http://googlewebmastercentral.blogspot.com/2014/02/faceted-navigation-best-and-5-of-worst.html
         request.response.status_code = 404
@@ -150,7 +153,6 @@ def search(context, request, search_type=None, return_generator=False, forced_ty
             result['@graph'] = list(graph)
             return result
 
-    result['actions'] = get_collection_actions(request, types[doc_types[0]])
     result['@graph'] = list(graph)
     return result
 

--- a/src/encoded/static/components/submission/expandable-tree.js
+++ b/src/encoded/static/components/submission/expandable-tree.js
@@ -83,6 +83,7 @@ class SubmissionProperty extends React.Component {
         var { field, schemas, keyTypes, keyIdx, hierarchy, keyLinks, depth } = this.props;
 
         var itemSchema = schemas[keyTypes[keyIdx]];
+        if (!itemSchema) return null;
         var isRequired = Array.isArray(itemSchema.required) && _.contains(itemSchema.required, field);
         var fieldBase = field.split('.')[0];
         var fieldSchema = itemSchema.properties[fieldBase];
@@ -146,6 +147,7 @@ class SubmissionLeaf extends React.Component{
 
     placeholderSortFxn(fieldA, fieldB){
         var itemSchema = this.props.schemas[this.props.keyTypes[this.props.keyIdx]];
+        if (!itemSchema) return 0;
         var fieldABase = fieldA.split('.')[0];
         var fieldBBase = fieldB.split('.')[0];
 

--- a/src/encoded/static/components/submission/submission-view.js
+++ b/src/encoded/static/components/submission/submission-view.js
@@ -367,11 +367,7 @@ export default class SubmissionView extends React.Component{
         var schema = this.props.schemas[type];
         var newIdx = this.state.ambiguousIdx;
         var newLink = this.state.creatingLink;
-
-        var newKeyTypes = _.clone(this.state.keyTypes);
-        newKeyTypes[newIdx] = type;
         var stateChange = {
-            'keyTypes'          : newKeyTypes,
             'ambiguousIdx'      : null,
             'ambiguousType'     : null,
             'ambiguousSelected' : null
@@ -537,8 +533,8 @@ export default class SubmissionView extends React.Component{
             newHierarchy = modifyHierarchy(hierarchy, keyIdx, parentKeyIdx);
             validCopy[keyIdx] = 1; // new object has no incomplete children yet
             validCopy[parentKeyIdx] = 0; // parent is now not ready for validation
-            typesCopy[keyIdx] = type;
         }
+        typesCopy[keyIdx] = type;
         var contextWithAlias = (contextCopy && contextCopy[keyIdx]) ? contextCopy[keyIdx] : {};
         if(contextWithAlias.aliases){
             contextWithAlias.aliases.push(alias);

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -51,7 +51,8 @@ ONLY_ADMIN_VIEW = [
 # This acl allows item creation; it is easily overwritten in lab and user,
 # as these items should not be available for creation
 SUBMITTER_CREATE = [
-    (Allow, 'group.submitter', ['add', 'create'])
+    (Allow, 'group.submitter', 'add'),
+    (Allow, 'group.submitter', 'create')
 ]
 
 ALLOW_EVERYONE_VIEW = [
@@ -471,7 +472,7 @@ class SharedItem(Item):
 @snovault.calculated_property(context=Item.AbstractCollection, category='action')
 def add(context, request):
     """smth."""
-    if request.has_permission('add'):
+    if request.has_permission('add', context):
         return {
             'name': 'add',
             'title': 'Add',

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -51,7 +51,7 @@ ONLY_ADMIN_VIEW = [
 # This acl allows item creation; it is easily overwritten in lab and user,
 # as these items should not be available for creation
 SUBMITTER_CREATE = [
-    (Allow, 'group.submitter', 'create'),
+    (Allow, 'group.submitter', ['add', 'create'])
 ]
 
 ALLOW_EVERYONE_VIEW = [
@@ -92,9 +92,7 @@ DELETED = [
 
 # Collection acls
 
-ALLOW_SUBMITTER_ADD = [
-    (Allow, 'group.submitter', ['add']),
-] + SUBMITTER_CREATE
+ALLOW_SUBMITTER_ADD = SUBMITTER_CREATE
 
 
 def paths_filtered_by_status(request, paths, exclude=('deleted', 'replaced'), include=None):
@@ -470,7 +468,7 @@ class SharedItem(Item):
         return roles
 
 
-@snovault.calculated_property(context=Item.Collection, category='action')
+@snovault.calculated_property(context=Item.AbstractCollection, category='action')
 def add(context, request):
     """smth."""
     if request.has_permission('add'):

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -9,13 +9,15 @@ from snovault import (
 from .base import (
     Item,
     paths_filtered_by_status,
-    get_item_if_you_can
+    get_item_if_you_can,
+    ALLOW_SUBMITTER_ADD
 )
 
 
 @abstract_collection(
     name='experiments',
     unique_key='accession',
+    acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': "Experiments",
         'description': 'Listing of all types of experiments.',

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -13,6 +13,7 @@ from snovault.attachment import ItemWithAttachment
 from .base import (
     Item,
     collection_add,
+    ALLOW_SUBMITTER_ADD
 )
 from pyramid.httpexceptions import (
     HTTPForbidden,
@@ -210,6 +211,7 @@ class FileSetMicroscopeQc(ItemWithAttachment, FileSet):
 @abstract_collection(
     name='files',
     unique_key='accession',
+    acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': 'Files',
         'description': 'Listing of Files',

--- a/src/encoded/types/individual.py
+++ b/src/encoded/types/individual.py
@@ -7,14 +7,15 @@ from snovault import (
 )
 # from pyramid.security import Authenticated
 from .base import (
-    Item
-    # paths_filtered_by_status,
+    Item,
+    ALLOW_SUBMITTER_ADD
 )
 
 
 @abstract_collection(
     name='individuals',
     unique_key='accession',
+    acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': "Individuals",
         'description': 'Listing of all types of individuals.',

--- a/src/encoded/types/microscope_setting.py
+++ b/src/encoded/types/microscope_setting.py
@@ -7,13 +7,14 @@ from snovault import (
 )
 # from pyramid.security import Authenticated
 from .base import (
-    Item
-    # paths_filtered_by_status,
+    Item,
+    ALLOW_SUBMITTER_ADD
 )
 
 
 @abstract_collection(
     name='microscope-settings',
+    acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': "Microscope Settings",
         'description': 'Collection of Metadata for microscope settings.',

--- a/src/encoded/types/quality_metric.py
+++ b/src/encoded/types/quality_metric.py
@@ -7,8 +7,8 @@ from snovault import (
 )
 # from pyramid.security import Authenticated
 from .base import (
-    Item
-    # paths_filtered_by_status,
+    Item,
+    ALLOW_SUBMITTER_ADD
 )
 
 
@@ -27,6 +27,7 @@ class QualityMetricFlag(Item):
 
 @abstract_collection(
     name='quality-metrics',
+    acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': 'Quality Metrics',
         'description': 'Listing of quality metrics',

--- a/src/encoded/types/treatment.py
+++ b/src/encoded/types/treatment.py
@@ -7,13 +7,14 @@ from snovault import (
 )
 # from pyramid.security import Authenticated
 from .base import (
-    Item
-    # paths_filtered_by_status,
+    Item,
+    ALLOW_SUBMITTER_ADD
 )
 
 
 @abstract_collection(
     name='treatments',
+    acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': "Treatments",
         'description': 'Listing of all types of treatments.',


### PR DESCRIPTION
'add' action/permission is calculated for an AbstractCollection now instead of Collection, allowing Experiments Collection to answer to permissions requests to see if current user/requestor may add.

Front-end edits to submissions to ensure type is up-to-date in/after initialization.