### PR TITLE
embed_static_content_description: Adding missing field.

### DIFF
--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -203,6 +203,7 @@ class ExperimentSet(Item):
         "processed_files.genome_assembly",
         "processed_files.last_modified.date_modified",
         "processed_files.static_content.location",
+        "processed_files.static_content.description",
         "processed_files.static_content.content.@type",
 
         # "processed_files.quality_metric.Total reads",
@@ -232,6 +233,7 @@ class ExperimentSet(Item):
         "experiments_in_set.processed_files.quality_metric.overall_quality_status",
         "experiments_in_set.processed_files.quality_metric_summary.*",
         "experiments_in_set.processed_files.static_content.location",
+        "experiments_in_set.processed_files.static_content.description",
         "experiments_in_set.processed_files.static_content.content.@type",  # Should only pull in @id, uuid, & display_title
         "experiments_in_set.processed_files.last_modified.date_modified",
         # "experiments_in_set.processed_files.@type"


### PR DESCRIPTION
Higlass foursight checks look for auto generated Higlass Items inside the static content. It uses the description to find them. This task adds the description that was lost in a recent refactor.