### PR TITLE
higlass_string_heights: Calculated heights must be patched as strings.

### DIFF
--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -542,6 +542,8 @@ def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file
     assert_true(len(new_higlass_json["views"]) == 1)
     assert_true(len(new_higlass_json["views"][0]["tracks"]["top"]) == 1)
 
+    assert_true(isinstance(new_higlass_json["views"][0]["tracks"]["top"][0]["height"], int), "Not an integer")
+
     # The new top track should be tall, since there are no other tracks. But not too tall.
     assert_true(
         new_higlass_json["views"][0]["tracks"]["top"][0]["height"] >= 100 and new_higlass_json["views"][0]["tracks"]["top"][0]["height"] < 600,

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -497,9 +497,8 @@ def test_add_bedGraph_higlass(testapp, higlass_mcool_viewconf, bedGraph_file_jso
 
     # The new top track should not be very tall, since there is a 2D file in the center.
     bedGraph_track = [ t for t in tracks["top"] if "-divergent-bar" in t["type"] ][0]
-    number_height = float(bedGraph_track["height"])
     assert_true(
-        number_height < 100,
+        bedGraph_track["height"] < 100,
         "1D file is too big: height should be less than 100, got {actual} instead.".format(
             actual=bedGraph_track["height"],
         )
@@ -543,16 +542,11 @@ def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file
     assert_true(len(new_higlass_json["views"]) == 1)
     assert_true(len(new_higlass_json["views"][0]["tracks"]["top"]) == 1)
 
-    # Make sure the height is a string and not an integer.
-    assert_true(isinstance(new_higlass_json["views"][0]["tracks"]["top"][0]["height"], str), "Not a string")
-
-    number_height = float(new_higlass_json["views"][0]["tracks"]["top"][0]["height"])
-
     # The new top track should be tall, since there are no other tracks. But not too tall.
     assert_true(
-        number_height >= 100 and number_height < 600,
+        new_higlass_json["views"][0]["tracks"]["top"][0]["height"] >= 100 and new_higlass_json["views"][0]["tracks"]["top"][0]["height"] < 600,
         "1D file is wrong size: height should be at least 100 and less than 600, got {actual} instead.".format(
-            actual=number_height,
+            actual=new_higlass_json["views"][0]["tracks"]["top"][0]["height"],
         )
     )
 
@@ -574,11 +568,10 @@ def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file
     # The new top tracks should be very tall, since there are no other tracks.
     bedGraph_tracks = [ t for t in new_higlass_json["views"][0]["tracks"]["top"] if "-divergent-bar" in t["type"] ]
     for t in bedGraph_tracks:
-        number_height = float(t["height"])
         assert_true(
-            number_height >= 100,
+            t["height"] >= 100,
             "1D file is too small: height should be at least 100, got {actual} instead.".format(
-                actual=number_height,
+                actual=t["height"],
             )
         )
 

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -497,8 +497,9 @@ def test_add_bedGraph_higlass(testapp, higlass_mcool_viewconf, bedGraph_file_jso
 
     # The new top track should not be very tall, since there is a 2D file in the center.
     bedGraph_track = [ t for t in tracks["top"] if "-divergent-bar" in t["type"] ][0]
+    number_height = float(bedGraph_track["height"])
     assert_true(
-        bedGraph_track["height"] < 100,
+        number_height < 100,
         "1D file is too big: height should be less than 100, got {actual} instead.".format(
             actual=bedGraph_track["height"],
         )
@@ -542,11 +543,16 @@ def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file
     assert_true(len(new_higlass_json["views"]) == 1)
     assert_true(len(new_higlass_json["views"][0]["tracks"]["top"]) == 1)
 
+    # Make sure the height is a string and not an integer.
+    assert_true(isinstance(new_higlass_json["views"][0]["tracks"]["top"][0]["height"], str), "Not a string")
+
+    number_height = float(new_higlass_json["views"][0]["tracks"]["top"][0]["height"])
+
     # The new top track should be tall, since there are no other tracks. But not too tall.
     assert_true(
-        new_higlass_json["views"][0]["tracks"]["top"][0]["height"] >= 100 and new_higlass_json["views"][0]["tracks"]["top"][0]["height"] < 600,
+        number_height >= 100 and number_height < 600,
         "1D file is wrong size: height should be at least 100 and less than 600, got {actual} instead.".format(
-            actual=new_higlass_json["views"][0]["tracks"]["top"][0]["height"],
+            actual=number_height,
         )
     )
 
@@ -568,10 +574,11 @@ def test_add_bedGraph_to_bedGraph(testapp, higlass_blank_viewconf, bedGraph_file
     # The new top tracks should be very tall, since there are no other tracks.
     bedGraph_tracks = [ t for t in new_higlass_json["views"][0]["tracks"]["top"] if "-divergent-bar" in t["type"] ]
     for t in bedGraph_tracks:
+        number_height = float(t["height"])
         assert_true(
-            t["height"] >= 100,
+            number_height >= 100,
             "1D file is too small: height should be at least 100, got {actual} instead.".format(
-                actual=t["height"],
+                actual=number_height,
             )
         )
 

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -979,8 +979,16 @@ def resize_1d_tracks(views):
 
         for track in top_tracks:
             # If it's too tall or too short, set it to the fixed height.
-            if "height" not in track or track["height"] > height_per_track or track["height"] < height_per_track * 0.8:
-                track["height"] = height_per_track
+            set_to_fixed_height = False
+            if "height" not in track:
+                set_to_fixed_height = True
+            else:
+                number_height = float(track["height"])
+                if number_height > height_per_track or number_height < height_per_track * 0.8:
+                    set_to_fixed_height = True
+
+            if set_to_fixed_height:
+                track["height"] = str(height_per_track)
     return views, ""
 
 def add_beddb_file(views, file, genome_assembly, viewconfig_info):

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -980,7 +980,7 @@ def resize_1d_tracks(views):
         for track in top_tracks:
             # If it's too tall or too short, set it to the fixed height.
             if "height" not in track or track["height"] > height_per_track or track["height"] < height_per_track * 0.8:
-                track["height"] = height_per_track
+                track["height"] = int(height_per_track)
     return views, ""
 
 def add_beddb_file(views, file, genome_assembly, viewconfig_info):

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -979,16 +979,8 @@ def resize_1d_tracks(views):
 
         for track in top_tracks:
             # If it's too tall or too short, set it to the fixed height.
-            set_to_fixed_height = False
-            if "height" not in track:
-                set_to_fixed_height = True
-            else:
-                number_height = float(track["height"])
-                if number_height > height_per_track or number_height < height_per_track * 0.8:
-                    set_to_fixed_height = True
-
-            if set_to_fixed_height:
-                track["height"] = str(height_per_track)
+            if "height" not in track or track["height"] > height_per_track or track["height"] < height_per_track * 0.8:
+                track["height"] = height_per_track
     return views, ""
 
 def add_beddb_file(views, file, genome_assembly, viewconfig_info):


### PR DESCRIPTION
After https://github.com/4dn-dcic/fourfront/pull/1007, I noticed foursight wasn't able to post higlass viewconfs with 1D tracks. The track heights were floating point numbers instead of integers, and that caused validation to fail. I've casted the track heights into integers to get around this limitation.

This doesn't affect live testing because the javascript Higlass plugin only uses integer dimensions.