### PR TITLE
resize-higlass: Build displays with variable heights.

### DIFF
--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -1967,7 +1967,7 @@ def test_custom_display_height(testapp, higlass_blank_viewconf, bedGraph_file_js
     tracks = default_height_viewconf_json2["views"][0]["tracks"]
     assert_true(len(tracks["top"]) == 3)
 
-    for index, track in enumerate([ t for t in tracks["top"] if "-divergent-bar" in t["type"] ]):
+    for track in [ t for t in tracks["top"] if "-divergent-bar" in t["type"] ]:
         assert_true(
             (track["height"] - 83 > -5 and track["height"] - 83 < 5),
             "1D file is too big: height should be around 83, got {actual} instead.".format(
@@ -1997,7 +1997,7 @@ def test_custom_display_height(testapp, higlass_blank_viewconf, bedGraph_file_js
     tracks = big_height_viewconf_json2["views"][0]["tracks"]
     assert_true(len(tracks["top"]) == 3)
 
-    for index, track in enumerate([ t for t in tracks["top"] if "-divergent-bar" in t["type"] ]):
+    for track in [ t for t in tracks["top"] if "-divergent-bar" in t["type"] ]:
         assert_true(
             (track["height"] - 125 > -5 and track["height"] - 125 < 5),
             "1D file is too big: height should be around 125, got {actual} instead.".format(


### PR DESCRIPTION
Higlass visualizations have a fixed height of around 300 pixels. This task lets you pass in a variable to control the height.
- 300 pixels is a good height for the Higlass Items on the ExpSet pages. When you look at the Processed Files or Supplementary Files tab all of the 1 dimensional tracks fit.
- Higlass Item page is designed for 600 pixel high displays. We should take advantage of that space.

To prevent 1d tracks from getting too tall, they are capped to 125 pixels in height.

The default height is set to 300 pixels so there should be no change in behavior.

This task will work with future foursight changes to change the heights of some of the Higlass Items.