### PR TITLE
anon_higlass_buttons: Anonymous users can see disabled HiGlass buttons with toolips.

### DIFF
--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -428,8 +428,6 @@ export default class App extends React.Component {
             analytics.registerPageView(this.props.href, this.props.context);
 
             // We need to rebuild tooltips after navigation to a different page.
-            ReactTooltip.rebuild();
-
             // Add a debounce so it runs again after a delay, so other components get a chance to mount.
             App.debouncedOnNavigationTooltipRebuild();
         }

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -90,8 +90,6 @@ class Timeout {
     }
 }
 
-
-
 /**
  * The root and top-most React component for our application.
  * This is wrapped by a Redux store and then rendered by either the server-side
@@ -191,6 +189,8 @@ export default class App extends React.Component {
     static defaultProps = {
         'sessionMayBeSet' : null
     };
+
+    static debouncedOnNavigationTooltipRebuild = _.debounce(ReactTooltip.rebuild, 500);
 
     /**
      * Does some initialization, checks if browser HistoryAPI is supported,
@@ -430,6 +430,8 @@ export default class App extends React.Component {
             // We need to rebuild tooltips after navigation to a different page.
             ReactTooltip.rebuild();
 
+            // Add a debounce so it runs again after a delay, so other components get a chance to mount.
+            App.debouncedOnNavigationTooltipRebuild();
         }
 
 

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -620,12 +620,18 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             hiGlassComponentHeight = 600;
         }
 
+        // If the user isn't logged in, add a tooltip reminding them to log in.
+        var tooltip = null;
+        if (!session) {
+            tooltip = "Log in to be able to clone, save, and share HiGlass Displays";
+        }
+
         return (
             <div className={"overflow-hidden tabview-container-fullscreen-capable" + (isFullscreen ? ' full-screen-view' : '')}>
                 <h3 className="tab-section-title">
                     <AddFileButton onClick={this.addFileToHiglass} loading={addFileLoading} genome_assembly={genome_assembly}
                         className="mt-17" style={{ 'paddingLeft' : 30, 'paddingRight' : 30 }} />
-                    <CollapsibleItemViewButtonToolbar session={session} windowWidth={windowWidth} constantButtons={this.fullscreenButton()} collapseButtonTitle={function(isOpen){
+                    <CollapsibleItemViewButtonToolbar tooltip={tooltip} windowWidth={windowWidth} constantButtons={this.fullscreenButton()} collapseButtonTitle={function(isOpen){
                         return (
                             <span>
                                 <i className={"icon icon-fw icon-" + (isOpen ? 'angle-up' : 'navicon')}/>&nbsp; Menu

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -24,8 +24,6 @@ export default class HiGlassViewConfigView extends DefaultItemView {
 
 }
 
-
-
 export class HiGlassViewConfigTabView extends React.PureComponent {
 
     static getTabObject(props, width){
@@ -533,8 +531,6 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             { saveLoading } = this.state,
             tooltip = "Save the current view shown below to this display";
 
-        if (!session) return null;
-
         var editPermission  = this.havePermissionToEdit();
 
         return (
@@ -549,10 +545,8 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             { cloneLoading } = this.state,
             tooltip = "Create your own new HiGlass Display based off of this one";
 
-        if (!session) return null;
-
         return (
-            <Button onClick={this.handleClone} disabled={cloneLoading} bsStyle="success" key="clonebtn" data-tip={tooltip}>
+            <Button onClick={this.handleClone} disabled={!session || cloneLoading} bsStyle="success" key="clonebtn" data-tip={tooltip}>
                 <i className={"icon icon-fw icon-" + (cloneLoading ? 'circle-o-notch icon-spin' : 'clone')}/>&nbsp; Clone
             </Button>
         );
@@ -610,7 +604,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
     }
 
     render(){
-        var { isFullscreen, windowWidth, windowHeight, width } = this.props,
+        var { isFullscreen, windowWidth, windowHeight, width, session } = this.props,
             { addFileLoading, genome_assembly } = this.state;
 
         const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
@@ -631,7 +625,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
                 <h3 className="tab-section-title">
                     <AddFileButton onClick={this.addFileToHiglass} loading={addFileLoading} genome_assembly={genome_assembly}
                         className="mt-17" style={{ 'paddingLeft' : 30, 'paddingRight' : 30 }} />
-                    <CollapsibleItemViewButtonToolbar windowWidth={windowWidth} constantButtons={this.fullscreenButton()} collapseButtonTitle={function(isOpen){
+                    <CollapsibleItemViewButtonToolbar session={session} windowWidth={windowWidth} constantButtons={this.fullscreenButton()} collapseButtonTitle={function(isOpen){
                         return (
                             <span>
                                 <i className={"icon icon-fw icon-" + (isOpen ? 'angle-up' : 'navicon')}/>&nbsp; Menu

--- a/src/encoded/static/components/item-pages/components/CollapsibleItemViewButtonToolbar.js
+++ b/src/encoded/static/components/item-pages/components/CollapsibleItemViewButtonToolbar.js
@@ -54,16 +54,10 @@ export class CollapsibleItemViewButtonToolbar extends React.PureComponent {
             );
         }
 
-        var { children, windowWidth, collapseButtonTitle, session } = this.props,
+        var { children, windowWidth, collapseButtonTitle, tooltip } = this.props,
             gridState       = this.state.mounted && layout.responsiveGridState(windowWidth),
             isMobileSize    = gridState && gridState !== 'lg',
             isOpen          = !isMobileSize || this.state.open;
-
-        // If the user isn't logged in, add a tooltip reminding them to log in.
-        var tooltip = null;
-        if (!session) {
-            tooltip = "Log in to be able to clone, save, and share HiGlass Displays";
-        }
 
         return (
             <div className="pull-right tabview-title-controls-container">

--- a/src/encoded/static/components/item-pages/components/CollapsibleItemViewButtonToolbar.js
+++ b/src/encoded/static/components/item-pages/components/CollapsibleItemViewButtonToolbar.js
@@ -7,8 +7,6 @@ import _ from 'underscore';
 import { ButtonToolbar, Collapse, Button, DropdownButton } from 'react-bootstrap';
 import { layout } from './../../util';
 
-
-
 export class CollapsibleItemViewButtonToolbar extends React.PureComponent {
 
     static defaultProps = {
@@ -56,15 +54,21 @@ export class CollapsibleItemViewButtonToolbar extends React.PureComponent {
             );
         }
 
-        var { children, windowWidth, collapseButtonTitle } = this.props,
+        var { children, windowWidth, collapseButtonTitle, session } = this.props,
             gridState       = this.state.mounted && layout.responsiveGridState(windowWidth),
             isMobileSize    = gridState && gridState !== 'lg',
             isOpen          = !isMobileSize || this.state.open;
 
+        // If the user isn't logged in, add a tooltip reminding them to log in.
+        var tooltip = null;
+        if (!session) {
+            tooltip = "Log in to be able to clone, save, and share HiGlass Displays";
+        }
+
         return (
             <div className="pull-right tabview-title-controls-container">
                 { isMobileSize ?
-                    <Collapse in={isOpen}>
+                    <Collapse in={isOpen} data-tip={tooltip}>
                         <div className="inner-panel" key="inner-collapsible-panel">
                             { Array.isArray(children) ? _.map(children, this.wrapChildForMobile) : this.wrapChildForMobile(children) }
                             <hr/>
@@ -72,7 +76,7 @@ export class CollapsibleItemViewButtonToolbar extends React.PureComponent {
                     </Collapse>
                 : null }
                 <div className="toolbar-wrapper pull-right" key="toolbar">
-                    <ButtonToolbar>
+                    <ButtonToolbar data-tip={ isMobileSize ? null : tooltip }>
                         { !isMobileSize && this.props.children }
                         <Button className="hidden-lg toggle-open-button" onClick={this.toggleOpenMenu} key="collapse-toggle-btn">
                             { typeof collapseButtonTitle === 'function' ? collapseButtonTitle(isOpen) : collapseButtonTitle }


### PR DESCRIPTION
If you visit a HiGlass view config page without logging in, you do not see the Save or Clone buttons. This task reveals the buttons as disabled and then presents a tooltip to log in to enable them.
![Before on data](https://user-images.githubusercontent.com/1376213/55101436-7f27a100-509a-11e9-92e2-45f856d63c4d.png)
On data

![After on local](https://user-images.githubusercontent.com/1376213/55101442-82229180-509a-11e9-9fbc-62cd32d544b9.png)
On my dev machine

- Save and Clone buttons appear.
- Clone button is disabled if there is no user session.
- Disabled buttons will never activate tooltips, so the containing element CollapsibleItemViewButtonToolbar will render tooltips if there is no user session. The screen size changes the implementation in (mobile vs desktop).
- Because the CollapsibleItemViewButtonToolbar takes extra time to load, the tool tips are not built immediately. You can see this in production by navigating to any Higlass Display from the higlass menu (don't just refresh the page.) To fix this issue, I added a debounce call to App that will try to rebuild the tooltips 500ms after the last tooltip build. See app.js for those changes.

I noticed if you change the browser width to add or remove the menu, the tooltips may break. You can do this on data. I don't think users will change their browser widths frequently so I didn't change it.