### PR TITLE
Badge message array

### DIFF
--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -560,6 +560,15 @@
                         "title": "Info",
                         "description": "Information about why the badge was added",
                         "type": "string"
+                    },
+                    "messages": {
+                        "title": "Info",
+                        "description": "Information about why the badge was added",
+                        "type": "array",
+                        "items": {
+                            "title": "Info",
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/src/encoded/static/components/item-pages/components/BadgesTabView.js
+++ b/src/encoded/static/components/item-pages/components/BadgesTabView.js
@@ -230,7 +230,7 @@ class SummaryIcon extends React.PureComponent {
 
 function BadgeItem(props){
     const { item, parent, windowWidth, height, context } = props;
-    const { message, badge } = item;
+    const { messages, badge } = item;
     const { badge_icon, description } = badge;
     const classification = BadgesTabView.badgeClassification(props);
     const badgeTitle = BadgesTabView.badgeTitle(props, classification);
@@ -254,7 +254,15 @@ function BadgeItem(props){
                         { badgeTitle }
                         { description ? <i className="icon icon-fw icon-info-circle ml-05" data-tip={description} /> : null }
                     </h4>
-                    { message ? <p className="mb-0">{ message } { linkMsg }</p> : linkMsg }
+                    <ul>
+                          { messages ? <p className="mb-0">{ messages.map(function(item) {
+                              return (
+                                  <li>
+                                      { item }
+                                  </li>
+                              );
+                          }) } { linkMsg }</p> : linkMsg }
+                    </ul>
                 </div>
             </div>
         </div>
@@ -363,5 +371,3 @@ export class EmbeddableSVGBadgeIcon extends React.PureComponent {
         );
     }
 }
-
-

--- a/src/encoded/static/components/item-pages/components/BadgesTabView.js
+++ b/src/encoded/static/components/item-pages/components/BadgesTabView.js
@@ -255,13 +255,12 @@ function BadgeItem(props){
                         { description ? <i className="icon icon-fw icon-info-circle ml-05" data-tip={description} /> : null }
                     </h4>
                     <ul>
-                          { messages ? <p className="mb-0">{ messages.map(function(item) {
-                              return (
-                                  <li>
-                                      { item }
-                                  </li>
-                              );
-                          }) } { linkMsg }</p> : linkMsg }
+                        { messages ? (
+                            <p className="mb-0">
+                                { messages.map(function(item) { return (<li>{ item }</li>); }) }
+                                { linkMsg }
+                            </p>
+                        ) : linkMsg }
                     </ul>
                 </div>
             </div>

--- a/src/encoded/tests/data/inserts/biosample.json
+++ b/src/encoded/tests/data/inserts/biosample.json
@@ -39,7 +39,11 @@
         "award": "Test-4DN",
         "badges": [{
             "badge": "e39777c6-8fe4-4424-bac1-40406342e026",
-            "message": "Biosample is missing a morphology image"
+            "messages": [
+                "Biosample is missing a morphology image",
+                "Biosample is missing culture duration",
+                "Biosample is missing passage number"
+            ]
         }],
         "submitted_by": "wrangler@wrangler.com",
         "lab": "test-4dn-lab",
@@ -111,7 +115,7 @@
         "badges": [
                     {
                       "badge": "dee03a23-49e5-4c33-afab-9ec90d65faf3",
-                      "message": "test badge message"
+                      "messages": ["test badge message 1", "test badge message 2"]
                     }
                   ]
     },

--- a/src/encoded/tests/data/inserts/experiment_set_replicate.json
+++ b/src/encoded/tests/data/inserts/experiment_set_replicate.json
@@ -62,11 +62,11 @@
         "badges": [
             {
                 "badge": "ddd03a23-49e5-4c33-afab-9ec90d65faf3",
-                "message": "Nice job!"
+                "messages": ["Nice job!"]
             },
             {
                 "badge": "/badges/inconsistent-replicate-info/",
-                "message": "Lorem Ipsum Text"
+                "messages": ["Lorem Ipsum Text"]
             }
         ]
     },

--- a/src/encoded/tests/test_aggregation.py
+++ b/src/encoded/tests/test_aggregation.py
@@ -45,7 +45,7 @@ def test_aggregation_view(workbook, testapp):
         if expected_path:
             assert agg_badge['embedded_path'] == expected_path
         # check fields on badge. hardcoded fields may need to be updated
-        assert 'message' in agg_badge['item']
+        assert 'messages' in agg_badge['item']
         assert 'badge' in agg_badge['item']
         assert 'commendation' in agg_badge['item']['badge']
         assert 'warning' in agg_badge['item']['badge']

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -29,7 +29,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
     # name_key = 'accession'
     aggregated_items = {
         "badges": [
-            "message",
+            "messages",
             "badge.commendation",
             "badge.warning",
             "badge.uuid",
@@ -45,7 +45,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
         'badges.badge.badge_classification',
         'badges.badge.description',
         'badges.badge.badge_icon',
-        'badges.message',
+        'badges.messages',
         'biosource.biosource_type',
         'biosource.individual.sex',
         'biosource.individual.organism.name',

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -62,7 +62,7 @@ class Experiment(Item):
     }
     aggregated_items = {
         "badges": [
-            "message",
+            "messages",
             "badge.commendation",
             "badge.warning",
             "badge.uuid",
@@ -78,7 +78,7 @@ class Experiment(Item):
         "badges.badge.badge_classification",
         "badges.badge.description",
         "badges.badge.badge_icon",
-        "badges.message",
+        "badges.messages",
         "experiment_sets.experimentset_type",
         "experiment_sets.@type",
         "experiment_sets.accession",
@@ -116,7 +116,7 @@ class Experiment(Item):
         "biosample.badges.badge.badge_classification",
         "biosample.badges.badge.description",
         "biosample.badges.badge.badge_icon",
-        "biosample.badges.message",
+        "biosample.badges.messages",
 
         "files.href",
         "files.accession",
@@ -132,7 +132,7 @@ class Experiment(Item):
         "files.badges.badge.badge_classification",
         "files.badges.badge.description",
         "files.badges.badge.badge_icon",
-        "files.badges.message",
+        "files.badges.messages",
 
         "processed_files.href",
         "processed_files.accession",

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -74,7 +74,7 @@ class ExperimentSet(Item):
     }
     aggregated_items = {
         "badges": [
-            "message",
+            "messages",
             "badge.commendation",
             "badge.warning",
             "badge.uuid",
@@ -90,7 +90,7 @@ class ExperimentSet(Item):
         "badges.badge.badge_classification",
         "badges.badge.description",
         "badges.badge.badge_icon",
-        "badges.message",
+        "badges.messages",
 
         "produced_in_pub.title",
         "produced_in_pub.abstract",
@@ -117,7 +117,7 @@ class ExperimentSet(Item):
         "experiments_in_set.badges.badge.badge_classification",
         "experiments_in_set.badges.badge.badge_icon",
         "experiments_in_set.badges.badge.description",
-        "experiments_in_set.badges.message",
+        "experiments_in_set.badges.messages",
 
         "experiments_in_set.biosample.accession",
         "experiments_in_set.biosample.modifications_summary",
@@ -140,7 +140,7 @@ class ExperimentSet(Item):
         "experiments_in_set.biosample.badges.badge.badge_classification",
         "experiments_in_set.biosample.badges.badge.badge_icon",
         "experiments_in_set.biosample.badges.badge.description",
-        "experiments_in_set.biosample.badges.message",
+        "experiments_in_set.biosample.badges.messages",
 
         "experiments_in_set.digestion_enzyme.name",
         "experiments_in_set.filesets.files_in_set.accession",
@@ -177,7 +177,7 @@ class ExperimentSet(Item):
         "experiments_in_set.files.badges.badge.badge_classification",
         "experiments_in_set.files.badges.badge.badge_icon",
         "experiments_in_set.files.badges.badge.description",
-        "experiments_in_set.files.badges.message",
+        "experiments_in_set.files.badges.messages",
 
         "experiments_in_set.files.related_files.relationship_type",
         "experiments_in_set.files.related_files.file.accession",

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -741,11 +741,11 @@ class FileFastq(File):
         "badges.badge.badge_classification",
         "badges.badge.description",
         "badges.badge.badge_icon",
-        "badges.message"
+        "badges.messages"
     ]
     aggregated_items = {
         "badges": [
-            "message",
+            "messages",
             "badge.commendation",
             "badge.warning",
             "badge.uuid",


### PR DESCRIPTION
Adds `messages` property to badges mixin that is an array rather than a string. Previous `message` property is still present to avoid having to upgrade or validation errors - will be removed at a later date.
- added messages property to badges mixin
- changed embeds in types file to use badges.messages instead of badges.message
- edited inserts to use messages property for badges instead of message
- edited an aggregation test to look for messages instead of message
- edited BadgeItem js function to return messages in a bulleted list instead of a single string