### PR TITLE
Added QMS table for each OPF collection in ExpSet

### DIFF
--- a/src/encoded/static/components/browse/components/file-tables.js
+++ b/src/encoded/static/components/browse/components/file-tables.js
@@ -262,10 +262,10 @@ export function renderFileQCReportLinkButton(file, field, detailIndex, fileEntry
     }
     const filename = Schemas.Term.toName('quality_metric.url', file.quality_metric.url, false);
     return (
-        <button type="button" className="btn btn-xs btn-primary" data-tip={"View report - " + filename}
+        <a className="btn btn-xs btn-primary" data-tip={"View report - " + filename}
             href={file.quality_metric.url} target="_blank" rel="noopener noreferrer">
             <i className="icon icon-fw icon-file-text-o" />
-        </button>
+        </a>
     );
 }
 

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -358,7 +358,7 @@ class QCMetricsTable extends React.PureComponent {
 
     static defaultProps = {
         heading: (
-            <h3 className="tab-section-title mt-12" key="tab-section-title-metrics">
+            <h3 className="tab-section-title mt-12">
                 <span>Quality Metrics</span>
             </h3>
         )
@@ -586,9 +586,10 @@ class SupplementaryFilesOPFCollection extends React.PureComponent {
         const { files, higlass_view_config, description, title } = collection;
         const { open } = this.state;
         const qcMetricsHeading = (
-            <h4 className="text-500 mt-2 mb-1" key={"tab-section-title-metrics-" + index}>
+            <h4 className="text-500 mt-2 mb-1">
                 <span>Quality Metrics</span>
-            </h4>);
+            </h4>
+        );
 
         return (
             <div data-open={open} className="supplementary-files-section-part" key={title || 'collection-' + index}>

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -353,15 +353,25 @@ class HiGlassAdjustableWidthRow extends React.PureComponent {
     }
 }
 
-class RenderQCMetricsTablesRow extends React.PureComponent {
+
+class QCMetricsTable extends React.PureComponent {
+
+    constructor(props){
+        super(props);
+        this.memoized = {
+            filterFilesWithQCSummary: memoize(commonFileUtil.filterFilesWithQCSummary),
+            groupFilesByQCSummaryTitles: memoize(commonFileUtil.groupFilesByQCSummaryTitles)
+        };
+    }
+
     render() {
         const { width, files, windowWidth, href } = this.props;
-        const filesWithMetrics = commonFileUtil.filterFilesWithQCSummary(files);
+        const filesWithMetrics = this.memoized.filterFilesWithQCSummary(files);
         const filesWithMetricsLen = filesWithMetrics.length;
 
-        if(!filesWithMetrics || filesWithMetricsLen === 0) return null;
+        if (!filesWithMetrics || filesWithMetricsLen === 0) return null;
 
-        const filesByTitles = commonFileUtil.groupFilesByQCSummaryTitles(filesWithMetrics);
+        const filesByTitles = this.memoized.groupFilesByQCSummaryTitles(filesWithMetrics);
 
         return (
             <div className="row">
@@ -487,7 +497,7 @@ class ProcessedFilesStackedTableSection extends React.PureComponent {
             <div className="processed-files-table-section exp-table-section">
                 {this.renderHeader()}
                 {this.renderTopRow()}
-                <RenderQCMetricsTablesRow {...this.props} />
+                <QCMetricsTable {...this.props} />
             </div>
         );
     }
@@ -589,7 +599,7 @@ class SupplementaryFilesOPFCollection extends React.PureComponent {
                             <HiGlassAdjustableWidthRow higlassItem={higlass_view_config} windowWidth={windowWidth} mounted={mounted} width={width - 21}
                                 renderRightPanel={this.renderFilesTable} leftPanelDefaultCollapsed={defaultOpen === false} />
                             : this.renderFilesTable(width - 21) }
-                        <RenderQCMetricsTablesRow { ...{ 'width': width - 20, windowWidth, href, files } } />
+                        <QCMetricsTable { ...{ 'width': width - 20, windowWidth, href, files } } />
                     </div>
                 </Collapse>
             </div>

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -26,7 +26,7 @@ import { EmbeddedHiglassActions } from './../static-pages/components';
 // eslint-disable-next-line no-unused-vars
 const { Item, File, ExperimentSet } = typedefs;
 
-// import { SET } from './../testdata/experiment_set/replicate_4DNESXZ4FW4';
+// import { SET } from './../testdata/experiment_set/replicate_4DNESDG4HNP9';
 // import { SET } from './../testdata/experiment_set/replicate_with_bigwigs';
 
 
@@ -353,6 +353,56 @@ class HiGlassAdjustableWidthRow extends React.PureComponent {
     }
 }
 
+class RenderQCMetricsTablesRow extends React.PureComponent {
+    render() {
+        const { width, files, windowWidth, href } = this.props;
+        const filesWithMetrics = commonFileUtil.filterFilesWithQCSummary(files);
+        const filesWithMetricsLen = filesWithMetrics.length;
+
+        if(!filesWithMetrics || filesWithMetricsLen === 0) return null;
+
+        const filesByTitles = commonFileUtil.groupFilesByQCSummaryTitles(filesWithMetrics);
+
+        return (
+            <div className="row">
+                <div className="exp-table-container col-12">
+                    <h3 className="tab-section-title mt-12" key="tab-section-title-metrics">
+                        <span>Quality Metrics</span>
+                    </h3>
+                    {_.map(filesByTitles, function (fileGroup, i) {
+                        const columnHeaders = [ // Static / present-for-each-table headers
+                            { columnClass: 'experiment', title: 'Experiment', initialWidth: 145, className: 'text-left' },
+                            { columnClass: 'file', title: 'For File', initialWidth: 100 }
+                        ].concat(_.map(fileGroup[0].quality_metric_summary, function (sampleQMSItem, qmsIndex) { // Dynamic Headers
+                            function renderColValue(file, field, colIndex, fileEntryBlockProps) {
+                                const qmsItem = file.quality_metric_summary[qmsIndex];
+                                const { value, tooltip } = QCMetricFromSummary.formatByNumberType(qmsItem);
+                                return <span className="inline-block" data-tip={tooltip}>{value}</span>;
+                            }
+                            return { columnClass: 'file-detail', title: sampleQMSItem.title, initialWidth: 80, render: renderColValue };
+                        }));
+
+                        // Add 'Link to Report' column, if any files w/ one. Else include blank one so columns align with any other stacked ones.
+                        const anyFilesWithMetricURL = _.any(fileGroup, function (f) {
+                            return f && f.quality_metric && f.quality_metric.url;
+                        });
+
+                        if(anyFilesWithMetricURL) {
+                            columnHeaders.push({ columnClass: 'file-detail', title: 'Report', initialWidth: 50, render: renderFileQCReportLinkButton });
+                        } else {
+                            columnHeaders.push({ columnClass: 'file-detail', title: ' ', initialWidth: 50, render: function () { return ''; } });
+                        }
+
+                        return (
+                            <ProcessedFilesStackedTable {...{ width, windowWidth, href, columnHeaders }} key={i}
+                                files={fileGroup} collapseLimit={10} collapseShow={7} collapseLongLists={true} titleForFiles="Processed File Metrics" />
+                        );
+                    })}
+                </div>
+            </div>
+        );
+    }
+}
 
 class ProcessedFilesStackedTableSection extends React.PureComponent {
 
@@ -387,7 +437,7 @@ class ProcessedFilesStackedTableSection extends React.PureComponent {
 
     constructor(props){
         super(props);
-        _.bindAll(this, 'renderTopRow', 'renderQCMetricsTablesRow', 'renderHeader', 'renderProcessedFilesTableAsRightPanel');
+        _.bindAll(this, 'renderTopRow', 'renderHeader', 'renderProcessedFilesTableAsRightPanel');
     }
 
     renderProcessedFilesTableAsRightPanel(rightPanelWidth, resetDivider, leftPanelCollapsed){
@@ -405,55 +455,6 @@ class ProcessedFilesStackedTableSection extends React.PureComponent {
         } else {
             return <ProcessedFilesStackedTable {...ProcessedFilesStackedTableSection.tableProps(this.props)} width={width}/>;
         }
-    }
-
-    renderQCMetricsTablesRow(){
-        const { width, files, windowWidth, href } = this.props;
-        const filesWithMetrics = commonFileUtil.filterFilesWithQCSummary(files);
-        const filesWithMetricsLen = filesWithMetrics.length;
-
-        if (!filesWithMetrics || filesWithMetricsLen === 0) return null;
-
-        const filesByTitles = commonFileUtil.groupFilesByQCSummaryTitles(filesWithMetrics);
-
-        return (
-            <div className="row">
-                <div className="exp-table-container col-12">
-                    <h3 className="tab-section-title mt-12" key="tab-section-title-metrics">
-                        <span>Quality Metrics</span>
-                    </h3>
-                    { _.map(filesByTitles, function(fileGroup, i){
-                        const columnHeaders = [ // Static / present-for-each-table headers
-                            { columnClass: 'experiment',  title: 'Experiment',  initialWidth: 145,  className: 'text-left' },
-                            { columnClass: 'file',        title: 'For File',    initialWidth: 100 }
-                        ].concat(_.map(fileGroup[0].quality_metric_summary, function(sampleQMSItem, qmsIndex){ // Dynamic Headers
-                            function renderColValue(file, field, colIndex, fileEntryBlockProps){
-                                const qmsItem = file.quality_metric_summary[qmsIndex];
-                                const { value, tooltip } = QCMetricFromSummary.formatByNumberType(qmsItem);
-                                return <span className="inline-block" data-tip={tooltip}>{ value }</span>;
-                            }
-                            return { columnClass : 'file-detail', title : sampleQMSItem.title, initialWidth : 80, render : renderColValue };
-                        }));
-
-                        // Add 'Link to Report' column, if any files w/ one. Else include blank one so columns align with any other stacked ones.
-                        const anyFilesWithMetricURL = _.any(fileGroup, function(f){
-                            return f && f.quality_metric && f.quality_metric.url;
-                        });
-
-                        if (anyFilesWithMetricURL){
-                            columnHeaders.push({ columnClass: 'file-detail', title: 'Report', initialWidth: 50, render : renderFileQCReportLinkButton });
-                        } else {
-                            columnHeaders.push({ columnClass: 'file-detail', title: ' ', initialWidth: 50, render : function(){ return ''; } });
-                        }
-
-                        return (
-                            <ProcessedFilesStackedTable {...{ width, windowWidth, href, columnHeaders }} key={i}
-                                files={fileGroup} collapseLimit={10} collapseShow={7} collapseLongLists={true} titleForFiles="Processed File Metrics" />
-                        );
-                    }) }
-                </div>
-            </div>
-        );
     }
 
     renderHeader(){
@@ -484,9 +485,9 @@ class ProcessedFilesStackedTableSection extends React.PureComponent {
     render(){
         return (
             <div className="processed-files-table-section exp-table-section">
-                { this.renderHeader() }
-                { this.renderTopRow() }
-                { this.renderQCMetricsTablesRow() }
+                {this.renderHeader()}
+                {this.renderTopRow()}
+                <RenderQCMetricsTablesRow {...this.props} />
             </div>
         );
     }
@@ -565,7 +566,7 @@ class SupplementaryFilesOPFCollection extends React.PureComponent {
     }
 
     render(){
-        const { collection, index, width, mounted, defaultOpen, windowWidth } = this.props;
+        const { collection, index, width, mounted, defaultOpen, windowWidth, href } = this.props;
         const { files, higlass_view_config, description, title } = collection;
         const { open } = this.state;
         return (
@@ -588,6 +589,7 @@ class SupplementaryFilesOPFCollection extends React.PureComponent {
                             <HiGlassAdjustableWidthRow higlassItem={higlass_view_config} windowWidth={windowWidth} mounted={mounted} width={width - 21}
                                 renderRightPanel={this.renderFilesTable} leftPanelDefaultCollapsed={defaultOpen === false} />
                             : this.renderFilesTable(width - 21) }
+                        <RenderQCMetricsTablesRow { ...{ 'width': width - 20, windowWidth, href, files } } />
                     </div>
                 </Collapse>
             </div>
@@ -764,7 +766,7 @@ class SupplementaryFilesTabView extends React.PureComponent {
     });
 
     render(){
-        const { context, width, mounted, windowWidth } = this.props;
+        const { context, width, mounted, windowWidth, href } = this.props;
         const gridState = mounted && layout.responsiveGridState(windowWidth);
         const otherProcessedFileSetsCombined = SupplementaryFilesTabView.combinedOtherProcessedFiles(context);
         const otherProcessedFileSetsCombinedLen = otherProcessedFileSetsCombined.length;
@@ -778,7 +780,7 @@ class SupplementaryFilesTabView extends React.PureComponent {
             (otherProcessedFileSetsCombinedLen > 0 ? (otherProcessedFileSetsCombinedLen + " Processed Files Collection" + (otherProcessedFileSetsCombinedLen > 1 ? "s" : "")) : '')
         );
 
-        const commonProps = { context, width, mounted, windowWidth };
+        const commonProps = { context, width, mounted, windowWidth, href };
 
         // TODO: Metadata.tsv stuff needs to be setup before we can select files from other_processed_files & reference_files
         //const commonProps = _.extend({ context, width, mounted, windowWidth }, SelectedFilesController.pick(this.props));

--- a/src/encoded/tests/data/master-inserts/user.json
+++ b/src/encoded/tests/data/master-inserts/user.json
@@ -132,17 +132,6 @@
         "groups": ["read-only-admin"]
     },
     {
-        "email": "chad_serrant@hms.harvard.edu",
-        "first_name": "Chad",
-        "job_title": "4DN staff",
-        "lab": "4dn-dcic-lab",
-        "last_name": "Serrant",
-        "uuid": "9866662f-4eb6-3a4b-7cdf-3ab267226988",
-        "viewing_groups": ["4DN"],
-        "groups": ["admin"],
-        "submits_for": ["4dn-dcic-lab"]
-    },
-    {
         "timezone": "US/Eastern",
         "email": "ud4dntest@gmail.com",
         "status": "current",
@@ -153,5 +142,44 @@
         "last_name": "Test",
         "viewing_groups": ["4DN"],
         "aliases": ["4dn-dcic-lab:testing_ui"]
+    },
+    {
+        "email": "william_ronchetti@hms.harvard.edu",
+        "first_name": "Will",
+        "job_title": "4DN staff",
+        "lab": "4dn-dcic-lab",
+        "last_name": "Ronchetti",
+        "uuid": "1a12362f-4eb6-4a9c-8173-776667226988",
+        "viewing_groups": ["4DN"],
+        "groups": ["admin"],
+        "submits_for": ["4dn-dcic-lab"]
+    },
+    {
+        "last_name": "App",
+        "viewing_groups": ["4DN"],
+        "aliases": ["4dn-dcic-lab:foursight_app"],
+        "first_name": "Foursight",
+        "timezone": "US/Eastern",
+        "status": "current",
+        "lab": "4dn-dcic-lab",
+        "groups": ["admin"],
+        "email": "foursight.app@gmail.com",
+        "uuid": "7677f8a8-79d2-4cff-ab0a-a967a2a68e39",
+        "submits_for": ["4dn-dcic-lab"],
+        "job_title": "Other"
+    },
+    {
+        "last_name": "App",
+        "viewing_groups": ["4DN"],
+        "aliases": ["4dn-dcic-lab:tibanna_app"],
+        "first_name": "Tibanna",
+        "timezone": "US/Eastern",
+        "status": "current",
+        "lab": "4dn-dcic-lab",
+        "groups": ["admin"],
+        "email": "tibanna.app@gmail.com",
+        "uuid": "b041dba8-e2b2-4e54-a621-97edb508a0c4",
+        "submits_for": ["4dn-dcic-lab"],
+        "job_title": "Other"
     }
 ]

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -233,6 +233,9 @@ class ExperimentSet(Item):
         "other_processed_files.files.href",
         "other_processed_files.files.status",
         "other_processed_files.files.last_modified.date_modified",
+        "other_processed_files.files.quality_metric.url",
+        "other_processed_files.files.quality_metric.overall_quality_status",
+        "other_processed_files.files.quality_metric_summary.*",
         "other_processed_files.higlass_view_config.description",
         "other_processed_files.higlass_view_config.last_modified.date_modified",
 
@@ -248,6 +251,9 @@ class ExperimentSet(Item):
         "experiments_in_set.other_processed_files.files.genome_assembly",
         "experiments_in_set.other_processed_files.files.status",
         "experiments_in_set.other_processed_files.files.last_modified.date_modified",
+        "experiments_in_set.other_processed_files.files.quality_metric.url",
+        "experiments_in_set.other_processed_files.files.quality_metric.overall_quality_status",
+        "experiments_in_set.other_processed_files.files.quality_metric_summary.*",
 
         "experiments_in_set.reference_files.accession",
         "experiments_in_set.reference_files.file_classification",


### PR DESCRIPTION
**Problem:** `Quality Metrics Summary` table needed for each OPF collection under `Supplementary Files Tab` in `Experiment Set View`.

**Solution:** First of all, added missing other processed files' QC metrics and summary data to the `context` by adding related lines in `experiment_set.py`. The Quality Metrics table was already implemented for processed files tab as a local function. It is converted to a pure React component to be used in multiple tabs.

~~**TODO:** Quality Metrics header is relatively large in size compared to the OPF collection header. The size may be adjusted.~~

<img width="1260" alt="Screen Shot 2019-09-05 at 19 28 41" src="https://user-images.githubusercontent.com/49978017/64360713-a7d1a080-d013-11e9-8343-1fe215153d1d.png">




