### PR TITLE
higlass_upgrade_1_5_4: Updating Higlass to handle bigbed files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "detect-browser": "^3.0.1",
     "domready": "^0.3.0",
     "form-serialize": "^0.6.0",
-    "higlass": "^1.5.2",
+    "higlass": "^1.5.4",
     "html-react-parser": "^0.4.7",
     "js-md5": "^0.4.2",
     "jsonwebtoken": "^7.4.3",


### PR DESCRIPTION
Upgrading Higlass to version 1.5.4.

- This fixes an issue where bigbed files wouldn't render. https://github.com/higlass/higlass/commit/79f4c0da3c3bca49e11ee8b01f608965d0151c84