### PR TITLE
Biosource title

### DIFF
--- a/src/encoded/schemas/modification.json
+++ b/src/encoded/schemas/modification.json
@@ -57,6 +57,7 @@
                "inversion",
                "duplication",
                "replacement",
+               "disruption",
                "point mutation",
                "complex change"
             ]

--- a/src/encoded/tests/test_types_biosource.py
+++ b/src/encoded/tests/test_types_biosource.py
@@ -3,6 +3,16 @@ pytestmark = [pytest.mark.working, pytest.mark.schema]
 
 
 @pytest.fixture
+def other_mod(testapp, lab, award):
+    data = {
+        "lab": lab['@id'],
+        "award": award['@id'],
+        "modification_type": "Stable Transfection",
+        "description": "second modification"
+    }
+    return testapp.post_json('/modification', item).json['@graph'][0]
+
+@pytest.fixture
 def GM12878_mod_biosource(testapp, lab, award, gm12878_oterm, basic_modification):
     item = {
         "accession": "4DNSROOOAAC1",
@@ -16,8 +26,21 @@ def GM12878_mod_biosource(testapp, lab, award, gm12878_oterm, basic_modification
 
 
 @pytest.fixture
-def cell_lines(GM12878_biosource, F123_biosource, GM12878_mod_biosource):
-    return [GM12878_biosource, F123_biosource, GM12878_mod_biosource]
+def GM12878_twomod_biosource(testapp, lab, award, gm12878_oterm, basic_modification, other_mod):
+    item = {
+        "accession": "4DNSROOOAAC2",
+        "biosource_type": "primary cell line",
+        "cell_line": gm12878_oterm['@id'],
+        'award': award['@id'],
+        'lab': lab['@id'],
+        'modifications': [basic_modification['@id'], other_mod['@id']]
+    }
+    return testapp.post_json('/biosource', item).json['@graph'][0]
+
+
+@pytest.fixture
+def cell_lines(GM12878_biosource, F123_biosource, GM12878_mod_biosource, GM12878_twomod_biosource):
+    return [GM12878_biosource, F123_biosource, GM12878_mod_biosource, GM12878_twomod_biosource]
 
 
 @pytest.fixture
@@ -46,10 +69,13 @@ def test_calculated_biosource_name(biosources):
             assert name == 'GM12878'
         if biotype == 'stem cell':
             assert name == 'F123-CASTx129'
-        if biotype == 'primary cell line':
+        if biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC1":
             # import pdb; pdb.set_trace()
             # used not real type here to test modification addition to name
             assert name == 'GM12878 Crispr'
+            res = testapp.patch_json(biosource['@id'],)
+        if biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC2":
+            assert name == 'GM12878 with modifications'
         if biotype == 'tissue':
             assert name == 'lung'
         if biotype == 'multicellular organism':

--- a/src/encoded/tests/test_types_biosource.py
+++ b/src/encoded/tests/test_types_biosource.py
@@ -74,7 +74,7 @@ def test_calculated_biosource_name(testapp, biosources, mod_w_change_and_target)
             # used not real type here to test modification addition to name
             assert name == 'GM12878 with Crispr'
             res = testapp.patch_json(biosource['@id'], {'modifications': [mod_w_change_and_target['@id']]})
-            assert res.json['@graph'][0]['biosource_name'] == 'GM12878 with Gene:eeny,meeny deletion'
+            assert res.json['@graph'][0]['biosource_name'] == 'GM12878 with eeny,meeny deletion'
         elif biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC2":
             assert name == 'GM12878 with Crispr, Stable Transfection'
         elif biotype == 'tissue':

--- a/src/encoded/tests/test_types_biosource.py
+++ b/src/encoded/tests/test_types_biosource.py
@@ -61,7 +61,7 @@ def biosources(cell_lines, lung_biosource, whole_biosource):
     return bs
 
 
-def test_calculated_biosource_name(biosources):
+def test_calculated_biosource_name(testapp, biosources, mod_w_change_and_target):
     for biosource in biosources:
         biotype = biosource['biosource_type']
         name = biosource['biosource_name']
@@ -73,9 +73,10 @@ def test_calculated_biosource_name(biosources):
             # import pdb; pdb.set_trace()
             # used not real type here to test modification addition to name
             assert name == 'GM12878 Crispr'
-            res = testapp.patch_json(biosource['@id'],)
+            res = testapp.patch_json(biosource['@id'], {'modifications': [mod_w_change_and_target['@id']]})
+            assert res.json['@graph'][0]['biosource_name'].startswith('GM12878 Crispr deletion for Gene:')
         if biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC2":
-            assert name == 'GM12878 with modifications'
+            assert name == 'GM12878 with genetic modifications'
         if biotype == 'tissue':
             assert name == 'lung'
         if biotype == 'multicellular organism':

--- a/src/encoded/tests/test_types_biosource.py
+++ b/src/encoded/tests/test_types_biosource.py
@@ -10,7 +10,7 @@ def other_mod(testapp, lab, award):
         "modification_type": "Stable Transfection",
         "description": "second modification"
     }
-    return testapp.post_json('/modification', item).json['@graph'][0]
+    return testapp.post_json('/modification', data).json['@graph'][0]
 
 @pytest.fixture
 def GM12878_mod_biosource(testapp, lab, award, gm12878_oterm, basic_modification):

--- a/src/encoded/tests/test_types_biosource.py
+++ b/src/encoded/tests/test_types_biosource.py
@@ -67,19 +67,19 @@ def test_calculated_biosource_name(testapp, biosources, mod_w_change_and_target)
         name = biosource['biosource_name']
         if biotype == 'immortalized cell line':
             assert name == 'GM12878'
-        if biotype == 'stem cell':
+        elif biotype == 'stem cell':
             assert name == 'F123-CASTx129'
-        if biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC1":
+        elif biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC1":
             # import pdb; pdb.set_trace()
             # used not real type here to test modification addition to name
-            assert name == 'GM12878 Crispr'
+            assert name == 'GM12878 with Crispr'
             res = testapp.patch_json(biosource['@id'], {'modifications': [mod_w_change_and_target['@id']]})
-            assert res.json['@graph'][0]['biosource_name'].startswith('GM12878 Crispr deletion for Gene:')
-        if biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC2":
-            assert name == 'GM12878 with genetic modifications'
-        if biotype == 'tissue':
+            assert res.json['@graph'][0]['biosource_name'] == 'GM12878 with Gene:eeny,meeny deletion'
+        elif biotype == 'primary cell line' and biosource['accession'] == "4DNSROOOAAC2":
+            assert name == 'GM12878 with Crispr, Stable Transfection'
+        elif biotype == 'tissue':
             assert name == 'lung'
-        if biotype == 'multicellular organism':
+        elif biotype == 'multicellular organism':
             assert name == 'whole human'
 
 

--- a/src/encoded/tests/test_types_modification.py
+++ b/src/encoded/tests/test_types_modification.py
@@ -16,12 +16,15 @@ def modifications(basic_modification, mod_w_genomic_change, mod_w_target,
 def test_calculated_modification_name(testapp, modifications):
     for name in modifications:
         modname = modifications[name]['modification_name']
-        assert modifications[name]['modification_name_short'] == modname
+        short = modifications[name]['modification_name_short']
+        # assert modifications[name]['modification_name_short'] == modname
         if name == 'basic_mod':
-            assert modname == 'Crispr'
+            assert modname == 'Crispr' and short == 'Crispr'
         if name == 'mod_w_gen_chg':
-            assert modname == 'Crispr deletion'
+            assert modname == 'Crispr deletion' and short == 'deletion'
         if name == 'mod_w_target':
             assert modname == 'Crispr for Gene:eeny,meeny'
+            assert short == 'Gene:eeny,meeny Crispr'
         if name == 'mod_w_both':
             assert modname == 'Crispr deletion for Gene:eeny,meeny'
+            assert short == 'Gene:eeny,meeny deletion'

--- a/src/encoded/tests/test_types_modification.py
+++ b/src/encoded/tests/test_types_modification.py
@@ -20,11 +20,11 @@ def test_calculated_modification_name(testapp, modifications):
         # assert modifications[name]['modification_name_short'] == modname
         if name == 'basic_mod':
             assert modname == 'Crispr' and short == 'Crispr'
-        if name == 'mod_w_gen_chg':
+        elif name == 'mod_w_gen_chg':
             assert modname == 'Crispr deletion' and short == 'deletion'
-        if name == 'mod_w_target':
+        elif name == 'mod_w_target':
             assert modname == 'Crispr for Gene:eeny,meeny'
             assert short == 'Gene:eeny,meeny Crispr'
-        if name == 'mod_w_both':
+        elif name == 'mod_w_both':
             assert modname == 'Crispr deletion for Gene:eeny,meeny'
             assert short == 'Gene:eeny,meeny deletion'

--- a/src/encoded/tests/test_types_modification.py
+++ b/src/encoded/tests/test_types_modification.py
@@ -24,7 +24,7 @@ def test_calculated_modification_name(testapp, modifications):
             assert modname == 'Crispr deletion' and short == 'deletion'
         elif name == 'mod_w_target':
             assert modname == 'Crispr for Gene:eeny,meeny'
-            assert short == 'Gene:eeny,meeny Crispr'
+            assert short == 'eeny,meeny Crispr'
         elif name == 'mod_w_both':
             assert modname == 'Crispr deletion for Gene:eeny,meeny'
-            assert short == 'Gene:eeny,meeny deletion'
+            assert short == 'eeny,meeny deletion'

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -75,10 +75,11 @@ class Biosource(Item):
             'stem cell derived cell line',
         ]
         mod_str = ''
-        if modifications and len(modifications) == 1:
-            mod_str = ' ' + request.embed(modifications[0], '@@object').get('modification_name_short', '')
-        elif modifications and len(modifications) > 1:
-            mod_str = ' with genetic modifications'
+        if modifications:
+            mod_str = ' with ' + ', '.join([request.embed(mod, '@@object').get('modification_name_short', '')
+                                            for mod in modifications])
+        # elif modifications and len(modifications) > 1:
+        #     mod_str = ' with genetic modifications'
         if biosource_type == "tissue":
             if tissue:
                 tissue_props = request.embed(tissue, '@@object')

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -75,11 +75,10 @@ class Biosource(Item):
             'stem cell derived cell line',
         ]
         mod_str = ''
-        if modifications:
-            mod_str = ' ' + '; '.join(
-                request.embed(mod, '@@object').get('modification_name_short', '')
-                for mod in modifications[:-1]) \
-                + request.embed(modifications[-1], '@@object').get('modification_name_short', '')
+        if len(modifications) == 1:
+            mod_str = ' ' + request.embed(modifications[0], '@@object').get('modification_name_short', '')
+        elif len(modifications) > 1:
+            mod_str = ' with genetic modifications'
         if biosource_type == "tissue":
             if tissue:
                 tissue_props = request.embed(tissue, '@@object')

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -75,9 +75,9 @@ class Biosource(Item):
             'stem cell derived cell line',
         ]
         mod_str = ''
-        if len(modifications) == 1:
+        if modifications and len(modifications) == 1:
             mod_str = ' ' + request.embed(modifications[0], '@@object').get('modification_name_short', '')
-        elif len(modifications) > 1:
+        elif modifications and len(modifications) > 1:
             mod_str = ' with genetic modifications'
         if biosource_type == "tissue":
             if tissue:

--- a/src/encoded/types/modification.py
+++ b/src/encoded/types/modification.py
@@ -52,15 +52,19 @@ class Modification(Item):
     })
     def modification_name_short(self, request, modification_type=None,
                                 genomic_change=None, target_of_mod=None):
-        if not modification_type:
-            return "None"
-
-        mod_name = modification_type
-        if genomic_change:
-            mod_name = mod_name + " " + genomic_change
+        mod_name = genomic_change if genomic_change else modification_type
         if target_of_mod:
             target = request.embed(target_of_mod, '@@object')
-            mod_name = mod_name + " for " + target['target_summary']
+            mod_name = target['target_summary'] + ' ' + mod_name
+        # if not modification_type:
+        #     return "None"
+        #
+        # mod_name = modification_type
+        # if genomic_change:
+        #     mod_name = mod_name + " " + genomic_change
+        # if target_of_mod:
+        #     target = request.embed(target_of_mod, '@@object')
+        #     mod_name = mod_name + " for " + target['target_summary']
         return mod_name
 
     @calculated_property(schema={
@@ -70,4 +74,4 @@ class Modification(Item):
     })
     def display_title(self, request, modification_type=None, genomic_change=None, target_of_mod=None):
         # biosample = '/biosample/'+ self.properties['biosample']
-        return self.modification_name_short(request, modification_type, genomic_change, target_of_mod)
+        return self.modification_name(request, modification_type, genomic_change, target_of_mod)

--- a/src/encoded/types/modification.py
+++ b/src/encoded/types/modification.py
@@ -55,7 +55,7 @@ class Modification(Item):
         mod_name = genomic_change if genomic_change else modification_type
         if target_of_mod:
             target = request.embed(target_of_mod, '@@object')
-            mod_name = target['target_summary'] + ' ' + mod_name
+            mod_name = target['target_summary'].replace('Gene:', '') + ' ' + mod_name
         # if not modification_type:
         #     return "None"
         #

--- a/src/encoded/types/target.py
+++ b/src/encoded/types/target.py
@@ -53,13 +53,16 @@ class Target(Item):
             # since targetted region is a list, go through each item and get summary elements
             for each_target in targeted_genome_regions:
                 genomic_region = request.embed(each_target, '@@object')
-                value = ""
-                value += genomic_region['genome_assembly']
-                if genomic_region.get('chromosome'):
-                    value += ':'
-                    value += genomic_region['chromosome']
-                if genomic_region.get('start_coordinate') and genomic_region.get('end_coordinate'):
-                    value += ':' + str(genomic_region['start_coordinate']) + '-' + str(genomic_region['end_coordinate'])
+                if genomic_region.get('location_description') and not (genomic_region.get('start_coordinate') or
+                                                                       genomic_region.get('end_coordinate')):
+                    value = genomic_region['location_description']
+                else:
+                    value = genomic_region['genome_assembly']
+                    if genomic_region.get('chromosome'):
+                        value += ':'
+                        value += genomic_region['chromosome']
+                    if genomic_region.get('start_coordinate') and genomic_region.get('end_coordinate'):
+                        value += ':' + str(genomic_region['start_coordinate']) + '-' + str(genomic_region['end_coordinate'])
                 values.append(value)
             return ",".join(filter(None, values))
         return "no target"


### PR DESCRIPTION
- Changes to biosource_name to make it more concise
- modification_name_short now different from modification_name
- added 'disruption' to genomic_change enum in target schema
- target_summary modified for genomic regions with location_description and no coords
Example - 
old biosource_name:
G1E-ER4 Crispr deletion for GRCm38; Stable Transfection insertion for Gene:GATA-1-ERStable Transfection insertion for Gene:GATA-1
new biosource_name:
G1E-ER4 with Slc25a37 E1 deletion, GATA-1-ER insertion, GATA-1 disruption