### PR TITLE
doi-biorxiv-fix: BioRxiv changed their url generation. Updating test.

### DIFF
--- a/src/encoded/tests/test_types_publication.py
+++ b/src/encoded/tests/test_types_publication.py
@@ -59,7 +59,7 @@ def test_update_publication_doi_biorxiv(testapp, publication_doi_biorxiv):
     assert publication_doi_biorxiv['title'][:50] == 'Designing Robustness to Temperature in a Feedforwa'
     assert publication_doi_biorxiv['abstract'][:50] == 'Incoherent feedforward loops represent important b'
     assert publication_doi_biorxiv['authors'] == ['Shaunak Sen', 'Jongmin Kim', 'Richard M. Murray']
-    assert publication_doi_biorxiv['url'] == 'https://www.biorxiv.org/content/early/2013/11/07/000091'
+    assert publication_doi_biorxiv['url'] == 'https://www.biorxiv.org/content/10.1101/000091v1'
     assert publication_doi_biorxiv['date_published'] == '2013-11-07'
     assert publication_doi_biorxiv['journal'] == 'bioRxiv'
 


### PR DESCRIPTION
BioRxiv changed the way they link to articles via URL. This broke one of our tests, which uses the old URL.

I could have added a call to always get the up to date URL, but
1) I don't expect journals to frequently change their URL lookup methods
2) I feel like I would just reuse the functions we're trying to test to make the test, defeating the purpose
3) We can always update our current BioRxiv publication urls by clearing them out, causing a script to regenerate them.