### PR TITLE
Fix for genome_assembly when cloning view configs

### DIFF
--- a/src/encoded/schemas/higlass_view_config.json
+++ b/src/encoded/schemas/higlass_view_config.json
@@ -28,7 +28,12 @@
             "title": "Genome Assembly",
             "description": "All data files will use this genome assembly.",
             "type" : "string",
-            "default": ""
+            "enum": [
+                "GRCh38",
+                "GRCm38",
+                "dm6",
+                "galGal5"
+            ]
         },
         "viewconfig": {
             "title": "View Configuration",

--- a/src/encoded/schemas/higlass_view_config.json
+++ b/src/encoded/schemas/higlass_view_config.json
@@ -27,13 +27,7 @@
         "genome_assembly" : {
             "title": "Genome Assembly",
             "description": "All data files will use this genome assembly.",
-            "type" : "string",
-            "enum": [
-                "GRCh38",
-                "GRCm38",
-                "dm6",
-                "galGal5"
-            ]
+            "type" : "string"
         },
         "viewconfig": {
             "title": "View Configuration",

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -249,15 +249,14 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         };
 
         var payload = {
-            'title'         : viewConfTitle,
-            'description'   : viewConfDesc,
-            'viewconfig'    : currentViewConf,
+            'title'          : viewConfTitle,
+            'description'    : viewConfDesc,
+            'viewconfig'     : currentViewConf,
+            'genome_assembly': context.genome_assembly,
             // We don't include other properties and let them come from schema default values.
             // For example, default status is 'draft', which will be used.
             // Lab and award do not carry over as current user might be from different lab.
         };
-        // add genome_assembly if it is present; must NOT be added if it is None
-        if (context.genome_assembly) payload.genome_assembly = context.genome_assembly;
 
         // Try to POST/PUT a new viewconf.
         this.setState(

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -256,6 +256,8 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             // For example, default status is 'draft', which will be used.
             // Lab and award do not carry over as current user might be from different lab.
         };
+        // add genome_assembly if it is present; must NOT be added if it is None
+        if (context.genome_assembly) payload.genome_assembly = context.genome_assembly;
 
         // Try to POST/PUT a new viewconf.
         this.setState(

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -90,7 +90,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             this.setState({
                 'originalViewConfig' : null, //object.deepClone(nextProps.viewConfig)
                 'viewConfig' : nextProps.viewConfig,
-                'genome_assembly' : (nextProps.context && nextProps.context.genome_assembly) || null
+                'genome_assembly' : (nextProps.context && nextProps.context.genome_assembly) || this.state.genome_assembly || null
             });
         }
     }

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -244,7 +244,7 @@ def higlass_blank_viewconf(testapp):
         "description" : "No files in viewconf, ready to clone.",
         "uuid" : "00000000-1111-0000-1111-000000000000",
         "name" : "empty-higlass-viewconf",
-        "genome_assembly" : "",
+        "genome_assembly" : "GRCm38",
         "viewconfig" : {
             "editable": True,
             "zoomFixed": False,
@@ -745,7 +745,6 @@ def test_bogus_fileuuid(testapp, higlass_mcool_viewconf):
 def test_add_files_by_accession(testapp, mcool_file_json, higlass_blank_viewconf, bg_file_json):
     """ Add files by the accession instead of the uuid.
     """
-
     # Add an mcool file. Add a higlass_uid.
     mcool_file_json['higlass_uid'] = "LTiacew8TjCOaP9gpDZwZw"
     mcool_file_json['genome_assembly'] = "GRCm38"


### PR DESCRIPTION
Removed default and added enum for genome_assembly in higlass_view_config.json. Also add genome_assembly when cloning a view config