### PR TITLE
Badge Tab Title

### DIFF
--- a/src/encoded/static/components/item-pages/components/BadgesTabView.js
+++ b/src/encoded/static/components/item-pages/components/BadgesTabView.js
@@ -15,9 +15,19 @@ export class BadgesTabView extends React.PureComponent {
 
     static getTabObject(props){
         const { context } = props;
+
+        let badgeSingularTitle = "Badge";
+
+        const badgesByClassification = BadgesTabView.badgesByClassification(context);
+        const classifications = _.keys(badgesByClassification);
+
+        if (classifications.length === 1){
+            [ badgeSingularTitle ] = classifications;
+        }
+
         const badgeList = BadgesTabView.getBadgesList(context);
         const badgeListLen = (badgeList && badgeList.length) || 0;
-        const titleStr = " " + badgeListLen + " Badge" + (badgeListLen > 1 ? "s" : "");
+        const titleStr = " " + badgeSingularTitle + (badgeListLen > 1 ? "s" : "");
 
         return {
             tab : <span><SummaryIcon context={context} />{ titleStr }</span>,
@@ -395,13 +405,6 @@ class BadgeItem extends React.PureComponent {
 }
 
 
-/**
- * @todo:
- * Improve & make use of possibly.
- * Currently blocker is that the path dimensions specified in `d` attribute(s)
- * are in context of SVG having 124 height and width. We need these to be correctly resized
- * re: `props.size` somehow.
- */
 export class EmbeddableSVGBadgeIcon extends React.PureComponent {
 
     static linearGradientDefinition(type = "gold"){ // TODO: Implement other colors/types

--- a/src/encoded/static/components/item-pages/components/BadgesTabView.js
+++ b/src/encoded/static/components/item-pages/components/BadgesTabView.js
@@ -272,10 +272,7 @@ class SummaryIcon extends React.PureComponent {
         const outerRadius = size / 2;
         const tooltip = _.map(classificationRatioPairs, function([ classificationTitle, classificationRatio ]){
             const badgesForClassificationLen = badgesByClassification[classificationTitle].length;
-            return (
-                badgesForClassificationLen + " " + classificationTitle + (badgesForClassificationLen > 1 ? 's' : '') +
-                ' (' + (Math.round(classificationRatio * 10000) / 100) + '%)'
-            );
+            return badgesForClassificationLen + " " + classificationTitle + (badgesForClassificationLen > 1 ? 's' : '');
         }).join(' + ');
 
         return (


### PR DESCRIPTION
## Changes

Previously, tab and tabview title for Badges would say `{count} Badge{ maybe 's' }`.
Now:
- If only a single classification, will have name of the classification (+ 's' if multiple badges).
- If multiple, will say ` Badge{ maybe 's' }` (no count).
  - Will still get count(s) if hover over the icon, for both single and multiple classifications being present.
- Subheadings are no longer shown if only a single classification present, given the title atop the tab will say the same thing e.g. "1 Warning".

### Screenshots

![](https://i.gyazo.com/16c6bf2b6d16d4ef5fc42829cb1d5b41.png)
_**N.B.** Percentages have been removed from tooltip._

![](https://i.gyazo.com/26653b7383fce2178ccfd93b5d5b0e22.png)