### PR TITLE
Fix HiGlass zoom problem after a tab change

### DIFF
--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -103,39 +103,39 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
      * componentDidUpdate (?) now that we don't swap out state.viewConfig with nextProps.viewConfig.
      * -- After cleanup.
      */
-    UNSAFE_componentWillReceiveProps(nextProps){
-        var nextState = {};
+    // UNSAFE_componentWillReceiveProps(nextProps){
+    //     const nextState = {};
 
-        /*  Below code:
-            We will likely adjust/remove to no longer change viewConfig if receive new one from back-end because
-            backend will always deliver new object reference. Even if same context['@id'] and context.date_modified.
-        */
+    //     /*  Below code:
+    //         We will likely adjust/remove to no longer change viewConfig if receive new one from back-end because
+    //         backend will always deliver new object reference. Even if same context['@id'] and context.date_modified.
+    //     */
 
-        if (nextProps.viewConfig !== this.props.viewConfig){
-            _.extend(nextState, {
-                'originalViewConfig' : null, //object.deepClone(nextProps.viewConfig) // Not currently used.
-                'viewConfig'         : nextProps.viewConfig,
-                'genome_assembly'    : (nextProps.context && nextProps.context.genome_assembly) || this.state.genome_assembly || null
-            });
-        }
-        const hiGlassTabIndex = (this.props.hiGlassTabIndex !== 'undefined') ? this.props.hiGlassTabIndex : -1;        
-        const recentTabIsHiglass = (hiGlassTabIndex === 0 ? this.props.href.indexOf('#') < 0 : false) || (this.props.href.indexOf('#higlass') >= 0);
-        if (recentTabIsHiglass && (nextProps.href !== this.props.href) && (object.itemUtil.atId(nextProps.context) === object.itemUtil.atId(this.props.context))) {
-            // If component is still same instance, then is likely that we're changing
-            // the URI hash as a consequence of changing tabs --or-- reloading current context due to change in session, etc.
-            // Export & save viewConfig from HiGlassComponent internal state to our own to preserve contents.
-            var hgc = this.getHiGlassComponent(),
-                currentViewConfStr = hgc && hgc.api.exportAsViewConfString(),
-                currentViewConf = currentViewConfStr && JSON.parse(currentViewConfStr);s               
-                //  currentViewConf && _.extend(nextState, {
-                //      'viewConfig' : currentViewConf
-                //  });
-        }
+    //     if (nextProps.viewConfig !== this.props.viewConfig){
+    //         _.extend(nextState, {
+    //             'originalViewConfig' : null, //object.deepClone(nextProps.viewConfig) // Not currently used.
+    //             'viewConfig'         : nextProps.viewConfig,
+    //             'genome_assembly'    : (nextProps.context && nextProps.context.genome_assembly) || this.state.genome_assembly || null
+    //         });
+    //     }
+    //     const hiGlassTabIndex = (this.props.hiGlassTabIndex !== 'undefined') ? this.props.hiGlassTabIndex : -1;
+    //     const recentTabIsHiglass = (hiGlassTabIndex === 0 ? this.props.href.indexOf('#') < 0 : false) || (this.props.href.indexOf('#higlass') >= 0);
+    //     if (recentTabIsHiglass && (nextProps.href !== this.props.href) && (object.itemUtil.atId(nextProps.context) === object.itemUtil.atId(this.props.context))) {
+    //         // If component is still same instance, then is likely that we're changing
+    //         // the URI hash as a consequence of changing tabs --or-- reloading current context due to change in session, etc.
+    //         // Export & save viewConfig from HiGlassComponent internal state to our own to preserve contents.
+    //         const hgc = this.getHiGlassComponent();
+    //         const currentViewConfStr = hgc && hgc.api.exportAsViewConfString();
+    //         const currentViewConf = currentViewConfStr && JSON.parse(currentViewConfStr);
+    //         //  currentViewConf && _.extend(nextState, {
+    //         //      'viewConfig' : currentViewConf
+    //         //  });
+    //     }
 
-        if (_.keys(nextState).length > 0) {
-            this.setState(nextState);
-        }
-    }
+    //     if (_.keys(nextState).length > 0) {
+    //         this.setState(nextState);
+    //     }
+    // }
 
     componentDidUpdate(pastProps, pastState){
         if (this.props.isFullscreen !== pastProps.isFullscreen){
@@ -267,13 +267,13 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         // Check if our title already has " - user's copy" substring and if so,
         // increment an appended counter instead of re-adding the substring.
         if (context.display_title.indexOf(viewConfTitleAppendStr) > -1){
-            var regexCheck      = new RegExp('(' + viewConfTitleAppendStr + ')\\s\\(\\d+\\)'),
-                regexMatches    = context.display_title.match(regexCheck);
+            const regexCheck = new RegExp('(' + viewConfTitleAppendStr + ')\\s\\(\\d+\\)');
+            const regexMatches = context.display_title.match(regexCheck);
 
             if (regexMatches && regexMatches.length === 2) {
                 // regexMatches[0] ==> " - user's copy (int)"
                 // regexMatches[1] ==> " - user's copy"
-                var copyCount = parseInt(
+                let copyCount = parseInt(
                     regexMatches[0].replace(regexMatches[1], '')
                         .trim()
                         .replace('(', '')
@@ -349,10 +349,10 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
     * @returns {void}
     */
     addFileToHiglass(fileAtID) {
-        var { context }         = this.props,
-            hgc                 = this.getHiGlassComponent(),
-            currentViewConfStr  = hgc && hgc.api.exportAsViewConfString(),
-            currentViewConf     = currentViewConfStr && JSON.parse(currentViewConfStr);
+        const { context } = this.props;
+        const hgc = this.getHiGlassComponent();
+        const currentViewConfStr = hgc && hgc.api.exportAsViewConfString();
+        const currentViewConf = currentViewConfStr && JSON.parse(currentViewConfStr);
 
         if (!currentViewConf){
             throw new Error('Could not get current view configuration.');
@@ -386,7 +386,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             firstViewLocationAndZoom = [xCenter, yCenter, k];
         }
 
-        var payload = {
+        const payload = {
             'higlass_viewconfig': currentViewConf,
             'genome_assembly': this.state.genome_assembly,
             'files' : [fileAtID],
@@ -394,7 +394,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         };
 
         // If it failed, show the error in the popup window.
-        var fallbackCallback = (errResp, xhr) => {
+        const fallbackCallback = (errResp, xhr) => {
             // Error callback
             Alerts.queue({
                 'title' : "Failed to add file.",
@@ -451,9 +451,9 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
     handleStatusChange(statusToSet = 'released', evt){
         evt.preventDefault();
 
-        var { context, href }   = this.props,
-            hgc                 = this.getHiGlassComponent(),
-            viewConfTitle       = context.title || context.display_title;
+        const { context, href } = this.props;
+        const hgc = this.getHiGlassComponent();
+        const viewConfTitle = context.title || context.display_title;
 
         // If the view config has already been released, just copy the URL to the clipboard and return.
         if (context.status === statusToSet) {
@@ -513,7 +513,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
 
         if (!session || !editPermission) return null; // TODO: Remove and implement for anon users. Eventually.
 
-        var btnProps  = {
+        const btnProps  = {
             'onSelect'      : this.handleStatusChange,
             //'onClick'       : context.status === 'released' ? null : this.handleStatusChangeToRelease,
             'variant'       : context.status === 'released' ? 'outline-dark' : 'info',
@@ -592,12 +592,12 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
      * in response to new `width` and `height` props passed to it.
      */
     handleFullscreenToggle(){
-        var { isFullscreen, toggleFullScreen } = this.props;
+        const { isFullscreen, toggleFullScreen } = this.props;
         setTimeout(toggleFullScreen, 0, !isFullscreen);
     }
 
     fullscreenButton(){
-        var { isFullscreen, toggleFullScreen } = this.props;
+        const { isFullscreen, toggleFullScreen } = this.props;
         if(typeof isFullscreen === 'boolean' && typeof toggleFullScreen === 'function'){
             return (
                 <button type="button" className="btn btn-outline-dark" onClick={this.handleFullscreenToggle} data-tip={!isFullscreen ? 'Expand to full screen' : null}>
@@ -625,20 +625,20 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
     render(){
         const { isFullscreen, windowWidth, windowHeight, width, session } = this.props;
         const { addFileLoading, genome_assembly, viewConfig } = this.state;
-        const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;        
+        const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
         // Setting the height of the HiGlass Component follows one of these rules:
         // - If it's Fullscreen it should almost take up the entire window.
         // - Set to a fixed height.
-        var hiGlassComponentHeight;
+        let hiGlassComponentHeight;
         if (isFullscreen) {
-            hiGlassComponentHeight = windowHeight -120;
+            hiGlassComponentHeight = windowHeight - 120;
         }
         else {
             hiGlassComponentHeight = 600;
         }
 
         // If the user isn't logged in, add a tooltip reminding them to log in.
-        var tooltip = null;
+        let tooltip = null;
         if (!session) {
             tooltip = "Log in to be able to clone, save, and share HiGlass Displays";
         }
@@ -778,8 +778,8 @@ class CollapsibleViewConfOutput extends React.PureComponent {
     }
 
     render(){
-        var { viewConfig } = this.props,
-            { open } = this.state;
+        const { viewConfig } = this.props;
+        const { open } = this.state;
 
         return (
             <div className="viewconfig-panel">

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -93,7 +93,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             'releaseLoading'        : false,
             'addFileLoading'        : false
         };
-
+         
         this.higlassRef = React.createRef();
     }
 
@@ -119,21 +119,22 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
                 'genome_assembly'    : (nextProps.context && nextProps.context.genome_assembly) || this.state.genome_assembly || null
             });
         }
-
-        if (nextProps.href !== this.props.href && object.itemUtil.atId(nextProps.context) === object.itemUtil.atId(this.props.context)){
+        const hiGlassTabIndex = (this.props.hiGlassTabIndex !== 'undefined') ? this.props.hiGlassTabIndex : -1;        
+        const recentTabIsHiglass = (hiGlassTabIndex === 0 ? this.props.href.indexOf('#') < 0 : false) || (this.props.href.indexOf('#higlass') >= 0);
+        if (recentTabIsHiglass && (nextProps.href !== this.props.href) && (object.itemUtil.atId(nextProps.context) === object.itemUtil.atId(this.props.context))) {
             // If component is still same instance, then is likely that we're changing
             // the URI hash as a consequence of changing tabs --or-- reloading current context due to change in session, etc.
             // Export & save viewConfig from HiGlassComponent internal state to our own to preserve contents.
-            var hgc                 = this.getHiGlassComponent(),
-                currentViewConfStr  = hgc && hgc.api.exportAsViewConfString(),
-                currentViewConf     = currentViewConfStr && JSON.parse(currentViewConfStr);
-
-            currentViewConf && _.extend(nextState, {
-                'viewConfig' : currentViewConf
-            });
+            var hgc = this.getHiGlassComponent(),
+                currentViewConfStr = hgc && hgc.api.exportAsViewConfString(),
+                currentViewConf = currentViewConfStr && JSON.parse(currentViewConfStr);
+               
+                //  currentViewConf && _.extend(nextState, {
+                //      'viewConfig' : currentViewConf
+                //  });
         }
 
-        if (_.keys(nextState).length > 0){
+        if (_.keys(nextState).length > 0) {
             this.setState(nextState);
         }
     }
@@ -628,7 +629,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         const { addFileLoading, genome_assembly, viewConfig } = this.state;
 
         const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
-
+        
         // Setting the height of the HiGlass Component follows one of these rules:
         // - If it's Fullscreen it should almost take up the entire window.
         // - Set to a fixed height.

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -93,7 +93,6 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             'releaseLoading'        : false,
             'addFileLoading'        : false
         };
-         
         this.higlassRef = React.createRef();
     }
 
@@ -127,8 +126,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             // Export & save viewConfig from HiGlassComponent internal state to our own to preserve contents.
             var hgc = this.getHiGlassComponent(),
                 currentViewConfStr = hgc && hgc.api.exportAsViewConfString(),
-                currentViewConf = currentViewConfStr && JSON.parse(currentViewConfStr);
-               
+                currentViewConf = currentViewConfStr && JSON.parse(currentViewConfStr);s               
                 //  currentViewConf && _.extend(nextState, {
                 //      'viewConfig' : currentViewConf
                 //  });
@@ -627,9 +625,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
     render(){
         const { isFullscreen, windowWidth, windowHeight, width, session } = this.props;
         const { addFileLoading, genome_assembly, viewConfig } = this.state;
-
-        const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
-        
+        const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;        
         // Setting the height of the HiGlass Component follows one of these rules:
         // - If it's Fullscreen it should almost take up the entire window.
         // - Set to a fixed height.

--- a/src/encoded/static/components/item-pages/components/TabbedView.js
+++ b/src/encoded/static/components/item-pages/components/TabbedView.js
@@ -68,7 +68,12 @@ export class TabbedView extends React.PureComponent {
     }
 
     static renderTabPane(tabObj, tabIndex = 0){
-        const { key, tab, placeholder, disabled = false, style = null, content } = tabObj;
+        const { key, tab, placeholder, disabled = false, style = null } = tabObj;
+        let { content } = tabObj;
+        if(this.hiGlassTabIndex >= 0){
+            content = React.cloneElement(content, { 'hiGlassTabIndex': this.hiGlassTabIndex });
+        }
+        
         return (
             <Tabs.TabPane
                 key={key || tabIndex}
@@ -299,18 +304,19 @@ export class TabbedView extends React.PureComponent {
     render(){
         const { contents, extraTabContent, activeKey, animated, onChange, destroyInactiveTabPane, renderTabBar, windowWidth } = this.props;
 
-        var allTabs = TabbedView.combineSystemAndCustomTabs(this.additionalTabs(), contents),
-            tabsProps = {
-                onChange, destroyInactiveTabPane,
-                'renderTabBar'          : () => (
-                    <ScrollableInkTabBar onTabClick={this.onTabClick} extraContent={extraTabContent}
-                        className="extra-style-2" tabBarGutter={0} />
-                ),
-                'renderTabContent'      : () => <TabContent animated={animated} />,
-                'ref'                   : this.tabsRef,
-                'defaultActiveKey'      : TabbedView.getDefaultActiveKeyFromContents(contents),
-                'children'              : _.map(allTabs, TabbedView.renderTabPane)
-            };
+        var allTabs = TabbedView.combineSystemAndCustomTabs(this.additionalTabs(), contents);
+        const hiGlassTabIndex = _.findIndex(contents, function (el) { return ['higlass'].indexOf(el.key) > -1; });
+        var tabsProps = {
+            onChange, destroyInactiveTabPane,
+            'renderTabBar': () => (
+                <ScrollableInkTabBar onTabClick={this.onTabClick} extraContent={extraTabContent}
+                    className="extra-style-2" tabBarGutter={0} />
+            ),
+            'renderTabContent': () => <TabContent animated={animated} />,
+            'ref': this.tabsRef,
+            'defaultActiveKey': TabbedView.getDefaultActiveKeyFromContents(contents),
+            'children': _.map(allTabs, TabbedView.renderTabPane, { 'hiGlassTabIndex': hiGlassTabIndex })
+        };
 
         if (activeKey) tabsProps.activeKey = activeKey;
 

--- a/src/encoded/static/components/item-pages/components/TabbedView.js
+++ b/src/encoded/static/components/item-pages/components/TabbedView.js
@@ -68,12 +68,8 @@ export class TabbedView extends React.PureComponent {
     }
 
     static renderTabPane(tabObj, tabIndex = 0){
-        const { key, tab, placeholder, disabled = false, style = null } = tabObj;
-        let { content } = tabObj;
-        if(this.hiGlassTabIndex >= 0){
-            content = React.cloneElement(content, { 'hiGlassTabIndex': this.hiGlassTabIndex });
-        }
-        
+        const { key, tab, placeholder, disabled = false, style = null, content } = tabObj;
+
         return (
             <Tabs.TabPane
                 key={key || tabIndex}
@@ -304,9 +300,8 @@ export class TabbedView extends React.PureComponent {
     render(){
         const { contents, extraTabContent, activeKey, animated, onChange, destroyInactiveTabPane, renderTabBar, windowWidth } = this.props;
 
-        var allTabs = TabbedView.combineSystemAndCustomTabs(this.additionalTabs(), contents);
-        const hiGlassTabIndex = _.findIndex(contents, function (el) { return ['higlass'].indexOf(el.key) > -1; });
-        var tabsProps = {
+        const allTabs = TabbedView.combineSystemAndCustomTabs(this.additionalTabs(), contents);
+        const tabsProps = {
             onChange, destroyInactiveTabPane,
             'renderTabBar': () => (
                 <ScrollableInkTabBar onTabClick={this.onTabClick} extraContent={extraTabContent}
@@ -315,7 +310,7 @@ export class TabbedView extends React.PureComponent {
             'renderTabContent': () => <TabContent animated={animated} />,
             'ref': this.tabsRef,
             'defaultActiveKey': TabbedView.getDefaultActiveKeyFromContents(contents),
-            'children': _.map(allTabs, TabbedView.renderTabPane, { 'hiGlassTabIndex': hiGlassTabIndex })
+            'children': _.map(allTabs, TabbedView.renderTabPane)
         };
 
         if (activeKey) tabsProps.activeKey = activeKey;


### PR DESCRIPTION
**Problem**: HiGlass component loses its state and zoom if page's active tab is changed. To reproduce the bug: adjust the HiGlass zoom then back and forth between tabs.

**Background**: HiGlass component uses a config file, a.k.a `viewConfig`, to initialize its state. The `viewConfig` is implicitly updated while any zoom/pan or misc. user interactions. Component provides an API to import and export its `viewConfig`. Beside this built-in config management, there exists `HiGlassViewConfigView.js/UNSAFE_componentWillReceiveProps` function. It is to save the viewConfig to React state, in order to prevent any lose while user changes the tabs in the page. Theoretically, it is a helpful feature from React perspective. On the other hand, HiGlass components implicit data loading and viewConfig updating is not so transparent, so container React component can hardly determine to save viewConfig. Unfortunately, `HiGlassViewConfigView.js/UNSAFE_componentWillReceiveProps` saves the state even if viewConfig is not stable. (We monitored by logging viewConfig's `InitialXDomain` and `InitialYDomain`, while switch from HiGlass tab, or between any tabs other than the HiGlass'.)

**Solution**: First of all, we limited saving to state: Instead of every tab change, saving runs only while leaving HiGlass container tab. It is trivial to determine HiGlass tab if it is not the first tab: `this.props.href `includes # higlass. On the other hand, if HiGlass tab is the first one, `this.props.href` lacks any # higlass. `rc-tabs` has an `activeKey` attribute, but we couldn't utilize it since cannot propagate of `activeKey` from `TabbedView` to `HiGlassViewConfigTabView` via `rc-tabs`. So we tweaked  `TabbedView` by adding a `hiGlassTabIndex` attribute. This solution worked well, since we can determine whether the recent tab is HiGlass container tab HiGlassViewConfigView.js/UNSAFE_componentWillReceiveProps`. If so save `viewConfig` to state.

While everything seems all set, we noticed that this solution fails for some conditions, e.g. the HiGlass server updated during our tests. After the update, component couldn't retrieve `chrom-sizes.js` file and gets `404` response from server. (see attached image) This condition triggers the component continuously update its `viewConfig`. So we can hardly save a stable version of `viewConfig`. We can hardly trust what we save, so why we need it? Finally, decided to cancel saving to state as once @alexkb0009 stated before. Commented out:

```
//currentViewConf && _.extend(nextState, {
//       'viewConfig' : currentViewConf
//});
```

**PS:** hiGlassTabIndex not used recently, but not removed.

chrom-sizes.js

![chrom-sizes-404-error](https://user-images.githubusercontent.com/49978017/64031606-70fe1500-cb51-11e9-88b2-3008cbf9c0d5.jpeg)
