### PR TITLE
rename-total-files: Renamed Total Filtered Files fields to reduce ambiguity

### DIFF
--- a/src/encoded/static/components/browse/components/file-tables.js
+++ b/src/encoded/static/components/browse/components/file-tables.js
@@ -259,7 +259,7 @@ export class RawFilesStackedTable extends React.PureComponent {
                                     _.flatten(_.pluck(expsWithBiosample.slice(3), 'file_pairs'), true).length +
                                     ' File Pairs'
                                     :
-                                    expFxn.fileCountFromExperiments(expsWithBiosample.slice(3)) + 
+                                    expFxn.fileCountFromExperiments(expsWithBiosample.slice(3)) +
                                     ' Files'
                             )
                     }/>
@@ -529,7 +529,7 @@ export class ProcessedFilesQCStackedTable extends ProcessedFilesStackedTable {
             { columnClass: 'experiment',    className: 'text-left',     title: 'Experiment',    initialWidth: 145   },
             //{ columnClass: 'file-pair',                                 title: 'File Pair',     initialWidth: 40,   visibleTitle : <i className="icon icon-download"></i> },
             { columnClass: 'file',        title: 'For File',          initialWidth: 100   },
-            { columnClass: 'file-detail', title: 'Total Reads', initialWidth: 80, field : "quality_metric.Total reads" },
+            { columnClass: 'file-detail', title: 'Filtered Reads', initialWidth: 80, field : "quality_metric.Total reads" },
             //{ columnClass: 'file-detail', title: 'Cis/Trans Ratio', initialWidth: 80, field : "quality_metric.Cis/Trans ratio" },
             //{ columnClass: 'file-detail', title: '% LR IC Reads', initialWidth: 80, field : "quality_metric.% Long-range intrachromosomal reads" },
             { columnClass: 'file-detail', title: 'Cis reads (>20kb)',   initialWidth: 80, field : "quality_metric.Cis reads (>20kb)", render: ProcessedFilesQCStackedTable.percentOfTotalReads },

--- a/src/encoded/static/components/item-pages/FileView.js
+++ b/src/encoded/static/components/item-pages/FileView.js
@@ -465,7 +465,7 @@ export class QualityControlResults extends React.PureComponent {
         }
 
         var itemsToReturn = [
-            renderMetric("Total reads", "Total Reads"),
+            renderMetric("Total reads", "Total Reads in File"),
             //renderMetric("Cis/Trans ratio", "Cis/Trans Ratio"),
             //renderMetric("% Long-range intrachromosomal reads", "% LR IC Reads"),
             renderMetric("Total Sequences", "Total Sequences"),


### PR DESCRIPTION
"Total Reads" is vague and hard to understand. We'll rename it to "Filtered Reads" when looking at an Experiment Set's file table.
![screen shot 2019-01-24 at 2 48 55 pm](https://user-images.githubusercontent.com/1376213/51705594-06e52680-1fea-11e9-827b-43cbbe7a7bf0.png)

![screen shot 2019-01-24 at 2 31 47 pm](https://user-images.githubusercontent.com/1376213/51705568-f3d25680-1fe9-11e9-975a-f3cf6d6c4929.png)

If you look at a Processed File for more information, it also uses "Total Reads". We'll change it to "Total Reads in File".
![screen shot 2019-01-24 at 2 59 35 pm](https://user-images.githubusercontent.com/1376213/51705761-76f3ac80-1fea-11e9-8771-5026641eab78.png)
