### PR TITLE
file_embed_last_modified: Embedding experiment last modified dates into files.

### DIFF
--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -813,6 +813,11 @@ class FileProcessed(File):
         'other_experiments': ('Experiment', 'other_processed_files.files'),
         'other_experiment_sets': ('ExperimentSet', 'other_processed_files.files')
     })
+    aggregated_items = {
+        "last_modified":[
+            "date_modified"
+        ],
+    }
 
     @classmethod
     def get_bucket(cls, registry):

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -245,6 +245,7 @@ class File(Item):
         'experiments.biosample.treatments_summary',
         'experiments.biosample.biosource.individual.organism.name',
         'experiments.digestion_enzyme.name',
+        'experiments.last_modified.date_modified',
         'file_format.file_format',
         'related_files.relationship_type',
         'related_files.file.accession',
@@ -796,6 +797,7 @@ class FileProcessed(File):
     item_type = 'file_processed'
     schema = load_schema('encoded:schemas/file_processed.json')
     embedded_list = File.embedded_list + file_workflow_run_embeds_processed + [
+        'experiment_sets.last_modified.date_modified',
         "quality_metric.Total reads",
         "quality_metric.Trans reads",
         "quality_metric.Cis reads (>20kb)",


### PR DESCRIPTION
Higlass Item checks use the last modified timestamp to determine if a new Item should be created.
For files, we will use the file's last modified date as well as the dates from the experiments and experiment sets.

The code changes embed the experiment and experiment_sets modified dates into the file embed lists. This also aggregates the last_modified.date_modified field into Processed Files.