### PR TITLE
Minor HiGlass-Related Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "detect-browser": "^3.0.1",
     "domready": "^0.3.0",
     "form-serialize": "^0.6.0",
-    "higlass": "^1.5.4",
+    "higlass": "^1.5.7",
     "html-react-parser": "^0.4.7",
     "js-md5": "^0.4.2",
     "jsonwebtoken": "^7.4.3",

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -327,7 +327,7 @@ export class HiGlassAdjustableWidthRow extends React.PureComponent {
             return (
                 <React.Fragment>
                     <EmbeddedHiglassActions context={higlassItem} showDescription={false} />
-                    <HiGlassAjaxLoadContainer higlassItem={higlassItem} className={collapsed ? 'disabled' : null} style={{ 'padding-top':'10px' }} height={Math.min(Math.max(rightPanelHeight - 16, minOpenHeight - 16), maxOpenHeight)} ref={this.higlassContainerRef} />
+                    <HiGlassAjaxLoadContainer higlassItem={higlassItem} className={collapsed ? 'disabled' : null} height={Math.min(Math.max(rightPanelHeight - 16, minOpenHeight - 16), maxOpenHeight)} ref={this.higlassContainerRef} />
                 </React.Fragment>
             );
         }

--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
@@ -32,12 +32,13 @@ export function isHiglassViewConfigItem(context){
  * @param {{ icon: string, title: JSX.Element|string }} props Props passed into this Component.
  */
 export function HiGlassLoadingIndicator(props) {
+    const { icon, title } = props;
     return (
         <React.Fragment>
             <h3>
-                <i className={"icon icon-lg icon-" + (props.icon || "television")}/>
+                <i className={"icon icon-lg icon-" + (icon || "television")}/>
             </h3>
-            { props.title || "Initializing" }
+            { title || "Initializing" }
         </React.Fragment>
     );
 }
@@ -86,7 +87,7 @@ export class HiGlassPlainContainer extends React.PureComponent {
     }
 
     componentDidMount(){
-
+        const { mountDelay } = this.props;
         const finish = () => {
             this.setState(function(currState){
                 return { 'mounted' : true, 'mountCount' : currState.mountCount + 1 };
@@ -121,7 +122,7 @@ export class HiGlassPlainContainer extends React.PureComponent {
                 finish();
             }
 
-        }, this.props.mountDelay || 500);
+        }, mountDelay || 500);
 
     }
 
@@ -175,12 +176,10 @@ export class HiGlassPlainContainer extends React.PureComponent {
     }
 
     render(){
-        var { disabled, isValidating, tilesetUid, height, width, options, style,
-            className, viewConfig, placeholder
-            } = this.props,
-            hiGlassInstance = null,
-            mounted         = (this.state && this.state.mounted) || false,
-            outerKey        = "mount-number-" + this.state.mountCount;
+        const { disabled, isValidating, tilesetUid, height, width, options, style, className, viewConfig, placeholder } = this.props;
+        const { mounted, mountCount, hasRuntimeError } = this.state;
+        let hiGlassInstance = null;
+        const outerKey = "mount-number-" + mountCount;
 
         if (isValidating || !mounted){
             var placeholderStyle = {};
@@ -195,7 +194,7 @@ export class HiGlassPlainContainer extends React.PureComponent {
                     <h4 className="text-400">Not Available</h4>
                 </div>
             );
-        } else if (this.state.hasRuntimeError) {
+        } else if (hasRuntimeError) {
             hiGlassInstance = (
                 <div className="text-center" key={outerKey} style={placeholderStyle}>
                     <h4 className="text-400">Runtime Error</h4>
@@ -203,7 +202,7 @@ export class HiGlassPlainContainer extends React.PureComponent {
             );
         } else {
             hiGlassInstance = (
-                <div key={outerKey} className="higlass-instance" style={{ 'transition' : 'none', 'height' : height, 'width' : width || null }} ref={this.instanceContainerRefFunction}>
+                <div key={outerKey} className="higlass-instance" style={{ 'transition' : 'none', height, 'width' : width || null }} ref={this.instanceContainerRefFunction}>
                     <HiGlassComponent {...{ options, viewConfig, width, height }} ref={this.hgcRef} />
                 </div>
             );
@@ -215,7 +214,7 @@ export class HiGlassPlainContainer extends React.PureComponent {
          */
         return (
             <div className={"higlass-view-container" + (className ? ' ' + className : '')} style={style}>
-                <link type="text/css" rel="stylesheet" href="https://unpkg.com/higlass@1.2.8/dist/hglib.css" crossOrigin="true" />
+                <link type="text/css" rel="stylesheet" href="https://unpkg.com/higlass@1.5.7/dist/hglib.css" crossOrigin="true" />
                 {/*<script src="https://unpkg.com/higlass@0.10.19/dist/scripts/hglib.js"/>*/}
                 <div className="higlass-wrapper row">{ hiGlassInstance }</div>
             </div>

--- a/src/encoded/static/scss/encoded/modules/_item-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_item-pages.scss
@@ -1675,7 +1675,6 @@ $badge-item-min-height: 90px;
 
 		// Adjustments for when HiGlass inside ExpSet view as mini preview thingy
 		.higlass-instance {
-			margin-top: -15px;
 			.ViewHeader-module_multitrack-header-nav-list-2nvcu {
 				.ViewHeader-module_multitrack-header-icon-squeazed-25lkF:nth-child(1),
 				.ViewHeader-module_multitrack-header-icon-16QKZ:nth-child(1),


### PR DESCRIPTION
### Updates

- Fix/prevent HiGlass from [re-initializing every time that toggle a checkbox](https://gyazo.com/4031c40cb5fcf2a65f9d9b495126c5ba) or drag/change width on ExpSet View.
  - This was occurring in part due to a new object reference (`{ 'padding-top' : '10px' }` for `props.style`) being passed into HiGlassPlainContainer/HiGlassAjaxLoadContainer upon each render, causing the HiGlassComponent to be re-rendered also every single time that the parent Component updated/re-rendered. This should theoretically be handled well by HiGlassComponent itself (e.g. it should itself be or act like a [PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent) instead of [Component](https://reactjs.org/docs/react-api.html#reactcomponent)...) and it may have been previously seemingly before grid was added in some recent HiGlass version, but this at least fixes the UX on our end.
- Update HiGlass CSS stylesheet to latest version (1.2.8->1.5.7).
- Update HiGlass JS package to latest version (1.5.4->1.5.7).
- Minor updates re: linting.