### PR TITLE
References

### DIFF
--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -175,6 +175,7 @@
             "title": "Reference publications",
             "description": "The publications that provide more information about the object.",
             "type": "array",
+            "exclude_from": ["submit4dn", "FFedit-create"],
             "lookup": 1000,
             "uniqueItems": true,
             "items": {

--- a/src/encoded/schemas/protocol.json
+++ b/src/encoded/schemas/protocol.json
@@ -66,6 +66,13 @@
                "Antibody Authentication",
                "Tissue Preparation Methods"
             ]
+        },
+        "url": {
+            "title": "URL",
+            "lookup": 1000,
+            "description": "An external resource with additional information about the protocol.",
+            "type": "string",
+            "format": "uri"
         }
     },
     "facets": {

--- a/src/encoded/schemas/treatment.json
+++ b/src/encoded/schemas/treatment.json
@@ -29,6 +29,13 @@
               "RNAi",
               "Other"
             ]
+        },
+        "url": {
+            "title": "URL",
+            "description": "An external resource with additional information about the construct.",
+            "type": "string",
+            "lookup": 1000,
+            "format": "uri"
         }
     },
     "facets": {

--- a/src/encoded/schemas/treatment_rnai.json
+++ b/src/encoded/schemas/treatment_rnai.json
@@ -79,13 +79,6 @@
                 "type": "string",
                 "linkTo": "Construct"
             }
-        },
-        "url": {
-            "title": "URL",
-            "description": "An external resource with additional information about the construct.",
-            "type": "string",
-            "lookup": 1000,
-            "format": "uri"
         }
     }
 }


### PR DESCRIPTION
Reference will be taken out of the schemas after carrying over the data to url field. The following schemas will have url field (most of them already had it). It should cover all current cases of reference uses. I did not use a mixin since most cases specified the description of the url field, or had other attributes related to it. If more fields need url in the future we can continue adding url to them. 
Award
Biosource
Construct
Enzyme
Individual - ALL
Lab
Modification
Publication
QualityMetric - ALL
Treatment - ALL
Vendor