### PR TITLE
Handle exclude_from: FFselection in facets

### DIFF
--- a/src/encoded/static/components/item-pages/components/AuditTabView.js
+++ b/src/encoded/static/components/item-pages/components/AuditTabView.js
@@ -59,7 +59,7 @@ export class AuditTabView extends React.PureComponent {
 
     /**
      * Returns string broken into parts with a JSON segment in it.
-     * 
+     *
      * @param {string} String with potential JSON string.
      * @returns {string[]} Array with either 1 part (no valid JSON found) or 3 parts (beforestring, JSONstring, afterstring).
      */
@@ -232,7 +232,7 @@ class AuditLevelGrouping extends React.Component {
                         />
                     )}
                     </div>
-                    
+
                 </div>
             </div>
         );
@@ -263,7 +263,7 @@ class AuditCategoryGrouping extends React.Component {
     auditItemsList(){
         if (!this.state.open) return null;
         return this.props.audits.map((aud, i) =>
-            <AuditItem 
+            <AuditItem
                 audit={aud}
                 key={i}
                 level={aud.level_name || this.props.level || "ERROR"}
@@ -325,13 +325,13 @@ class AuditItem extends React.Component {
                             var detailParts = AuditTabView.findJSONinString(d);
                             return (
                                 <li key={i}>
-                                    { detailParts[0] ? 
+                                    { detailParts[0] ?
                                         <div>{ detailParts[0] }</div>
                                     : null }
-                                    { detailParts[1] ? 
+                                    { detailParts[1] ?
                                         <div>{ AuditTabView.convertJSONToTable(detailParts[1]) }</div>
                                     : null }
-                                    { detailParts[2] ? 
+                                    { detailParts[2] ?
                                         <div>{ detailParts[2] }</div>
                                     : null }
                                 </li>

--- a/src/encoded/static/scss/encoded/modules/_rc-tabs.scss
+++ b/src/encoded/static/scss/encoded/modules/_rc-tabs.scss
@@ -538,7 +538,7 @@ h4.tab-section-title {
 }
 
 .tab-section-title-horiz-divider {
-    /* Use classes 'mb-0', 'mb-1', etc. to set margins */ 
+    /* Use classes 'mb-0', 'mb-1', etc. to set margins */
     margin-top: 0;
     margin-bottom: 0;
     border-top-color: #ccc;
@@ -647,7 +647,7 @@ h4.tab-section-title {
       }
     }
 
-    span.active > i.icon { 
+    span.active > i.icon {
       opacity : 1;
 
       &.icon-warning {
@@ -655,8 +655,8 @@ h4.tab-section-title {
       }
 
       &.icon-ban, &.icon-exclamation-circle {
-          //color : $audit-color-error;
-          color: #ff5757;
+          color : $audit-color-warning;
+          //color: #ff5757;
       }
 
     }
@@ -698,5 +698,3 @@ h4.tab-section-title {
   border-right: none;
   background-color: #fff;
 }
-
-


### PR DESCRIPTION
EDIT -- CLOSED FOR NOW

This may be a temporary change, but I added the ability to remove facets from the selection page, specifically. Can be extended to other views in the future, if we want.

Downside -- requires another ajax.promise, since we need the schema.

Another problem -- tries to get schema using camelCase type. e.g. FileReference.json (which doesn't exist)