### PR TITLE
higlass-bigbed: Adding bigbed files doesn't break higlass displays

### DIFF
--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -1147,7 +1147,7 @@ def test_add_bigbed_higlass(testapp, higlass_mcool_viewconf, bigbed_file_json):
     """
 
     # Get a bigbed file to add.
-    bigbed_file_json['higlass_uid'] = "Y08H_toDQ-OxidYJAzFPXA"
+    bigbed_file_json['higlass_uid'] = "FTv3kHMmSlm0YTmtdOYAPA"
     bigbed_file_json['md5sum'] = '00000000000000000000000000000001'
     bigbed_file_json['genome_assembly'] = "GRCm38"
     bigbed_file = testapp.post_json('/file_processed', bigbed_file_json).json['@graph'][0]
@@ -1176,6 +1176,15 @@ def test_add_bigbed_higlass(testapp, higlass_mcool_viewconf, bigbed_file_json):
     # Assert_true(there is still 1 central view)
     assert_true(len(tracks["center"][0]["contents"]) == 1)
     assert_true("mcool" in tracks["center"][0]["contents"][0]["name"])
+
+    # Make sure the view has an initialXDomain and initialYDomain.
+    assert_true(len(new_higlass_json["views"][0]["initialXDomain"]) == 2)
+    assert_true(new_higlass_json["views"][0]["initialXDomain"][0] != None)
+    assert_true(new_higlass_json["views"][0]["initialXDomain"][1] != None)
+
+    assert_true(len(new_higlass_json["views"][0]["initialYDomain"]) == 2)
+    assert_true(new_higlass_json["views"][0]["initialYDomain"][0] != None)
+    assert_true(new_higlass_json["views"][0]["initialYDomain"][1] != None)
 
     # Only one new top track should have appeared.
     assert_true(len(tracks["left"]) == len(old_tracks["left"]))

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -725,7 +725,7 @@ def create_1d_track(new_file, side="top"):
     if new_file["file_format"] == "/file-formats/bed/":
         new_track["type"] = "bedlike"
     elif new_file["file_format"] == "/file-formats/bigbed/":
-        new_track["height"] = "100"
+        new_track["height"] = 35
         new_track["type"] = "horizontal-vector-heatmap"
         new_track["options"]["valueScaling"] = "linear"
         # Add the color range options. A list of 256 strings, each containing an integer.
@@ -1140,5 +1140,5 @@ def add_zoom_lock_if_needed(view_config, view, scales_and_center_k):
         ]
 
         # Copy the initialXDomain and initialYDomain
-        view["initialXDomain"] = view_config["views"][0]["initialXDomain"]
-        view["initialYDomain"] = view_config["views"][0]["initialYDomain"]
+        view["initialXDomain"] = view_config["views"][0]["initialXDomain"] or view["initialXDomain"]
+        view["initialYDomain"] = view_config["views"][0]["initialYDomain"] or view["initialYDomain"]


### PR DESCRIPTION
Adding bigbed files to the HiGlass view config pages would break any 2D mcool files added. Either the 2D file wouldn't appear or you would get a runtime error.

Here's an example of the 2D file not appearing:

![screen shot 2019-01-29 at 3 57 40 pm](https://user-images.githubusercontent.com/1376213/51990665-886c0700-2477-11e9-814d-fc128288be73.png)

All views need an initialXDomain, but only 2D views need an initialYDomain. The code I introduced copied the None initialYDomain values from the 1D views and applied them to the new view.

![screen shot 2019-01-30 at 10 10 01 am](https://user-images.githubusercontent.com/1376213/51990678-8bff8e00-2477-11e9-9608-ee7fd0edde78.png)
