### PR TITLE
Remove download_tracking.is_visualization

### DIFF
--- a/src/encoded/schemas/tracking_item.json
+++ b/src/encoded/schemas/tracking_item.json
@@ -16,7 +16,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "status": {
             "default": "in review by lab"
@@ -77,10 +77,6 @@
                 },
                 "range_query" : {
                     "title": "Range Query",
-                    "type": "boolean"
-                },
-                "is_visualization": {
-                    "title": "Is Visualization",
                     "type": "boolean"
                 },
                 "request_headers": {

--- a/src/encoded/static/components/static-pages/StatisticsPageView.js
+++ b/src/encoded/static/components/static-pages/StatisticsPageView.js
@@ -187,7 +187,7 @@ class UsageStatsViewController extends StatsViewController {
                 var untilDate   = moment.utc(),
                     fromDate,
                     uri         = '/date_histogram_aggregations/?date_histogram=date_created&type=TrackingItem&tracking_type=download_tracking';
-                uri += '&group_by=download_tracking.experiment_type&group_by=download_tracking.geo_country&group_by=download_tracking.is_visualization&group_by=download_tracking.file_format';
+                uri += '&group_by=download_tracking.experiment_type&group_by=download_tracking.geo_country&group_by=download_tracking.range_query&group_by=download_tracking.file_format';
                 if (props.currentGroupBy === 'monthly'){
                     untilDate.startOf('month').subtract(1, 'minute'); // Last minute of previous month
                     fromDate = untilDate.clone();
@@ -769,11 +769,11 @@ class UsageStatsView extends StatsChartViewBase {
             };
             ddtitle = titles[currCountBy];
         } else if (chartID === 'file_downloads'){
-            '&group_by=download_tracking.experiment_type&group_by=download_tracking.geo_country&group_by=download_tracking.is_visualization&group_by=download_tracking.file_format';
+            '&group_by=download_tracking.experiment_type&group_by=download_tracking.geo_country&group_by=download_tracking.range_query&group_by=download_tracking.file_format';
             titles = {
                 'download_tracking.experiment_type'     : <React.Fragment><i className="icon icon-fw icon-folder-o"/>&nbsp; Experiment Type</React.Fragment>,
                 'download_tracking.geo_country'         : <React.Fragment><i className="icon icon-fw icon-globe"/>&nbsp; Country</React.Fragment>,
-                'download_tracking.is_visualization'    : <React.Fragment><i className="icon icon-fw icon-television"/>&nbsp; Downloads as part of visualization</React.Fragment>,
+                'download_tracking.range_query'    : <React.Fragment><i className="icon icon-fw icon-television"/>&nbsp; Downloads as part of visualization</React.Fragment>,
                 'download_tracking.file_format'         : <React.Fragment><i className="icon icon-fw icon-file-text-o"/>&nbsp; File Format</React.Fragment>,
             };
             ddtitle = titles[currCountBy];

--- a/src/encoded/tests/test_file.py
+++ b/src/encoded/tests/test_file.py
@@ -223,7 +223,6 @@ def test_file_rev_linked_to_exp_download(testapp, registry, proc_file_json, expe
         # this needs to be updated if the proc_file_json fixture is
         assert dl_tracking['file_format'] == file_formats.get('pairs').get('file_format')
         assert dl_tracking['range_query'] is False
-        assert dl_tracking['is_visualization'] is False
         assert dl_tracking['user_uuid'] == 'anonymous'
         assert isinstance(dl_tracking['request_headers'], type(''))
     s3.delete_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'])
@@ -259,7 +258,6 @@ def test_file_rev_linked_to_exp_set_download(testapp, registry, proc_file_json,
         # this needs to be updated if the proc_file_json fixture is
         assert dl_tracking['file_format'] == file_formats.get('pairs').get('file_format')
         assert dl_tracking['range_query'] is False
-        assert dl_tracking['is_visualization'] is False
         assert dl_tracking['user_uuid'] == 'anonymous'
     s3.delete_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'])
 

--- a/src/encoded/tests/test_upgrade_tracking_item.py
+++ b/src/encoded/tests/test_upgrade_tracking_item.py
@@ -1,0 +1,33 @@
+import pytest
+pytestmark = [pytest.mark.setone, pytest.mark.working]
+
+
+@pytest.fixture
+def tracking_item_1():
+    return {
+        "tracking_type": "download_tracking",
+        "uuid": "b068f9d3-c026-4ef6-8769-104d745b9ca0",
+        "download_tracking": {
+            "range_query": True,
+            "experiment_type": "in situ Hi-C",
+            "remote_ip": "86.154.184.239",
+            "request_path": "/files-processed/4DNFIBBKG9KD/@@download/4DNFIBBKG9KD.hic",
+            "user_uuid": "anonymous",
+            "filename": "4DNFIBBKG9KD.hic",
+            "file_format": "hic",
+            "geo_country": "GB",
+            "geo_city": "Summertown, Oxfordshire",
+            "user_agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/72.0.3626.121 Chrome/72.0.3626.121 Safari/537.36",
+            "is_visualization": False
+        },
+        "status": "released",
+        "schema_version": "1"
+    }
+
+
+def test_tracking_item_delete_is_visualization(app, tracking_item_1):
+    migrator = app.registry['upgrader']
+    value = migrator.upgrade('tracking_item', tracking_item_1, current_version='1', target_version='2')
+    dt = value['download_tracking']
+    assert 'range_query' in dt
+    assert 'is_visualization' not in dt

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -1174,7 +1174,6 @@ def download(context, request):
         raise ValueError(external.get('service'))
 
     tracking_values['experiment_type'] = get_file_experiment_type(request, context, properties)
-    tracking_values['is_visualization'] = False
     # create a tracking_item to track this download
     tracking_item = {'date_created': datetime.datetime.now(datetime.timezone.utc),
                      'status': 'in review by lab', 'tracking_type': 'download_tracking',

--- a/src/encoded/upgrade/tracking_item.py
+++ b/src/encoded/upgrade/tracking_item.py
@@ -1,0 +1,17 @@
+from snovault import (
+    upgrade_step,
+)
+
+
+@upgrade_step('tracking_item', '1', '2')
+def data_release_update_1_2(value, system):
+
+    if int(value.get('schema_version', '1')) >= 2:
+        return
+
+    if 'download_tracking' not in value:
+        return
+
+    download_tracking = value['download_tracking']
+    if download_tracking and 'is_visualization' in download_tracking:
+        del download_tracking['is_visualization']


### PR DESCRIPTION
Small PR to:
- Remove `download_tracking.is_visualization` from TrackingItem
- No longer fill `is_visualization` in file.py
- Write upgrader and test
- Remove check for `is_visualization` on statistics page. Used `range_query` instead