### PR TITLE
Remove indexer.processes setting and set snovault to 1.2.2

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -31,7 +31,7 @@ auto-checkout = snovault
 		dcicutils
 
 [sources]
-snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.2.0
+snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.2.2
 Submit4DN = git https://github.com/4dn-dcic/Submit4DN.git rev=0.9.7
 dcicutils = git https://github.com/4dn-dcic/utils.git branch=master
 jsonschema = git https://github.com/4dn-dcic/jsonschema_serialize_fork.git
@@ -86,7 +86,6 @@ system_bucket = elasticbeanstalk-encoded-4dn-system
 # it will be overwritten in deploy/generate_buildout_cfg.py
 elasticsearch_instance = none
 load_test_data = encoded.loadxl:load_test_data
-indexer_processes =
 encoded_version = v-64c7473
 sqlalchemy_url =
 env_name = local

--- a/deploy/generate_buildout_cfg.py
+++ b/deploy/generate_buildout_cfg.py
@@ -21,10 +21,8 @@ create_tables = true
 load_test_data = encoded.loadxl:{load_function}
 mpindexer = {should_index}
 indexer = {should_index}
-indexer_processes = {procs}
 structlog.dir = {log_dir}
 '''
-# TODO: add in indexer.processes
 
 
 def dbconn_from_env():
@@ -50,7 +48,6 @@ def build_cfg_file():
 
     data['should_index'] = 'true'
     data['load_function'] = 'load_test_data'
-    data['procs'] = str(multiprocessing.cpu_count())
     data['es_server'] = os.environ.get("ES_URL")
     data['log_dir'] = '/var/log/'
     if os.environ.get("LOAD_FUNCTION"):

--- a/development.ini
+++ b/development.ini
@@ -11,7 +11,6 @@ load_test_only = true
 create_tables = true
 testing = true
 postgresql.statement_timeout = 20
-indexer.processes =
 mpindexer = true
 indexer = true
 elasticsearch.aws_auth = false

--- a/production.ini.in
+++ b/production.ini.in
@@ -7,7 +7,6 @@ blob_bucket = ${blob_bucket}
 system_bucket = ${system_bucket}
 # blob_store_profile_name = encoded-4dn-files
 accession_factory = ${accession_factory}
-indexer.processes = ${indexer_processes}
 elasticsearch.server = ${elasticsearch_instance}
 snovault.app_version = ${encoded_version}
 env.name = ${env_name}

--- a/src/encoded/tests/features/conftest.py
+++ b/src/encoded/tests/features/conftest.py
@@ -20,7 +20,6 @@ def app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server,
     settings['collection_datastore'] = 'elasticsearch'
     settings['item_datastore'] = 'elasticsearch'
     settings['indexer'] = True
-    settings['indexer.processes'] = 2
 
     # use aws auth to access elasticsearch
     if aws_auth:

--- a/test.ini
+++ b/test.ini
@@ -5,7 +5,6 @@ file_upload_bucket = elasticbeanstalk-encoded-4dn-files
 blob_bucket = elasticbeanstalk-encoded-4dn-blobs
 #blob_store_profile_name = encoded-4dn-files
 accession_factory = encoded.server_defaults.test_accession
-indexer.processes =
 elasticsearch.server = 172.31.49.128:9872
 snovault.app_version =
 


### PR DESCRIPTION
Small branch to set snovault to `v1.2.2`. This branch includes some indexer changes, including always using `multiprocessing.cpu_count() - 1` for the number of processes in the MPIndexer pool. As such, this branch removes the `indexer.processes` setting.