### PR TITLE
More cases to add experiment_type to download tracking

### DIFF
--- a/src/encoded/tests/test_file.py
+++ b/src/encoded/tests/test_file.py
@@ -222,7 +222,6 @@ def test_file_rev_linked_to_exp_set_download(testapp, registry, proc_file_json,
     """
     res = testapp.post_json('/file_processed', proc_file_json, status=201)
     resobj = res.json['@graph'][0]
-    import pdb; pdb.set_trace()
     testapp.patch_json(two_experiment_replicate_set['@id'],
                        {'other_processed_files': [{'title': 'Test', 'files': [resobj['@id']]}]})
     # hard-coded for convenience; should match experiment_data in datafixtures

--- a/src/encoded/tests/test_file.py
+++ b/src/encoded/tests/test_file.py
@@ -202,10 +202,46 @@ def test_file_rev_linked_to_exp_download(testapp, registry, proc_file_json, expe
     ti_coll = registry['collections']['TrackingItem']
     tracking_items = [ti_coll.get(id) for id in ti_coll]
     tracked_exp_file_dls = [ti.properties.get('download_tracking') for ti in tracking_items
-                            if ti.properties.get('download_tracking', {}).get('experiment_type') is not None]
+                            if ti.properties.get('download_tracking', {}).get('experiment_type') is not 'None']
     assert len(tracked_exp_file_dls) > 0
     for dl_tracking in tracked_exp_file_dls:
         assert dl_tracking['experiment_type'] == experiment_data['experiment_type']
+        assert 'file_format' in dl_tracking
+        # this needs to be updated if the proc_file_json fixture is
+        assert dl_tracking['file_format'] == file_formats.get('pairs').get('file_format')
+        assert dl_tracking['range_query'] is False
+        assert dl_tracking['is_visualization'] is False
+        assert dl_tracking['user_uuid'] == 'anonymous'
+    s3.delete_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'])
+
+
+def test_file_rev_linked_to_exp_set_download(testapp, registry, proc_file_json,
+                                             two_experiment_replicate_set, file_formats):
+    """
+    Use exp_set.other_processed_files field to really test this
+    """
+    res = testapp.post_json('/file_processed', proc_file_json, status=201)
+    resobj = res.json['@graph'][0]
+    import pdb; pdb.set_trace()
+    testapp.patch_json(two_experiment_replicate_set['@id'],
+                       {'other_processed_files': [{'title': 'Test', 'files': [resobj['@id']]}]})
+    # hard-coded for convenience; should match experiment_data in datafixtures
+    expected_exp_type = 'micro-C'
+    s3 = boto3.client('s3')
+    s3.put_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'],
+                  Body=str.encode('12346789abcd'))
+    download_filename = resobj['upload_key'].split('/')[1]
+    download_link = resobj['href']
+    resp = testapp.get(download_link)
+
+    # ensure that the download tracking item was created
+    ti_coll = registry['collections']['TrackingItem']
+    tracking_items = [ti_coll.get(id) for id in ti_coll]
+    tracked_exp_file_dls = [ti.properties.get('download_tracking') for ti in tracking_items
+                            if ti.properties.get('download_tracking', {}).get('experiment_type') is not 'None']
+    assert len(tracked_exp_file_dls) > 0
+    for dl_tracking in tracked_exp_file_dls:
+        assert dl_tracking['experiment_type'] == expected_exp_type
         assert 'file_format' in dl_tracking
         # this needs to be updated if the proc_file_json fixture is
         assert dl_tracking['file_format'] == file_formats.get('pairs').get('file_format')

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -949,7 +949,6 @@ def get_file_experiment_type(request, context, properties):
         elif hasattr(context, 'experiment_sets'):  # FileProcessed only
             rev_exp_sets = context.experiment_sets(request)
             if rev_exp_sets:
-                experiments_using_file = []
                 for exp_set in rev_exp_sets:
                     exp_set_info = get_item_if_you_can(request, exp_set)
                     if exp_set_info:
@@ -958,7 +957,7 @@ def get_file_experiment_type(request, context, properties):
     for file_experiment in experiments_using_file:
         exp_info = get_item_if_you_can(request, file_experiment)
         if exp_info is None:
-            break
+            continue
         exp_type = exp_info.get('experiment_type')
         if found_experiment_type == 'None' or found_experiment_type == exp_type:
             found_experiment_type = exp_type

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -893,20 +893,7 @@ def download(context, request):
     else:
         raise ValueError(external.get('service'))
 
-    # get the experiment type associated with this file
-    experiments_using_file = context.experiments(request)
-    found_experiment_type = 'None'
-    for file_experiment in experiments_using_file:
-        exp_info = get_item_if_you_can(request, file_experiment)
-        if exp_info is None:
-            break
-        exp_type = exp_info.get('experiment_type')
-        if found_experiment_type == 'None' or found_experiment_type == exp_type:
-            found_experiment_type = exp_type
-        else:  # multiple experiment types
-            found_experiment_type = 'Integrative analysis'
-            break
-    tracking_values['experiment_type'] = found_experiment_type
+    tracking_values['experiment_type'] = get_file_experiment_type(request, context, properties)
     tracking_values['is_visualization'] = False
     # create a tracking_item to track this download
     tracking_item = {'date_created': datetime.datetime.now(datetime.timezone.utc),
@@ -944,6 +931,41 @@ def download(context, request):
 
     # 307 redirect specifies to keep original method
     raise HTTPTemporaryRedirect(location=location)
+
+
+def get_file_experiment_type(request, context, properties):
+    """
+    Get the string experiment_type value given a File context and properties.
+    Checks the source_experiments, rev_linked experiments and experiment_sets
+    """
+    # identify which experiments to use
+    experiments_using_file = []
+    if properties.get('source_experiments'):
+        experiments_using_file = properties['source_experiments']
+    else:
+        rev_exps = context.experiments(request)
+        if rev_exps:
+            experiments_using_file = rev_exps
+        elif hasattr(context, 'experiment_sets'):  # FileProcessed only
+            rev_exp_sets = context.experiment_sets(request)
+            if rev_exp_sets:
+                experiments_using_file = []
+                for exp_set in rev_exp_sets:
+                    exp_set_info = get_item_if_you_can(request, exp_set)
+                    if exp_set_info:
+                        experiments_using_file.extend(exp_set_info.get('experiments_in_set', []))
+    found_experiment_type = 'None'
+    for file_experiment in experiments_using_file:
+        exp_info = get_item_if_you_can(request, file_experiment)
+        if exp_info is None:
+            break
+        exp_type = exp_info.get('experiment_type')
+        if found_experiment_type == 'None' or found_experiment_type == exp_type:
+            found_experiment_type = exp_type
+        else:  # multiple experiment types
+            found_experiment_type = 'Integrative analysis'
+            break
+    return found_experiment_type
 
 
 def validate_file_format_validity_for_file_type(context, request):


### PR DESCRIPTION
Here are the new cases for adding `experiment_type` to a download tracking item:
- downloaded file has `source_experiments`
- downloaded file has rev_linked experiments (including other_experiments for processed files)
- downloaded file has rev_linked experiment_sets (including other_experiment_sets for processed files)