### PR TITLE
Abstract types fourfront

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ notifications:
     secure: DQyUTk6evwPpO0P5+OPhBSgl+fGEerOjBlBwQliXAkDaMKH3Cpi4cTQ3ETR/+3g6bGqPGK+QJ1R+6Ht+hJD7dNomyVIoQmvF0P5afJtpk/A3cDILe90t76ET9jc/iBjWeUFQdokFUJ7Gt1GGYtI6e5XcVu/Qc/xqCvFMtsBN6mnBFuvcQki+WkoIIPPawyhfryCNOLo5vvbi4SZ5dZI+M0MGq9HQjOyF1sdIgKuXhxjupmL+kVPVXAq9kiOANYFkwbNsP9j0BTYW5wFHpAztBqz3NT6EchgCdue8tgV4hC4rRFvM/bsA4qz/TJ5wRRLBRXtnNtPcyhAqTiU+wC6qWt++fjSEMGe4KYqtRRV1YuxQiTVHN84t77DILLNfMh/6uSs0KijwOT+Oazwd/UsN1zYOH93AM4FZ0h92yyb6j6JQ+DUk4WFel1Zr4kZzhtHSPGw+K4fxY0zIt1qpaDPXjtZHQ0+LwIIMtwMp5bBcwDn9d1ADnUhUAuuIN2hHaXrVy4vP2hIcd0LzezBqvc7JXimyd5yRgUeOCTrKGkAeSo8VA7XIj0ZmlpQRYKNTJP+gz4Y6C/RCxISnFDF/vcX+IsDdvreZXJMplE1Aqxf0uR6Zj8Sr8q+QWGKydv6ettlLZuqDuv0l/l/9qpzYfRqLSZcetGRVFHHcR9wuQiDyums=
 before_install:
 - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-- SNO_PATH="snovault = git https://github.com/$USER/$SNO_REPO.git branch="
+- SNO_PATH="snovault = git https://github.com/$USER/$SNO_REPO.git rev="
 - SNO_BRANCH=$(grep "${SNO_PATH}" buildout.cfg | sed "s@$SNO_PATH@@")
 - SNO_STATUS=$(curl -s "https://api.travis-ci.org/$USER/$SNO_REPO.svg?branch=$SNO_BRANCH"
   | grep pass)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -32,7 +32,7 @@ auto-checkout = snovault
 		dcicutils
 
 [sources]
-snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.0.0
+snovault = git https://github.com/4dn-dcic/snovault.git rev=abstract_profiles
 Submit4DN = git https://github.com/4dn-dcic/Submit4DN.git rev=0.9.7
 dcicutils = git https://github.com/4dn-dcic/utils.git branch=master
 jsonschema = git https://github.com/4dn-dcic/jsonschema_serialize_fork.git

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -32,7 +32,7 @@ auto-checkout = snovault
 		dcicutils
 
 [sources]
-snovault = git https://github.com/4dn-dcic/snovault.git rev=abstract_profiles
+snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.1.0
 Submit4DN = git https://github.com/4dn-dcic/Submit4DN.git rev=0.9.7
 dcicutils = git https://github.com/4dn-dcic/utils.git branch=master
 jsonschema = git https://github.com/4dn-dcic/jsonschema_serialize_fork.git

--- a/src/encoded/tests/test_fixtures.py
+++ b/src/encoded/tests/test_fixtures.py
@@ -106,7 +106,7 @@ def test_order_complete(app, conn):
     master_types = []
     profiles = testapp.get('/profiles/?frame=raw').json
     for a_type in profiles:
-        if profiles[a_type].get('id'):
+        if profiles[a_type].get('id') and profiles[a_type]['isAbstract'] is False:
             schema_name = profiles[a_type]['id'].split('/')[-1][:-5]
             master_types.append(schema_name)
     print(ORDER)

--- a/src/encoded/tests/test_views.py
+++ b/src/encoded/tests/test_views.py
@@ -279,7 +279,6 @@ def test_profiles(testapp, item_type):
 
 
 def test_profiles_all(testapp, registry):
-    from jsonschema_serialize_fork import Draft4Validator
     res = testapp.get('/profiles/').maybe_follow(status=200)
     # make sure all types are present, including abstract types
     for ti in registry[TYPES].by_item_type.values():

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -260,8 +260,15 @@ class Collection(snovault.Collection, AbstractCollection):
             self.__acl__ = ALLOW_SUBMITTER_ADD
 
 
+@snovault.abstract_collection(
+    name='items',
+    properties={
+        'title': "Item Listing",
+        'description': 'Abstract collection of all Items.',
+    })
 class Item(snovault.Item):
     """smth."""
+    item_type = 'item'
     AbstractCollection = AbstractCollection
     Collection = Collection
     STATUS_ACL = {

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -59,7 +59,7 @@ EXP_CATEGORIZER_SCHEMA = {
     })
 class Experiment(Item):
     """The main experiment class."""
-
+    item_type = 'experiment'
     base_types = ['Experiment'] + Item.base_types
     schema = load_schema('encoded:schemas/experiment.json')
     name_key = 'accession'

--- a/src/encoded/types/individual.py
+++ b/src/encoded/types/individual.py
@@ -23,7 +23,7 @@ from .base import (
     })
 class Individual(Item):
     """the base class for individual collection."""
-
+    item_type = 'individual'
     base_types = ['Individual'] + Item.base_types
     schema = load_schema('encoded:schemas/individual.json')
     embedded_list = Item.embedded_list + lab_award_attribution_embed_list + ['organism.name']

--- a/src/encoded/types/microscope_setting.py
+++ b/src/encoded/types/microscope_setting.py
@@ -22,6 +22,7 @@ from .base import (
     })
 class MicroscopeSetting(Item):
     """the base class for microscope settings collection."""
+    item_type = 'microscope_setting'
     base_types = ['MicroscopeSetting'] + Item.base_types
     schema = load_schema('encoded:schemas/microscope_setting.json')
     embedded_list = Item.embedded_list + lab_award_attribution_embed_list

--- a/src/encoded/types/quality_metric.py
+++ b/src/encoded/types/quality_metric.py
@@ -35,9 +35,8 @@ class QualityMetricFlag(Item):
     })
 class QualityMetric(Item):
     """Quality metrics class."""
-
-    base_types = ['QualityMetric'] + Item.base_types
     item_type = 'quality_metric'
+    base_types = ['QualityMetric'] + Item.base_types
     schema = load_schema('encoded:schemas/quality_metric.json')
     embedded_list = Item.embedded_list + lab_award_attribution_embed_list
 

--- a/src/encoded/types/treatment.py
+++ b/src/encoded/types/treatment.py
@@ -22,7 +22,7 @@ from .base import (
     })
 class Treatment(Item):
     """Treatment class."""
-
+    item_type = 'treatment'
     base_types = ['Treatment'] + Item.base_types
     schema = load_schema('encoded:schemas/treatment.json')
     embedded_list = Item.embedded_list + lab_award_attribution_embed_list

--- a/src/encoded/types/user_content.py
+++ b/src/encoded/types/user_content.py
@@ -29,7 +29,7 @@ import requests
         'description': 'Listing of all types of content which may be created by people.',
     })
 class UserContent(Item):
-
+    item_type = 'user_content'
     base_types = ['UserContent'] + Item.base_types
     schema = load_schema('encoded:schemas/user_content.json')
     embedded_list = lab_award_attribution_embed_list


### PR DESCRIPTION
Adds abstract types to the `/profiles/` view, as well as some new, helpful keys. Companion branch to https://github.com/4dn-dcic/snovault/releases/tag/v1.1.0

Adds `abstract_collection` decorator to Item type and also add `item_type` to abstract types that did not have it defined. Also updated a few tests.