### PR TITLE
Removed archived_processed_files property from schemas

### DIFF
--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -153,18 +153,6 @@
                 "linkTo": "FileProcessed"
             }
         },
-        "archived_processed_files": {
-            "title": "Archived Processed Files",
-            "description": "Archived processed files that are derived from files in this experiment set.",
-            "type": "array",
-            "exclude_from": ["submit4dn", "FFedit-create"],
-            "items": {
-                "title": "Archived Processed File",
-                "description": "File metadata.",
-                "type": "string",
-                "linkTo": "FileProcessed"
-            }
-        },
         "other_processed_files": {
             "title": "Archived or Preliminary Processed Files",
             "description": "Archived or preliminary processed filesets that are derived from files in this experiment set.",

--- a/src/encoded/schemas/experiment_set.json
+++ b/src/encoded/schemas/experiment_set.json
@@ -96,18 +96,6 @@
                 "linkTo": "FileProcessed"
             }
         },
-        "archived_processed_files": {
-            "title": "Archived Processed Files",
-            "description": "Archived processed files that are derived from files in this experiment set.",
-            "type": "array",
-            "exclude_from": ["submit4dn", "FFedit-create"],
-            "items": {
-                "title": "Archived Processed File",
-                "description": "File metadata.",
-                "type": "string",
-                "linkTo": "FileProcessed"
-            }
-        },
         "other_processed_files": {
             "title": "Archived or Preliminary Processed Files",
             "description": "Archived or preliminary processed filesets that are derived from files in this experiment set.",


### PR DESCRIPTION
Removed archived_processed_files property from experiment and experiment_set schemas; has already been replaced by other_processed_files for experiments in portal