### PR TITLE
higlass_default_fix: Default higlass view must have a views entry.

### DIFF
--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -445,6 +445,9 @@ def add_files_to_higlass_viewconf(request):
     if not higlass_viewconfig:
         default_higlass_viewconf = get_item_if_you_can(request, "00000000-1111-0000-1111-000000000000")
         higlass_viewconfig = default_higlass_viewconf["viewconfig"]
+        # Add a view section if the default higlass_viewconfig lacks one
+        if "views" not in higlass_viewconfig:
+            higlass_viewconfig["views"] = []
 
     # If no view config could be found, fail
     if not higlass_viewconfig:


### PR DESCRIPTION
The default Higlass view config on staging has no "views" key. The viewconf generator assumes it does and raises KeyErrors when it cannot find it. I've added some code to add the key.