### PR TITLE
embed_opf_higlass_modified: Embedding last modified date.

### DIFF
--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -247,6 +247,7 @@ class ExperimentSet(Item):
         "other_processed_files.files.status",
         "other_processed_files.files.last_modified.date_modified",
         "other_processed_files.higlass_view_config.description",
+        "other_processed_files.higlass_view_config.last_modified.date_modified",
 
         "experiments_in_set.other_processed_files.files.href",
         "experiments_in_set.other_processed_files.title",


### PR DESCRIPTION
Experiment Sets will track the last modified date of Higlass Items related to the OtherProcessedFiles (aka supplementary files) section.

This will help the foursight checks determine whether or not to update the Higlass Item if the ExpSet was updated.