### PR TITLE
Higlass window height

### DIFF
--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -567,11 +567,12 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         // Setting the height of the HiGlass Component follows one of these rules:
         // - If it's Fullscreen it should almost take up the entire window.
         // - Set the height to around 3/4 of the width.
+        var hiGlassComponentHeight;
         if (isFullscreen) {
-            const hiGlassComponentHeight = windowHeight -120;
+            hiGlassComponentHeight = windowHeight -120;
         }
         else {
-            const hiGlassComponentHeight = Math.floor(hiGlassComponentWidth * 0.75);
+            hiGlassComponentHeight = Math.floor(hiGlassComponentWidth * 0.75);
         }
 
         return (

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -71,7 +71,6 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
          * @property {boolean} cloneLoading         True if AJAX request is en route to clone Item.
          * @property {boolean} releaseLoading       True if AJAX request is en route to change Item status.
          * @property {boolean} addFileLoading          True if AJAX request is en route to add file to `state.viewConfig`.
-         * @property {integer} hiGlassComponentHeight   (Optional) The height of the HiGlassComponent, in pixels.
          */
         this.state = {
             'viewConfig'            : props.viewConfig,
@@ -80,8 +79,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             'saveLoading'           : false,
             'cloneLoading'          : false,
             'releaseLoading'        : false,
-            'addFileLoading'        : false,
-            'hiGlassComponentHeight': props.hiGlassComponentHeight || null
+            'addFileLoading'        : false
         };
     }
 
@@ -562,19 +560,15 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
 
     render(){
         var { isFullscreen, windowWidth, windowHeight, width } = this.props,
-            { addFileLoading, genome_assembly, hiGlassComponentHeight } = this.state;
+            { addFileLoading, genome_assembly } = this.state;
 
         const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
+
         // Setting the height of the HiGlass Component follows one of these rules:
         // - If it's Fullscreen it should almost take up the entire window.
-        // - If the height was entered as a prop, use that.
         // - Set the height to around 3/4 of the width.
-
         if (isFullscreen) {
             const hiGlassComponentHeight = windowHeight -120;
-        }
-        else if (hiGlassComponentHeight) {
-            const hiGlassComponentHeight = hiGlassComponentHeight;
         }
         else {
             const hiGlassComponentHeight = Math.floor(hiGlassComponentWidth * 0.75);

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -71,7 +71,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
          * @property {boolean} cloneLoading         True if AJAX request is en route to clone Item.
          * @property {boolean} releaseLoading       True if AJAX request is en route to change Item status.
          * @property {boolean} addFileLoading          True if AJAX request is en route to add file to `state.viewConfig`.
-         * @property {integer} hiGlassComponentHeight   The height of the HiGlassComponent, in pixels.
+         * @property {integer} hiGlassComponentHeight   (Optional) The height of the HiGlassComponent, in pixels.
          */
         this.state = {
             'viewConfig'            : props.viewConfig,
@@ -80,7 +80,8 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             'saveLoading'           : false,
             'cloneLoading'          : false,
             'releaseLoading'        : false,
-            'addFileLoading'        : false
+            'addFileLoading'        : false,
+            'hiGlassComponentHeight': props.hiGlassComponentHeight || null
         };
     }
 
@@ -561,11 +562,23 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
 
     render(){
         var { isFullscreen, windowWidth, windowHeight, width } = this.props,
-            { addFileLoading, genome_assembly } = this.state;
+            { addFileLoading, genome_assembly, hiGlassComponentHeight } = this.state;
 
         const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
-        // Set the height of the HiGlass Component to the width to make the display a square. Unless we're at fullscreen.
-        const hiGlassComponentHeight = isFullscreen ? windowHeight -120 : hiGlassComponentWidth;
+        // Setting the height of the HiGlass Component follows one of these rules:
+        // - If it's Fullscreen it should almost take up the entire window.
+        // - If the height was entered as a prop, use that.
+        // - Set the height to around 3/4 of the width.
+
+        if (isFullscreen) {
+            const hiGlassComponentHeight = windowHeight -120;
+        }
+        else if (hiGlassComponentHeight) {
+            const hiGlassComponentHeight = hiGlassComponentHeight;
+        }
+        else {
+            const hiGlassComponentHeight = Math.floor(hiGlassComponentWidth * 0.75);
+        }
 
         return (
             <div className={"overflow-hidden tabview-container-fullscreen-capable" + (isFullscreen ? ' full-screen-view' : '')}>

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -71,6 +71,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
          * @property {boolean} cloneLoading         True if AJAX request is en route to clone Item.
          * @property {boolean} releaseLoading       True if AJAX request is en route to change Item status.
          * @property {boolean} addFileLoading          True if AJAX request is en route to add file to `state.viewConfig`.
+         * @property {integer} hiGlassComponentHeight   The height of the HiGlassComponent, in pixels.
          */
         this.state = {
             'viewConfig'            : props.viewConfig,
@@ -562,6 +563,10 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         var { isFullscreen, windowWidth, windowHeight, width } = this.props,
             { addFileLoading, genome_assembly } = this.state;
 
+        const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
+        // Set the height of the HiGlass Component to the width to make the display a square. Unless we're at fullscreen.
+        const hiGlassComponentHeight = isFullscreen ? windowHeight -120 : hiGlassComponentWidth;
+
         return (
             <div className={"overflow-hidden tabview-container-fullscreen-capable" + (isFullscreen ? ' full-screen-view' : '')}>
                 <h3 className="tab-section-title">
@@ -584,8 +589,8 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
                 <div className="higlass-tab-view-contents">
                     <div className="higlass-container-container" style={isFullscreen ? { 'paddingLeft' : 10, 'paddingRight' : 10 } : null }>
                         <HiGlassPlainContainer {..._.omit(this.props, 'context', 'viewConfig')}
-                            width={isFullscreen ? windowWidth : width + 20 }
-                            height={isFullscreen ? windowHeight -120 : 500}
+                            width={hiGlassComponentWidth}
+                            height={hiGlassComponentHeight}
                             viewConfig={this.state.viewConfig}
                             ref="higlass" />
                     </div>

--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
@@ -16,7 +16,7 @@ export class HiGlassPlainContainer extends React.PureComponent {
     static does2DTrackExist(viewConfig){
 
         var found = false;
-        
+
         _.forEach(viewConfig.views || [], function(view){
             if (found) return;
             _.forEach((view.tracks && view.tracks.center) || [], function(centerTrack){
@@ -54,7 +54,7 @@ export class HiGlassPlainContainer extends React.PureComponent {
         'options' : { 'bounded' : true },
         'isValidating' : false,
         'disabled' : false,
-        'height' : 400,
+        'height' : 500,
         'viewConfig' : null,
         'groupID' : null
     };

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -600,32 +600,32 @@ def add_1d_file_to_higlass_viewconf(views, new_file):
     # If there are no views, create a default.
     if not views:
         new_view = {
-            initialYDomain: [
+            "initialYDomain": [
                 -10000,
                 10000
             ],
-            initialXDomain: [
+            "initialXDomain": [
                 -10000,
                 10000
             ],
-            tracks: {
-                right: [ ],
-                gallery: [ ],
-                left: [ ],
-                whole: [ ],
-                bottom: [ ],
-                top: [],
-                center: [],
+            "tracks": {
+                "right": [ ],
+                "gallery": [ ],
+                "left": [ ],
+                "whole": [ ],
+                "bottom": [ ],
+                "top": [],
+                "center": [],
             },
-            uid: "Not set yet",
-            layout: {
-                w: 12,
-                static: true,
-                h: 12,
-                y: 0,
-                i: "Not set yet",
-                moved: false,
-                x: 0
+            "uid": "Not set yet",
+            "layout": {
+                "w": 12,
+                "static": False,
+                "h": 12,
+                "y": 0,
+                "i": "Not set yet",
+                "moved": False,
+                "x": 0
             }
         }
         new_view["uid"] = uuid.uuid4()
@@ -662,36 +662,36 @@ def add_2d_file_to_higlass_viewconf(views, new_file):
             add_new_view = False
     else:
         base_view = {
-            initialYDomain: [
+            "initialYDomain": [
                 -10000,
                 10000
             ],
-            initialXDomain: [
+            "initialXDomain": [
                 -10000,
                 10000
             ],
-            tracks: {
-                right: [ ],
-                gallery: [ ],
-                left: [ ],
-                whole: [ ],
-                bottom: [ ],
-                top: [ ],
-                center: [
+            "tracks": {
+                "right": [ ],
+                "gallery": [ ],
+                "left": [ ],
+                "whole": [ ],
+                "bottom": [ ],
+                "top": [],
+                "center": [
                     {
                         "contents" : []
                     }
                 ],
             },
-            uid: "Not set yet",
-            layout: {
-                w: 12,
-                static: true,
-                h: 12,
-                y: 0,
-                i: "Not set yet",
-                moved: false,
-                x: 0
+            "uid": "Not set yet",
+            "layout": {
+                "w": 12,
+                "static": False,
+                "h": 12,
+                "y": 0,
+                "i": "Not set yet",
+                "moved": False,
+                "x": 0
             }
         }
 


### PR DESCRIPTION
- HiGlass Displays use windows whose height is 75% of the width.
- Static pages now use 500 pixel high HiGlass windows.

Fixed bug when I mixed JS and Python dictionaries.