### PR TITLE
Higlass view fixes

### DIFF
--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -666,6 +666,7 @@ def add_single_file_to_higlass_viewconf(views, new_file):
         new_view, error = create_2d_view(new_file)
         if error:
             return None, errors
+        copy_1d_tracks_into_2d_view(views, new_view)
         add_view_to_views(new_view, views)
     elif file_format == "/file-formats/beddb/":
         # Add the 1D track to top, left
@@ -1126,3 +1127,32 @@ def add_2d_chromsize(new_views, files_info):
         view["tracks"]["center"][0]["contents"].insert(0, chromsize_contents)
 
     return new_views, None
+
+def copy_1d_tracks_into_2d_view(views, new_view):
+    """
+    Args:
+        views: A list of views for this view config.
+        new_view: A view that needs to copy tracks from. Will be modified.
+
+    Returns:
+        Boolean indicating success.
+    """
+
+    # Get the first view, this should have all of the changes.
+    if len(views) < 1:
+        return False
+    base_view = views[0]
+
+    # Copy the genome assembly search box as well.
+    for field in ("genomePositionSearchBox", "autocompleteSource"):
+        if field in base_view:
+            new_view[field] = base_view[field]
+
+    # For each side (except center)
+    for side in ("top", "left"):
+        # If there are any tracks here
+        for track in base_view["tracks"][side]:
+            # Copy them into the new_view's side
+            new_view["tracks"][side].append(track)
+
+    return True

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -516,8 +516,6 @@ def add_files_to_higlass_viewconf(request):
     repack_higlass_views(new_views)
 
     # Set up the additional views so they all move and zoom with the first.
-    #setZoomLocationLocks(new_views, higlass_viewconfig, first_view_location_and_zoom)
-
     for view in new_views:
         add_zoom_lock_if_needed(higlass_viewconfig, view, first_view_location_and_zoom)
 


### PR DESCRIPTION
2 problems emerged on staging after task https://github.com/4dn-dcic/fourfront/pull/958

## New 2D views did not copy 1D tracks
1. Start with a blank view
2. Add a 2D file like an mcool.
3. Add a 1D file like a bigwig.
4. Add another 2D file.
The second 2D file should also have a bigwig, but it didn't.
I added a test and a new function *copy_1d_tracks_into_2d_view* to handle this.

## Zoom levels broke
1. Start with a blank view
2. Add a 2D file like an mcool.
3. Add another 2D file.
Note how the two views are now blank. If you try to "Zoom to Data Extent" you will probably get a runtime error.
I introduced a bug that used unreasonable defaults for initialXDomain and initialYDomain. To fix this, I copy those fields from the first view. I made a new function *add_zoom_lock_if_needed* and removed an old function to make it work.