### PR TITLE
higlass-last-second-swaps: Using curated track titles as a filter

### DIFF
--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -645,7 +645,7 @@ class AddFileButton extends React.PureComponent {
             tooltip         = "Search for a file and add it to the display.",
             dropMessage     = "Drop a File here.",
             searchURL       = (
-                '/search/?type=File&higlass_uid!=No+value'
+                '/search/?type=File&track_title!=No+value'
                 + (genome_assembly? '&genome_assembly=' + encodeURIComponent(genome_assembly) : '' )
                 + '#!selection'
             );

--- a/src/encoded/tests/data/inserts/file_processed.json
+++ b/src/encoded/tests/data/inserts/file_processed.json
@@ -269,7 +269,11 @@
             "file_size" :12345678,
             "md5sum": "6c2b2059745304918502d4ed2a863f59"
         }
-    ]
+    ],
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },
 {
     "lab":"/labs/4dn-dcic-lab/",
@@ -278,7 +282,11 @@
     "file_format": "d13d06cf-218e-4f61-bbf0-91f226248b2c",
     "description": "a cool file for 3 experiments",
     "accession": "4DNFIAAAAAA4",
-    "uuid":"8571c559-22b4-487e-9cb8-7ac402e93a9f"
+    "uuid":"8571c559-22b4-487e-9cb8-7ac402e93a9f",
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },{
     "lab":"/labs/4dn-dcic-lab/",
     "award":"/awards/1U01CA200059-01/",
@@ -286,7 +294,11 @@
     "file_format": "d13d11cf-218e-4f61-bbf0-91f226248b2c",
     "description": "a hic file for 3 experiments",
     "accession": "4DNFIAAAAAA5",
-    "uuid":"5b58e449-b7f0-4120-b20b-634f19c67f9e"
+    "uuid":"5b58e449-b7f0-4120-b20b-634f19c67f9e",
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },
 {
     "lab":"/labs/4dn-dcic-lab/",
@@ -296,7 +308,11 @@
     "uuid":"d273d710-6b6d-4e43-a84c-5658a891c032",
     "accession": "4DNFIMCOOL01",
 	"higlass_uid": "OxZJjFLwRYq8PA_cRgipbQ",
-    "genome_assembly": "GRCm38"
+    "genome_assembly": "GRCm38",
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },
 {
     "lab":"/labs/4dn-dcic-lab/",
@@ -315,7 +331,11 @@
     "uuid":"d273d710-6b6d-4e43-a84c-5658a891c034",
     "accession": "4DNFIMCOOL03",
     "higlass_uid": "OxZJjFLwRYq8PA_cRgipbQ",
-    "genome_assembly": "GRCh38"
+    "genome_assembly": "GRCh38",
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },
 {
     "lab":"/labs/4dn-dcic-lab/",
@@ -329,7 +349,11 @@
           "file_format": "pairs_px2",
           "status": "to be uploaded by workflow"
        }
-    ]
+    ],
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },
 {
     "aliases":[
@@ -352,7 +376,11 @@
        {
           "file_format": "beddb"
        }
-    ]
+    ],
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 }
 ,{
     "lab":"/labs/4dn-dcic-lab/",
@@ -362,7 +390,11 @@
     "uuid": "5bca8842-0f3c-4224-9763-016caa0eec84",
     "accession": "4DNFIU37KWB1",
     "higlass_uid": "Tjm04dCjSBCuFR0pGYEaGw",
-    "genome_assembly": "GRCm38"
+    "genome_assembly": "GRCm38",
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 }
 ,{
     "lab":"/labs/4dn-dcic-lab/",
@@ -378,7 +410,11 @@
           "file_format": "bg_px2",
           "status": "to be uploaded by workflow"
        }
-    ]
+    ],
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },
 {
     "aliases":[
@@ -395,7 +431,11 @@
     "award":"/awards/1U01CA200059-01/",
     "higlass_uid": "FTv3kHMmSlm0YTmtdOYAPA",
     "genome_assembly": "GRCh38",
-    "uuid":"a34d5ea5-eada-4def-a4a7-c227b0d32395"
+    "uuid":"a34d5ea5-eada-4def-a4a7-c227b0d32395",
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 },
 {
     "lab":"/labs/4dn-dcic-lab/",
@@ -407,6 +447,10 @@
     "file_format":"bbafb7f8-98d5-48d7-8e75-dc40a5186e19",
     "date_created":"2018-11-29T01:37:58.357095+00:00",
     "submitted_by":"/users/986b362f-4eb6-4a9c-8173-3ab267307e3a/",
-    "uuid":"94827a84-2b65-45f4-ad4d-fc2219c52e7b"
+    "uuid":"94827a84-2b65-45f4-ad4d-fc2219c52e7b",
+    "dataset_type": "Dataset",
+    "file_type": "File",
+    "assay_info": "Assay",
+    "biosource_name" : "Biosource"
 }
 ]

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -732,11 +732,8 @@ def add_2d_file_to_higlass_viewconf(views, new_file):
 def get_title(file):
     """ Returns a string containing the title for the view.
     """
-    title = file["display_title"]
-    if "file_classification" in file:
-        title += "({classification})".format(
-            classification = file["file_classification"]
-        )
+    # Use the track title. As a fallback, use the display title.
+    title = file.get("track_title", file["display_title"])
     return title
 
 def repack_higlass_views(views):

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -733,15 +733,9 @@ def get_title(file):
     """ Returns a string containing the title for the view.
     """
     # Use the track title. As a fallback, use the display title.
-<<<<<<< HEAD
     title = file.get("track_title", file["display_title"])
     return title
-=======
-    if "track_title" in file:
-        return "(" + file["track_title"] + ")"
 
-    return "(" + file["display_title"] + ")"
->>>>>>> adac53c74b3a1a4821cf54c809e968a50d046a7e
 
 def repack_higlass_views(views):
     """Set up the higlass views so they fit in a 3 x 2 grid. The packing order is:


### PR DESCRIPTION
Now using the track_title field when presenting files to add to the HiGlass display.
HiGlass also shows the track_title field on each view.