### PR TITLE
js-resize-higlass: Resize Higlass viewconfigs to fit the container height.

### DIFF
--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
@@ -117,7 +117,7 @@ export class HiGlassAjaxLoadContainer extends React.PureComponent {
         this.setState({ 'loading': true }, ()=>{
             // Use the @id to get the item, then remove the loading message
             ajax.load(object.itemUtil.atId(higlassItem), (r)=>{
-                this.setState({'higlassItem' : r,'loading': false});
+                this.setState({ 'higlassItem' : r,'loading': false });
             });
         });
     }

--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import _ from 'underscore';
-import { isServerSide, ajax, console, object } from './../../../util';
+import { ajax, object } from './../../../util';
 import { HiGlassPlainContainer, HiGlassLoadingIndicator } from './HiGlassPlainContainer';
-
+import memoize from 'memoize-one';
+import { deepClone } from "../../../util/object";
 
 /**
  * Accepts `higlassItem` (HiglassViewConfig Item JSON) as a prop and loads in the full
@@ -13,6 +13,64 @@ import { HiGlassPlainContainer, HiGlassLoadingIndicator } from './HiGlassPlainCo
  * instantiating a HiGlassPlainContainer.
  */
 export class HiGlassAjaxLoadContainer extends React.PureComponent {
+
+    /**
+     * Dynamically scale the 1-dimensional top tracks in the Higlass viewconf.
+     * Memoized function.
+     * @param {object} The Higlass view configuration. This is not modified.
+     * @param {integer} The target height for the Higlass config, in pixels.
+     * @returns {object}
+     */
+    static scaleViewconfToHeight = memoize(function(originalViewconf, givenHeight){
+        var viewconf = deepClone(originalViewconf);
+
+        // Check parameters.
+        if (!("views" in viewconf)) { return viewconf; }
+        if (givenHeight === null || givenHeight <= 0) {return viewconf; }
+
+        // Are there any views with 1D tracks? If not, stop
+        const has1DTracks = function(view) {
+            return (
+                "tracks" in view &&
+                "top" in view["tracks"] &&
+                view["tracks"]["top"].length > 0
+            );
+        };
+        if (!(_.some(viewconf["views"], has1DTracks))) {
+            return viewconf;
+        }
+
+        // Determine the height for each view. There may be so many views they must be on multiple rows.
+        const heightPerView = viewconf["views"] <= 2 ? givenHeight : (givenHeight / 2) | 0;
+
+        _.each(viewconf["views"], function(view){
+            if (!(has1DTracks(view))) { return; }
+
+            // 2D tracks scale automatically, so we will let it take about 2/3s of the total height.
+            let scaledHeightFor1DTracks = heightPerView;
+            if (
+                "tracks" in view &&
+                "center" in view["tracks"] &&
+                view["tracks"]["center"].length > 0
+            ) {
+                scaledHeightFor1DTracks = (heightPerView / 3) | 0;
+            }
+
+            const sumOfOriginal1DTracks = _.reduce(
+                _.filter(view["tracks"]["top"], function(track) { return ("height" in track);}),
+                function(memo, track) { return memo + track["height"];},
+                0
+            );
+            // Resize each 1D track to fit the given display height (round to the nearest integer so Higlass can use them)
+            _.each(
+                _.filter(view["tracks"]["top"], function(track) { return ("height" in track);}),
+                function (track) {
+                    track["height"] = (track["height"] * scaledHeightFor1DTracks / sumOfOriginal1DTracks) | 0;
+                }
+            );
+        });
+        return viewconf;
+    });
 
     constructor(props){
         super(props);
@@ -59,7 +117,7 @@ export class HiGlassAjaxLoadContainer extends React.PureComponent {
         this.setState({ 'loading': true }, ()=>{
             // Use the @id to get the item, then remove the loading message
             ajax.load(object.itemUtil.atId(higlassItem), (r)=>{
-                this.setState({ 'higlassItem' : r, 'loading': false });
+                this.setState({'higlassItem' : r,'loading': false});
             });
         });
     }
@@ -87,7 +145,9 @@ export class HiGlassAjaxLoadContainer extends React.PureComponent {
             );
         }
 
+        // Scale the higlass config so it fits the given container.
+        const adjustedViewconfig = HiGlassAjaxLoadContainer.scaleViewconfToHeight(higlassItem.viewconfig, height);
         // Pass the viewconfig to the HiGlassPlainContainer
-        return <HiGlassPlainContainer {..._.omit(this.props, 'higlassItem')} viewConfig={higlassItem.viewconfig} ref={this.containerRef}/>;
+        return <HiGlassPlainContainer {..._.omit(this.props, 'higlassItem')} viewConfig={adjustedViewconfig} ref={this.containerRef}/>;
     }
 }

--- a/src/encoded/tests/data/inserts/file_processed.json
+++ b/src/encoded/tests/data/inserts/file_processed.json
@@ -415,7 +415,7 @@
     "file_format": "d1312212-218e-4f61-aaf0-91f226248b2c",
     "uuid": "5bca8842-0f3c-4224-9763-016caa0eec84",
     "accession": "4DNFIU37KWB1",
-    "higlass_uid": "Tjm04dCjSBCuFR0pGYEaGw",
+    "higlass_uid": "43d7eec9-70ed-4b51-8f3e-dc382a6f3af5",
     "genome_assembly": "GRCm38",
     "override_experiment_type": "Dataset",
     "file_type": "File",

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -1956,6 +1956,7 @@ def test_custom_display_height(testapp, higlass_blank_viewconf, bedGraph_file_js
             "{uuid}".format(uuid=bg_file['uuid']),
             "{uuid}".format(uuid=bg_file['uuid']),
         ],
+        'height': 300,
     })
 
     assert_true(response.json["errors"] == '')

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -468,7 +468,7 @@ def add_files_to_higlass_viewconf(request):
     first_view_location_and_zoom = request.json_body.get('firstViewLocationAndZoom', [None, None, None])
     remove_unneeded_tracks = request.json_body.get('remove_unneeded_tracks', None)
     genome_assembly = request.json_body.get('genome_assembly', None)
-    maximum_height = request.json_body.get('height', 300)
+    maximum_height = request.json_body.get('height', 600)
 
     # Check the height of the display.
     if maximum_height < 100:


### PR DESCRIPTION
Higlass Items used to be 600 pixels tall, but when you looked at the Higlass item on an ExpSet's Processed Files or Supplementary Files page, they didn't fit in the 300 pixel container. The workaround was to make the Higlass Items only 300 pixels tall.

With these code changes, the Higlass Items will fit a 600 pixel container by default, and javascript will dynamically resize the Higlass Item so it fits the given container.
- HiGlassAjaxLoadContainer has a memoized function to update the heights of the top tracks in all views in a viewconfig.
- 2D tracks (like an mcool heatmap) do not have a set size and the Higlass library already dynamically resizes them, so HiGlassAjaxLoadContainer does not alter that content.

Other changes include:
- Default height for Higlass Items is now 600 pixels
- Had to update the Higlass Tileset uid for some of the test data.
