### PR TITLE
Reordered columns for ExperimentSetReplicate

### DIFF
--- a/src/encoded/schemas/experiment_set.json
+++ b/src/encoded/schemas/experiment_set.json
@@ -186,18 +186,6 @@
                 "sm" : 120
             }
         },
-        "lab.display_title" : {
-            "title" : "Lab"
-        },
-        "dataset_label": {
-            "title": "Dataset"
-        },
-        "condition": {
-            "title": "Condition"
-        },
-        "experiments_in_set.biosample.biosource.individual.organism.name": {
-            "title" : "Organism"
-        },
         "experiments_in_set.biosample.biosource_summary": {
             "title" : "Biosample",
             "widthMap" : {
@@ -206,8 +194,18 @@
                 "sm" : 120
             }
         },
+        "dataset_label": {
+            "title": "Dataset"
+        },
+        "condition": {
+            "title": "Condition"
+        },
         "experiments_in_set.experiment_categorizer.combined" : {
             "title" : "Assay Details"
+        },
+        "experiments_in_set.biosample.biosource.individual.organism.name": {
+            "title" : "Organism",
+            "default_hidden": true
         },
         "experiments_in_set.biosample.modifications.display_title": {
             "title" : "Modifications",
@@ -216,6 +214,9 @@
         "experiments_in_set.biosample.treatments.display_title": {
             "title" : "Treatments",
             "default_hidden" : true
+        },
+        "lab.display_title" : {
+            "title" : "Lab"
         },
         "public_release": {
             "title" : "Public Release",

--- a/src/encoded/schemas/experiment_set_replicate.json
+++ b/src/encoded/schemas/experiment_set_replicate.json
@@ -80,5 +80,11 @@
                 }
             }
         }
+    },
+    "columns": {
+        "experimentset_type": {
+            "title": "Set Type",
+            "default_hidden": true
+        }
     }
 }


### PR DESCRIPTION
Reordered columns for Browse page / ExperimentSetReplicate collection view
- lab moved to end
- biosample moved up
- dataset and condition in front of assay details
- set_type hidden for ExperimentSetReplicate but not ExperimentSet
- organism hidden