### PR TITLE
User subscriptions

### DIFF
--- a/src/encoded/static/components/submissions.js
+++ b/src/encoded/static/components/submissions.js
@@ -59,7 +59,6 @@ export default class Submissions extends React.Component {
         }
         return(
             <div>
-                <h1 className="page-title">Submission tracking</h1>
                 <div className="flexible-description-box item-page-heading" style={{'marginBottom':'25px'}}>
                     <p className="text-larger">{main_message}</p>
                 </div>

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -24,6 +24,17 @@ def lab(testapp, award):
 
 
 @pytest.fixture
+def another_lab(testapp, award):
+    item = {
+        'name': 'another-encode-lab',
+        'title': 'Another ENCODE lab',
+        'status': 'current',
+        'awards': [award['@id']]
+    }
+    return testapp.post_json('/lab', item).json['@graph'][0]
+
+
+@pytest.fixture
 def admin(testapp):
     item = {
         'first_name': 'Test',

--- a/src/encoded/tests/test_types_user.py
+++ b/src/encoded/tests/test_types_user.py
@@ -58,7 +58,7 @@ def test_subscriptions_dont_duplicate_on_update(registry, lab, user_w_lab):
         'last_name': 'McUser',
         'email': 'user@mcuser.org',
         'status': 'current',
-        'subscriptions': [{'url': '?lab.uuid' + lab['uuid'] + '&sort=-date_created',
+        'subscriptions': [{'url': '?lab.uuid=' + lab['uuid'] + '&sort=-date_created',
                            'title': 'All submissions for ENCODE lab'}]
     }
     test_user = User.create(registry, None, user_data)

--- a/src/encoded/tests/test_types_user.py
+++ b/src/encoded/tests/test_types_user.py
@@ -15,19 +15,40 @@ def user_w_lab(testapp, lab):
     res = testapp.post_json('/user', item)
     return testapp.get(res.location).json
 
-def test_user_subscriptions(submitter, admin, user_w_lab, lab):
+
+def test_user_subscriptions(testapp, submitter, admin, user_w_lab, lab, another_lab):
+    import copy
     # submitter has submits_for but no lab
     assert 'submits_for' in submitter
     assert len(submitter['subscriptions']) == 1
-    assert submitter['subscriptions'][0]['title'] == 'My submissions'
+    assert submitter['subscriptions'][0]['title'] == 'My submissions for ' + lab['title']
+    # subscription url contains user and lab uuids
+    assert submitter['uuid'] in submitter['subscriptions'][0]['url']
+    assert lab['uuid'] in submitter['subscriptions'][0]['url']
+    # ensure that submissions are the same after another update
+    subscriptions_before_update = copy.copy(submitter['subscriptions'])
+    submitter.update()
+    assert submitter['subscriptions'] == subscriptions_before_update
+    # make sure we can add more labs to submits for
+    submits_for_patch = [submitter['submits_for'][0]['@id'], another_lab['@id']]
+    res = testapp.patch_json(submitter['@id'], {'submits_for': submits_for_patch})
+    assert len(res.json['@graph'][0]['subscriptions']) == 2
+    # these are old formats for subscriptions; test that they're gone
+    subscription_keys = [sub['title'] for sub in res.json['@graph'][0]['subscriptions']]
+    assert 'My lab' not in subscription_keys and 'My submissions' not in subscription_keys
+
     # user_w_lab has lab but no submits_for
     assert 'lab' in user_w_lab
     assert len(user_w_lab['subscriptions']) == 1
-    assert user_w_lab['subscriptions'][0]['title'] == lab['title']
+    assert user_w_lab['subscriptions'][0]['title'] == 'All submissions for ' + lab['title']
+    # subscription url contains just lab uuid
+    assert user_w_lab['uuid'] not in user_w_lab['subscriptions'][0]['url']
+    assert lab['uuid'] in user_w_lab['subscriptions'][0]['url']
     # admin has no submits_for and no lab, thus should have no subscriptions
     assert 'lab' not in admin
     assert admin['submits_for'] == []
     assert len(admin['subscriptions']) == 0
+
 
 def test_subscriptions_dont_duplicate_on_update(registry, lab, user_w_lab):
     # run _update on a new user with already formed subscriptions.
@@ -37,7 +58,8 @@ def test_subscriptions_dont_duplicate_on_update(registry, lab, user_w_lab):
         'last_name': 'McUser',
         'email': 'user@mcuser.org',
         'status': 'current',
-        'subscriptions': [{'url': '?lab.link_id=~labs~encode-lab~&sort=-date_created', 'title': 'ENCODE lab'}]
+        'subscriptions': [{'url': '?lab.uuid' + lab['uuid'] + '&sort=-date_created',
+                           'title': 'All submissions for ENCODE lab'}]
     }
     test_user = User.create(registry, None, user_data)
     assert len(test_user.properties['subscriptions']) == 1

--- a/src/encoded/types/user.py
+++ b/src/encoded/types/user.py
@@ -135,7 +135,7 @@ class User(Item):
             }
             labs[properties['lab']] = my_lab
         # if submitter, add subscriptions to this user submissions for each lab
-        for submits_lab in properties.get('submits_for'):
+        for submits_lab in properties.get('submits_for', []):
             submit_lab = labs.get(submits_lab, self.collection.get(submits_lab))
             lab_title = submit_lab.properties.get('title', 'NO TITLE FOUND')
             curr_subs_dict['My submissions for ' + lab_title] = {

--- a/src/encoded/types/user.py
+++ b/src/encoded/types/user.py
@@ -115,46 +115,38 @@ class User(Item):
             return []
 
     def _update(self, properties, sheets=None):
-        # fill default submission entries. There are two possible:
-        # 1. if user has submits_for, subscribe to yourself
-        # 2. if user has lab, subscribe to all lab submissions
-        # if these are already present, don't add them again
-        my_uuid = self.uuid.__str__()
-        needs_sub = True
-        needs_lab = True
-        lab_id = properties.get('lab')
-        if lab_id:
-            lab_obj = self.collection.get(lab_id)
-            lab_props = lab_obj.properties
-            lab_title = lab_props.get('title')
-        else:
-            lab_obj = lab_props = lab_title = None
-        curr_subs = properties['subscriptions'] if 'subscriptions' in properties else []
-        for sub in curr_subs:
-            if 'title' in sub:
-                if sub['title'] == 'My submissions':
-                    needs_sub = False
-                if sub['title'] == lab_title:
-                    needs_sub = False
-        if needs_sub and 'submits_for' in properties and len(properties['submits_for']) > 0:
-            submission_creds = {}
-            submission_creds['url'] = '?submitted_by.link_id=~users~' + my_uuid + '~&sort=-date_created'
-            submission_creds['title'] = 'My submissions'
-            curr_subs.append(submission_creds)
-        if needs_lab and lab_obj is not None:
-            if 'name' in lab_props:
-                lab_id = lab_props['name']
-            elif 'uuid' in lab_props:
-                lab_id = lab_props['uuid']
-            else:
-                lab_id = lab_props['title']
-            submission_creds2 = {}
-            submission_creds2['url'] = '?lab.link_id=~labs~' + lab_id + '~&sort=-date_created'
-            submission_creds2['title'] = lab_title
-            curr_subs.append(submission_creds2)
-        if len(curr_subs) > 0 and (needs_sub or needs_lab):
-            properties['subscriptions'] = curr_subs
+        # update user subscriptions to ensure that they include the labs
+        # that the user is associated with, as well as their own submissions
+        # if they are a sumbitter
+        curr_subs = properties.get('subscriptions', [])
+        # subscriptions is a list but change to dict here for processing
+        curr_subs_dict = {sub['title']: sub for sub in curr_subs}
+        labs = {}  # cache lab info. keyed by @id
+        # remove old subscriptions
+        if 'My submissions' in curr_subs_dict: del curr_subs_dict['My submissions']
+        if 'My lab' in curr_subs_dict: del curr_subs_dict['My lab']
+        # if user has a lab, include all submissions to that lab
+        if properties.get('lab'):
+            my_lab = self.collection.get(properties['lab'])
+            my_lab_title = my_lab.properties.get('title', 'NO TITLE FOUND')
+            curr_subs_dict['All submissions for ' + my_lab_title] = {
+                'title': 'All submissions for ' + my_lab_title,
+                'url': '?lab.uuid=' + str(my_lab.uuid) + '&sort=-date_created'
+            }
+            labs[properties['lab']] = my_lab
+        # if submitter, add subscriptions to this user submissions for each lab
+        for submits_lab in properties.get('submits_for'):
+            submit_lab = labs.get(submits_lab, self.collection.get(submits_lab))
+            lab_title = submit_lab.properties.get('title', 'NO TITLE FOUND')
+            curr_subs_dict['My submissions for ' + lab_title] = {
+                'title': 'My submissions for ' + lab_title,
+                'url': '?submitted_by.uuid=' + str(self.uuid) + '&lab.uuid=' +
+                       str(submit_lab.uuid) + '&sort=-date_created'
+            }
+        # sort alphabetically by title
+        properties['subscriptions'] = sorted(list(curr_subs_dict.values()), key= lambda v:v['title'])
         super(User, self)._update(properties, sheets)
+
 
 @view_config(context=User, permission='view', request_method='GET', name='page')
 def user_page_view(context, request):


### PR DESCRIPTION
Rewrote subscription processing in user _update and updated tests. Also made a small JS change to subscriptions page

Changes:
* Rewrote the subscriptions code in `_update` function in `types/user.py`. Now it will not add duplicate subscriptions after updates.
* Removed the previous "My lab" and "My submissions" subscriptions.
* Changed "My lab" subscription to "My lab " + <lab title>. This uses lab.uuid in the subscription `url`.
* Added one subscription per `submits_for` lab, which uses lab.uuid and user.uuid to in the subscription `url`.
* Made the subscription test more thorough (`tests/test_types_user.py`)