### PR TITLE
higlass_1d_size_label: 1d tracks resize their heights. Labels also appear

### DIFF
--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -495,6 +495,15 @@ def test_add_bedGraph_higlass(testapp, higlass_mcool_viewconf, bedGraph_file_jso
     assert_true(len(tracks["left"]) == len(old_tracks["left"]))
     assert_true(len(tracks["top"]) == len(old_tracks["top"]) + 1)
 
+    # The new top track should not be very tall, since there is a 2D file in the center.
+    bedGraph_track = [ t for t in tracks["top"] if "-divergent-bar" in t["type"] ][0]
+    assert_true(
+        bedGraph_track["height"] < 100,
+        "1D file is too big: height should be less than 100, got {actual} instead.".format(
+            actual=bedGraph_track["height"],
+        )
+    )
+
 def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file_json):
     """ Given a viewconf with an mcool file, the viewconf should add a bedGraph on top.
 
@@ -533,6 +542,17 @@ def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file
     assert_true(len(new_higlass_json["views"]) == 1)
     assert_true(len(new_higlass_json["views"][0]["tracks"]["top"]) == 1)
 
+    # The new top track should be tall, since there are no other tracks. But not too tall.
+    assert_true(
+        new_higlass_json["views"][0]["tracks"]["top"][0]["height"] >= 100 and new_higlass_json["views"][0]["tracks"]["top"][0]["height"] < 600,
+        "1D file is wrong size: height should be at least 100 and less than 600, got {actual} instead.".format(
+            actual=new_higlass_json["views"][0]["tracks"]["top"][0]["height"],
+        )
+    )
+
+    # Make sure there is a label.
+    assert_true(new_higlass_json["views"][0]["tracks"]["top"][0]["options"]["labelPosition"] != "hidden")
+
     # Add another bedGraph file. Make sure the bedGraphs are stacked atop each other.
     response = testapp.post_json("/add_files_to_higlass_viewconf/", {
         'higlass_viewconfig': new_higlass_json,
@@ -544,6 +564,16 @@ def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file
 
     assert_true(len(new_higlass_json["views"]) == 1)
     assert_true(len(new_higlass_json["views"][0]["tracks"]["top"]) == 2)
+
+    # The new top tracks should be very tall, since there are no other tracks.
+    bedGraph_tracks = [ t for t in new_higlass_json["views"][0]["tracks"]["top"] if "-divergent-bar" in t["type"] ]
+    for t in bedGraph_tracks:
+        assert_true(
+            t["height"] >= 100,
+            "1D file is too small: height should be at least 100, got {actual} instead.".format(
+                actual=t["height"],
+            )
+        )
 
 def test_add_mcool_to_mcool(testapp, higlass_mcool_viewconf, mcool_file_json):
     """ Given a viewconf with a mcool file, the viewconf should add anohter mcool on the side.

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -1199,7 +1199,7 @@ def add_2d_file(views, new_content, viewconfig_info):
                 views[0]["tracks"]["center"][0]["contents"].append(contents)
         # Resize 1d tracks.
         views, error = resize_1d_tracks(views)
-        return views, ""
+        return views, error
 
     # If there is central content, then we need to make a new view.
     # Stop if there are already 6 views.

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -827,6 +827,7 @@ def add_bg_bw_bed_file(views, file, genome_assembly, viewconfig_info):
         "options": {
             "name": get_title(file),
             "coordSystem": file["genome_assembly"],
+            "labelPosition": "bottomRight",
         },
         "type": "horizontal-divergent-bar",
         "orientation": "1d-horizontal",
@@ -874,6 +875,7 @@ def add_bigbed_file(views, file, genome_assembly, viewconfig_info):
             "coordSystem": file["genome_assembly"],
             "colorRange": [],
             "valueScaling": "linear",
+            "labelPosition": "bottomRight",
         },
         "height": 35,
         "type": "horizontal-vector-heatmap",
@@ -913,10 +915,72 @@ def add_1d_file(views, new_track, genome_assembly):
         # Add to the "top" tracks, after the gene annotation track but before the chromsize tracks.
         non_gene_annotation_indecies = [i for i, track in enumerate(view["tracks"]["top"]) if "gene-annotations" not in track["type"]]
 
+        new_track_to_add = deepcopy(new_track)
+
         if len(non_gene_annotation_indecies) > 0:
-            view["tracks"]["top"].insert(non_gene_annotation_indecies[-1], new_track)
+            view["tracks"]["top"].insert(non_gene_annotation_indecies[-1], new_track_to_add)
         else:
-            view["tracks"]["top"].insert(0, new_track)
+            view["tracks"]["top"].insert(0, new_track_to_add)
+
+    views, error = resize_1d_tracks(views)
+    return views, ""
+
+def resize_1d_tracks(views):
+    """ For each view, resize the top 1D tracks (excluding gene-annotation and chromosome)
+    Args:
+        views(list)         : All of the views from the view config.
+
+    Returns:
+        views(list) : A list of the modified views. None if there is an error.
+        error(str) : A string explaining the error. This is None if there is no error.
+    """
+
+    for view in views:
+        view_info = get_view_content_info(view)
+
+        # Skip to the next view if there are no top tracks.
+        if not view_info["has_top_tracks"]:
+            continue
+
+        top_tracks = [ t for t in view["tracks"]["top"] if t["type"] not in ("horizontal-gene-annotations", "horizontal-chromosome-labels") ]
+
+        # Skip to the next view if there are no data tracks.
+        if len(top_tracks) < 1:
+            continue
+
+        gene_chromosome_tracks = [ t for t in view["tracks"]["top"] if t["type"] in ("horizontal-gene-annotations", "horizontal-chromosome-labels") ]
+
+        # Get the height allocated for all of the top tracks.
+        remaining_height = 600
+        # If there is a central view, the top rows will have less height to work with.
+        if view_info["has_center_content"]:
+            remaining_height = 200
+
+        # Remove the height from the chromosome and gene-annotation tracks
+        for track in gene_chromosome_tracks:
+            remaining_height -= track.get("height", 50)
+
+        # Evenly divide the remaining height.
+        height_per_track = remaining_height / len(top_tracks)
+
+        # Set the maximum track height.
+        if view_info["has_center_content"]:
+            # We want to maximize the center track space, so cap the top track height to 35.
+            if height_per_track > 35:
+                height_per_track = 35
+        else:
+            # The height should be no more than half the height
+            if height_per_track > remaining_height / 2:
+                height_per_track = remaining_height / 2
+
+        # Minimum height is 20.
+        if height_per_track < 20:
+            height_per_track = 20
+
+        for track in top_tracks:
+            # If it's too tall or too short, set it to the fixed height.
+            if "height" not in track or track["height"] > height_per_track or track["height"] < height_per_track * 0.8:
+                track["height"] = height_per_track
     return views, ""
 
 def add_beddb_file(views, file, genome_assembly, viewconfig_info):
@@ -1133,6 +1197,8 @@ def add_2d_file(views, new_content, viewconfig_info):
                 contents["type"] = "2d-chromosome-grid"
                 # The grid should be the last item to draw so it is always visible.
                 views[0]["tracks"]["center"][0]["contents"].append(contents)
+        # Resize 1d tracks.
+        views, error = resize_1d_tracks(views)
         return views, ""
 
     # If there is central content, then we need to make a new view.
@@ -1166,6 +1232,9 @@ def add_2d_file(views, new_content, viewconfig_info):
     if len(views) > 1:
         for view in views:
             add_zoom_lock_if_needed(viewconfig_info["higlass_viewconfig"], view, viewconfig_info["first_view_location_and_zoom"])
+
+    # Resize 1d tracks.
+    views, error = resize_1d_tracks(views)
     return views, ""
 
 def create_2d_content(file, viewtype):

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -923,7 +923,7 @@ def add_1d_file(views, new_track, genome_assembly):
             view["tracks"]["top"].insert(0, new_track_to_add)
 
     views, error = resize_1d_tracks(views)
-    return views, ""
+    return views, error
 
 def resize_1d_tracks(views):
     """ For each view, resize the top 1D tracks (excluding gene-annotation and chromosome)
@@ -1235,7 +1235,7 @@ def add_2d_file(views, new_content, viewconfig_info):
 
     # Resize 1d tracks.
     views, error = resize_1d_tracks(views)
-    return views, ""
+    return views, error
 
 def create_2d_content(file, viewtype):
     """ Generates a 2D track.


### PR DESCRIPTION
During a demonstration, someone pointed out the 1D tracks don't show the track name. I have added a labelPosition to the tracks.

I also try to resize the height of the tracks so they take up all of the available room. This resizes all top tracks except chromosome labels and gene annotation tracks.
- If there are no 2D tracks, each top track divides the full height evenly.
- If there is a 2D track, the center track will have most of the height, while the top tracks will remain small.