### PR TITLE
audit-color: Make the error icon the same color as the warning icon.

### DIFF
--- a/src/encoded/static/components/item-pages/components/AuditTabView.js
+++ b/src/encoded/static/components/item-pages/components/AuditTabView.js
@@ -59,7 +59,7 @@ export class AuditTabView extends React.PureComponent {
 
     /**
      * Returns string broken into parts with a JSON segment in it.
-     * 
+     *
      * @param {string} String with potential JSON string.
      * @returns {string[]} Array with either 1 part (no valid JSON found) or 3 parts (beforestring, JSONstring, afterstring).
      */
@@ -232,7 +232,7 @@ class AuditLevelGrouping extends React.Component {
                         />
                     )}
                     </div>
-                    
+
                 </div>
             </div>
         );
@@ -263,7 +263,7 @@ class AuditCategoryGrouping extends React.Component {
     auditItemsList(){
         if (!this.state.open) return null;
         return this.props.audits.map((aud, i) =>
-            <AuditItem 
+            <AuditItem
                 audit={aud}
                 key={i}
                 level={aud.level_name || this.props.level || "ERROR"}
@@ -325,13 +325,13 @@ class AuditItem extends React.Component {
                             var detailParts = AuditTabView.findJSONinString(d);
                             return (
                                 <li key={i}>
-                                    { detailParts[0] ? 
+                                    { detailParts[0] ?
                                         <div>{ detailParts[0] }</div>
                                     : null }
-                                    { detailParts[1] ? 
+                                    { detailParts[1] ?
                                         <div>{ AuditTabView.convertJSONToTable(detailParts[1]) }</div>
                                     : null }
-                                    { detailParts[2] ? 
+                                    { detailParts[2] ?
                                         <div>{ detailParts[2] }</div>
                                     : null }
                                 </li>

--- a/src/encoded/static/scss/encoded/modules/_rc-tabs.scss
+++ b/src/encoded/static/scss/encoded/modules/_rc-tabs.scss
@@ -538,7 +538,7 @@ h4.tab-section-title {
 }
 
 .tab-section-title-horiz-divider {
-    /* Use classes 'mb-0', 'mb-1', etc. to set margins */ 
+    /* Use classes 'mb-0', 'mb-1', etc. to set margins */
     margin-top: 0;
     margin-bottom: 0;
     border-top-color: #ccc;
@@ -647,7 +647,7 @@ h4.tab-section-title {
       }
     }
 
-    span.active > i.icon { 
+    span.active > i.icon {
       opacity : 1;
 
       &.icon-warning {
@@ -655,8 +655,8 @@ h4.tab-section-title {
       }
 
       &.icon-ban, &.icon-exclamation-circle {
-          //color : $audit-color-error;
-          color: #ff5757;
+          color : $audit-color-warning;
+          //color: #ff5757;
       }
 
     }
@@ -698,5 +698,3 @@ h4.tab-section-title {
   border-right: none;
   background-color: #fff;
 }
-
-


### PR DESCRIPTION
There is a heavy red/green clash when the red Audit error icon appears on top of the green status bar.

![image](https://user-images.githubusercontent.com/1376213/49471341-9f291100-f7da-11e8-8bd0-1f57d23a43f0.png)

This will set the color to orange, the same as the warning color.

![image 1](https://user-images.githubusercontent.com/1376213/49471363-acde9680-f7da-11e8-8f4c-51cd5750f06e.png)
