### PR TITLE
Higlass menu changes

### DIFF
--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -548,6 +548,8 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         return (
             <div className={"overflow-hidden tabview-container-fullscreen-capable" + (isFullscreen ? ' full-screen-view' : '')}>
                 <h3 className="tab-section-title">
+                    <AddFileButton onClick={this.addFileToHiglass} loading={addFileLoading} genome_assembly={genome_assembly}
+                        className="mt-17" style={{ 'paddingLeft' : 30, 'paddingRight' : 30 }} />
                     <CollapsibleItemViewButtonToolbar constantButtons={this.fullscreenButton()} collapseButtonTitle={function(isOpen){
                         return (
                             <span>
@@ -555,7 +557,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
                             </span>
                         );
                     }}>
-                        <AddFileButton onClick={this.addFileToHiglass} loading={addFileLoading} genome_assembly={genome_assembly}/>
+                        {/* <AddFileButton onClick={this.addFileToHiglass} loading={addFileLoading} genome_assembly={genome_assembly}/> */}
                         { this.saveButton() }
                         { this.cloneButton() }
                         { this.statusChangeButton() }
@@ -633,7 +635,8 @@ class AddFileButton extends React.PureComponent {
 
         return (
             <React.Fragment>
-                <Button onClick={this.setIsSelecting} disabled={loading} bsStyle="success" key="addfilebtn" data-tip={tooltip}>
+                <Button onClick={this.setIsSelecting} disabled={loading} bsStyle="success" key="addfilebtn" data-tip={tooltip}
+                    {..._.pick(this.props, 'className', 'style')}>
                     <i className={"icon icon-fw icon-" + (loading ? 'circle-o-notch icon-spin' : 'plus')}/>&nbsp; Add Data
                 </Button>
                 <LinkToSelector isSelecting={isSelecting} onSelect={this.receiveFile} onCloseChildWindow={this.unsetIsSelecting} dropMessage={dropMessage} searchURL={searchURL} />

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -107,7 +107,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         //    }
         // }
     }
-    
+
     // This is not yet needed; may be re-enabled when can compare originalViewConfig vs state.viewConfig
     // componentDidMount(){
     //     // Hacky... we need to wait for HGC to load up and resize itself and such...
@@ -548,7 +548,6 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         return (
             <div className={"overflow-hidden tabview-container-fullscreen-capable" + (isFullscreen ? ' full-screen-view' : '')}>
                 <h3 className="tab-section-title">
-                    <span>HiGlass Browser</span>
                     <CollapsibleItemViewButtonToolbar constantButtons={this.fullscreenButton()} collapseButtonTitle={function(isOpen){
                         return (
                             <span>
@@ -556,11 +555,10 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
                             </span>
                         );
                     }}>
+                        <AddFileButton onClick={this.addFileToHiglass} loading={addFileLoading} genome_assembly={genome_assembly}/>
                         { this.saveButton() }
                         { this.cloneButton() }
                         { this.statusChangeButton() }
-                        <AddFileButton onClick={this.addFileToHiglass} loading={addFileLoading} genome_assembly={genome_assembly}/>
-                        { this.copyURLButton() }
                     </CollapsibleItemViewButtonToolbar>
                 </h3>
                 <hr className="tab-section-title-horiz-divider"/>
@@ -636,7 +634,7 @@ class AddFileButton extends React.PureComponent {
         return (
             <React.Fragment>
                 <Button onClick={this.setIsSelecting} disabled={loading} bsStyle="success" key="addfilebtn" data-tip={tooltip}>
-                    <i className={"icon icon-fw icon-" + (loading ? 'circle-o-notch icon-spin' : 'plus')}/>&nbsp; Add
+                    <i className={"icon icon-fw icon-" + (loading ? 'circle-o-notch icon-spin' : 'plus')}/>&nbsp; Add Data
                 </Button>
                 <LinkToSelector isSelecting={isSelecting} onSelect={this.receiveFile} onCloseChildWindow={this.unsetIsSelecting} dropMessage={dropMessage} searchURL={searchURL} />
             </React.Fragment>

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -640,9 +640,18 @@ def add_2d_file_to_higlass_viewconf(views, new_file):
 
     # Choose the first available view. If there are no views, make up some defaults.
     base_view = None
+    add_new_view = True
 
     if views:
         base_view = views[0]
+        # If this view does not have a center track, then reuse this view.
+        if not (
+            "center" in base_view["tracks"] \
+            and len(base_view["tracks"]["center"]) > 0 \
+            and "contents" in base_view["tracks"]["center"][0] \
+            and len(base_view["tracks"]["center"][0]["contents"]) > 0
+        ) :
+            add_new_view = False
     else:
         base_view = {
             initialYDomain: [
@@ -678,8 +687,11 @@ def add_2d_file_to_higlass_viewconf(views, new_file):
             }
         }
 
-    new_view = deepcopy(base_view)
-    new_view["uid"] = uuid.uuid4()
+    if add_new_view:
+        new_view = deepcopy(base_view)
+        new_view["uid"] = uuid.uuid4()
+    else:
+        new_view = base_view
     new_view["layout"]["i"] = new_view["uid"]
 
     new_content = {}
@@ -705,7 +717,8 @@ def add_2d_file_to_higlass_viewconf(views, new_file):
 
     new_view["tracks"]["center"][0]["contents"].append(new_content)
 
-    views.append(new_view)
+    if add_new_view:
+        views.append(new_view)
     return True, None
 
 def get_title(file):


### PR DESCRIPTION
Changes to the HiGlass Browser page
* Removed the "HiGlass Browser" banner
* Renamed the "Add" button to "Add File" and moved it to the first button in the list

* If you add a 2D file to a blank display it will populate the view (instead of making a new view next to the blank one.)