### PR TITLE
Adding flaky

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ tests_require = [
     'pytest-xdist',
     'pytest-cov',
     'attrs',
+    'flaky',
 ]
 
 setup(

--- a/src/encoded/tests/test_aggregation.py
+++ b/src/encoded/tests/test_aggregation.py
@@ -1,6 +1,6 @@
 import pytest
 from .features.conftest import app_settings, workbook
-pytestmark = [pytest.mark.working, pytest.mark.indexing]
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky]
 
 def test_aggregation_facet(workbook, testapp):
     res = testapp.get('/search/?type=ExperimentSetReplicate').json

--- a/src/encoded/tests/test_aggregation.py
+++ b/src/encoded/tests/test_aggregation.py
@@ -1,6 +1,7 @@
 import pytest
 from .features.conftest import app_settings, workbook
-pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky]
+from .test_search import delay_rerun
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun)]
 
 def test_aggregation_facet(workbook, testapp):
     res = testapp.get('/search/?type=ExperimentSetReplicate').json

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -1,7 +1,7 @@
 # Use workbook fixture from BDD tests (including elasticsearch)
 from .features.conftest import app_settings, app, workbook
 import pytest
-pytestmark = [pytest.mark.indexing]
+pytestmark = [pytest.mark.indexing, pytest.mark.flaky]
 
 @pytest.mark.skip(reason="update data when we have a working experiment")
 def test_report_download(testapp, workbook):

--- a/src/encoded/tests/test_batch_download.py
+++ b/src/encoded/tests/test_batch_download.py
@@ -1,7 +1,8 @@
 # Use workbook fixture from BDD tests (including elasticsearch)
 from .features.conftest import app_settings, app, workbook
+from .test_search import delay_rerun
 import pytest
-pytestmark = [pytest.mark.indexing, pytest.mark.flaky]
+pytestmark = [pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun)]
 
 @pytest.mark.skip(reason="update data when we have a working experiment")
 def test_report_download(testapp, workbook):

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -9,8 +9,9 @@ import time
 from encoded.verifier import verify_item
 from snovault.elasticsearch.interfaces import INDEXER_QUEUE
 from .features.conftest import app_settings, app as conf_app
+from .test_search import delay_rerun
 
-pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky]
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun)]
 
 # subset of collections to run test on
 TEST_COLLECTIONS = ['testing_post_put_patch', 'file_processed']

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -50,6 +50,7 @@ def teardown(app, use_collections=TEST_COLLECTIONS):
 
 
 @pytest.mark.slow
+@pytest.mark.flaky
 def test_indexing_simple(app, testapp, indexer_testapp):
     es = app.registry['elasticsearch']
     doc_count = es.count(index='testing_post_put_patch', doc_type='testing_post_put_patch').get('count')
@@ -92,6 +93,7 @@ def test_indexing_simple(app, testapp, indexer_testapp):
     assert testing_ppp_settings['settings']['index']['number_of_shards'] == '1'
 
 
+@pytest.mark.flaky
 def test_create_mapping_on_indexing(app, testapp, registry, elasticsearch):
     """
     Test overall create_mapping functionality using app.
@@ -142,6 +144,7 @@ def test_fp_uuid(testapp, award, experiment, lab, file_formats):
     return res.json['@graph'][0]['uuid']
 
 
+@pytest.mark.flaky
 def test_file_processed_detailed(app, testapp, indexer_testapp, test_fp_uuid,
                                  award, lab, file_formats):
     # Todo, input a list of accessions / uuids:
@@ -190,6 +193,7 @@ def test_file_processed_detailed(app, testapp, indexer_testapp, test_fp_uuid,
     assert found_rel_sid > found_fp_sid  # sid of related file is greater
 
 
+@pytest.mark.flaky
 def test_real_validation_error(app, indexer_testapp, testapp, lab, award, file_formats):
     """
     Create an item (file-processed) with a validation error and index,

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -126,6 +126,7 @@ def test_create_mapping_on_indexing(app, testapp, registry, elasticsearch):
         assert compare_against_existing_mapping(es, item_type, item_record, True)
 
 
+@pytest.fixture
 def test_fp_uuid(testapp, award, experiment, lab, file_formats):
     # this is a processed file
     item = {

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -10,7 +10,7 @@ from encoded.verifier import verify_item
 from snovault.elasticsearch.interfaces import INDEXER_QUEUE
 from .features.conftest import app_settings, app as conf_app
 
-pytestmark = [pytest.mark.working, pytest.mark.indexing]
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky]
 
 # subset of collections to run test on
 TEST_COLLECTIONS = ['testing_post_put_patch', 'file_processed']
@@ -50,7 +50,6 @@ def teardown(app, use_collections=TEST_COLLECTIONS):
 
 
 @pytest.mark.slow
-@pytest.mark.flaky
 def test_indexing_simple(app, testapp, indexer_testapp):
     es = app.registry['elasticsearch']
     doc_count = es.count(index='testing_post_put_patch', doc_type='testing_post_put_patch').get('count')
@@ -93,7 +92,6 @@ def test_indexing_simple(app, testapp, indexer_testapp):
     assert testing_ppp_settings['settings']['index']['number_of_shards'] == '1'
 
 
-@pytest.mark.flaky
 def test_create_mapping_on_indexing(app, testapp, registry, elasticsearch):
     """
     Test overall create_mapping functionality using app.
@@ -128,7 +126,6 @@ def test_create_mapping_on_indexing(app, testapp, registry, elasticsearch):
         assert compare_against_existing_mapping(es, item_type, item_record, True)
 
 
-@pytest.fixture
 def test_fp_uuid(testapp, award, experiment, lab, file_formats):
     # this is a processed file
     item = {
@@ -144,7 +141,6 @@ def test_fp_uuid(testapp, award, experiment, lab, file_formats):
     return res.json['@graph'][0]['uuid']
 
 
-@pytest.mark.flaky
 def test_file_processed_detailed(app, testapp, indexer_testapp, test_fp_uuid,
                                  award, lab, file_formats):
     # Todo, input a list of accessions / uuids:
@@ -193,7 +189,6 @@ def test_file_processed_detailed(app, testapp, indexer_testapp, test_fp_uuid,
     assert found_rel_sid > found_fp_sid  # sid of related file is greater
 
 
-@pytest.mark.flaky
 def test_real_validation_error(app, indexer_testapp, testapp, lab, award, file_formats):
     """
     Create an item (file-processed) with a validation error and index,

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -160,6 +160,7 @@ def test_search_embedded_file_by_accession(workbook, testapp):
         assert '46e82a90-49e5-4c33-afab-9ec90d65faa0' in file_uuids
 
 
+@pytest.mark.fixture
 def mboI_dts(testapp, workbook):
     # returns a dictionary of strings of various date and datetimes
     # relative to the creation date of the mboI one object in test inserts

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -27,6 +27,7 @@ def recursively_find_uuids(json, uuids):
     return uuids
 
 
+@pytest.mark.flaky
 def test_search_view(workbook, testapp):
     res = testapp.get('/search/?type=Item').json
     assert res['@type'] == ['Search']
@@ -40,6 +41,7 @@ def test_search_view(workbook, testapp):
     assert '@graph' in res
 
 
+@pytest.mark.flaky
 def test_search_with_no_query(workbook, testapp):
     # using /search/ (with no query) should default to /search/?type=Item
     # thus, should satisfy same assertions as test_search_view
@@ -59,6 +61,7 @@ def test_search_with_no_query(workbook, testapp):
     assert '@graph' in res
 
 
+@pytest.mark.flaky
 def test_collections_redirect_to_search(workbook, testapp):
     # we removed the collections page and redirect to search of that type
     # redirected_from is not used for search
@@ -75,6 +78,7 @@ def test_collections_redirect_to_search(workbook, testapp):
     assert '@graph' in res
 
 
+@pytest.mark.flaky
 def test_search_with_embedding(workbook, testapp):
     res = testapp.get('/search/?type=Biosample&limit=all').json
     # Use a specific biosample, found by accession from test data
@@ -96,6 +100,7 @@ def test_search_with_embedding(workbook, testapp):
     assert test_json['lab'].get('awards') is None
 
 
+@pytest.mark.flaky
 def test_search_with_simple_query(workbook, testapp):
     # run a simple query with type=Organism and q=mouse
     res = testapp.get('/search/?type=Organism&q=mouse').json
@@ -129,6 +134,7 @@ def test_search_with_simple_query(workbook, testapp):
     assert not set(mouse_uuids).issubset(set(mauxz_uuids))
 
 
+@pytest.mark.flaky
 def test_search_facets_and_columns_order(workbook, testapp, registry):
     # TODO: Adjust ordering of mixed-in facets, perhaps sort by lookup or something, in order to un-xfail.
     test_type = 'experiment_set_replicate'
@@ -149,6 +155,7 @@ def test_search_facets_and_columns_order(workbook, testapp, registry):
         assert res['columns'][key]['title'] == val['title']
 
 
+@pytest.mark.flaky
 def test_search_embedded_file_by_accession(workbook, testapp):
     res = testapp.get('/search/?type=ExperimentHiC&files.accession=4DNFIO67APU1').json
     assert len(res['@graph']) > 0
@@ -185,6 +192,7 @@ def mboI_dts(testapp, workbook):
     }
 
 
+@pytest.mark.flaky
 def test_search_date_range_find_within(mboI_dts, testapp, workbook):
     # the MboI enzyme should be returned with all the provided pairs
     gres = testapp.get('/search/?type=Enzyme&name=MboI').json
@@ -205,6 +213,7 @@ def test_search_date_range_find_within(mboI_dts, testapp, workbook):
         assert set(g_uuids).issubset(set(s_uuids))
 
 
+@pytest.mark.flaky
 def test_search_with_nested_integer(testapp, workbook):
     search0 = '/search/?type=ExperimentHiC'
     s0res = testapp.get(search0).json
@@ -225,7 +234,7 @@ def test_search_with_nested_integer(testapp, workbook):
     assert set(s1_uuids) | set(s2_uuids) == set(s0_uuids)
 
 
-
+@pytest.mark.flaky
 def test_search_date_range_dontfind_without(mboI_dts, testapp, workbook):
     # the MboI enzyme should be returned with all the provided pairs
     dts = {k: v.replace(':', '%3A') for k, v in mboI_dts.items()}
@@ -239,12 +248,14 @@ def test_search_date_range_dontfind_without(mboI_dts, testapp, workbook):
         assert testapp.get(search, status=404)
 
 
+@pytest.mark.flaky
 def test_search_query_string_AND_NOT_cancel_out(workbook, testapp):
     # if you use + and - with same field you should get no result
     search = '/search/?q=cell+-cell&type=Biosource'
     assert testapp.get(search, status=404)
 
 
+@pytest.mark.flaky
 def test_search_query_string_with_booleans(workbook, testapp):
     """
     moved references to res_not_induced and not_induced_uuids,
@@ -277,6 +288,7 @@ def test_search_query_string_with_booleans(workbook, testapp):
     assert swag_bios not in not_uuids
 
 
+@pytest.mark.flaky
 def test_metadata_tsv_view(workbook, htmltestapp):
 
     FILE_ACCESSION_COL_INDEX = 3
@@ -344,6 +356,7 @@ def test_metadata_tsv_view(workbook, htmltestapp):
     check_tsv(result_rows, len(res2_post_data['accession_triples']))
 
 
+@pytest.mark.flaky
 def test_default_schema_and_non_schema_facets(workbook, testapp, registry):
     from snovault import TYPES
     from snovault.util import add_default_embeds
@@ -365,6 +378,7 @@ def test_default_schema_and_non_schema_facets(workbook, testapp, registry):
     assert 'biosource.biosource_type' in facet_fields
 
 
+@pytest.mark.flaky
 def test_search_query_string_no_longer_functional(workbook, testapp):
     # since we now use simple_query_string, cannot use field:value or range
     # expect 404s, since simple_query_string doesn't return exceptions
@@ -377,6 +391,7 @@ def test_search_query_string_no_longer_functional(workbook, testapp):
     assert len(res_search.json['@graph']) == 0
 
 
+@pytest.mark.flaky
 def test_search_with_added_display_title(workbook, testapp, registry):
     # 4DNBS1234567 is display_title for biosample
     search = '/search/?type=ExperimentHiC&biosample=4DNBS1234567'
@@ -407,6 +422,7 @@ def test_search_with_added_display_title(workbook, testapp, registry):
     assert added_ff_facet[0]['title'] == ff_title + ' (Title)'
 
 
+@pytest.mark.flaky
 def test_search_with_no_value(workbook, testapp):
     search = '/search/?description=No+value&description=GM12878+prepared+for+HiC&type=Biosample'
     res_json = testapp.get(search).json
@@ -430,11 +446,13 @@ def test_search_with_no_value(workbook, testapp):
 
 from .test_views import TYPE_LENGTH
 
+@pytest.mark.flaky
 def test_collection_limit(workbook, testapp):
     res = testapp.get('/biosamples/?limit=2', status=301)
     assert len(res.follow().json['@graph']) == 2
 
 
+@pytest.mark.flaky
 def test_collection_actions_filtered_by_permission(workbook, testapp, anontestapp):
     res = testapp.get('/biosamples/')
     assert any(action for action in res.follow().json.get('actions', []) if action['name'] == 'add')
@@ -444,6 +462,7 @@ def test_collection_actions_filtered_by_permission(workbook, testapp, anontestap
     assert len(res.json['@graph']) == 0
 
 
+@pytest.mark.flaky
 def test_index_data_workbook(app, workbook, testapp, indexer_testapp, htmltestapp):
     from snovault.elasticsearch import create_mapping
     es = app.registry['elasticsearch']
@@ -498,6 +517,7 @@ def test_index_data_workbook(app, workbook, testapp, indexer_testapp, htmltestap
 ######################################
 
 
+@pytest.mark.flaky
 def test_barplot_aggregation_endpoint(workbook, testapp):
 
     # Check what we get back -

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -5,8 +5,14 @@ from encoded.commands.run_upgrader_on_inserts import get_inserts
 import json
 import time
 from snovault import TYPES
-pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing, pytest.mark.flaky]
 
+def delay_rerun(*args):
+    """ Rerun function for flaky """
+    time.sleep(90)
+    return True
+
+
+pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun)]
 
 ### IMPORTANT
 # uses the inserts in ./data/workbook_inserts

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -160,7 +160,7 @@ def test_search_embedded_file_by_accession(workbook, testapp):
         assert '46e82a90-49e5-4c33-afab-9ec90d65faa0' in file_uuids
 
 
-@pytest.mark.fixture
+@pytest.fixture
 def mboI_dts(testapp, workbook):
     # returns a dictionary of strings of various date and datetimes
     # relative to the creation date of the mboI one object in test inserts

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -5,7 +5,7 @@ from encoded.commands.run_upgrader_on_inserts import get_inserts
 import json
 import time
 from snovault import TYPES
-pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing]
+pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing, pytest.mark.flaky]
 
 
 ### IMPORTANT
@@ -27,7 +27,6 @@ def recursively_find_uuids(json, uuids):
     return uuids
 
 
-@pytest.mark.flaky
 def test_search_view(workbook, testapp):
     res = testapp.get('/search/?type=Item').json
     assert res['@type'] == ['Search']
@@ -41,7 +40,6 @@ def test_search_view(workbook, testapp):
     assert '@graph' in res
 
 
-@pytest.mark.flaky
 def test_search_with_no_query(workbook, testapp):
     # using /search/ (with no query) should default to /search/?type=Item
     # thus, should satisfy same assertions as test_search_view
@@ -61,7 +59,6 @@ def test_search_with_no_query(workbook, testapp):
     assert '@graph' in res
 
 
-@pytest.mark.flaky
 def test_collections_redirect_to_search(workbook, testapp):
     # we removed the collections page and redirect to search of that type
     # redirected_from is not used for search
@@ -78,7 +75,6 @@ def test_collections_redirect_to_search(workbook, testapp):
     assert '@graph' in res
 
 
-@pytest.mark.flaky
 def test_search_with_embedding(workbook, testapp):
     res = testapp.get('/search/?type=Biosample&limit=all').json
     # Use a specific biosample, found by accession from test data
@@ -100,7 +96,6 @@ def test_search_with_embedding(workbook, testapp):
     assert test_json['lab'].get('awards') is None
 
 
-@pytest.mark.flaky
 def test_search_with_simple_query(workbook, testapp):
     # run a simple query with type=Organism and q=mouse
     res = testapp.get('/search/?type=Organism&q=mouse').json
@@ -134,7 +129,6 @@ def test_search_with_simple_query(workbook, testapp):
     assert not set(mouse_uuids).issubset(set(mauxz_uuids))
 
 
-@pytest.mark.flaky
 def test_search_facets_and_columns_order(workbook, testapp, registry):
     # TODO: Adjust ordering of mixed-in facets, perhaps sort by lookup or something, in order to un-xfail.
     test_type = 'experiment_set_replicate'
@@ -155,7 +149,6 @@ def test_search_facets_and_columns_order(workbook, testapp, registry):
         assert res['columns'][key]['title'] == val['title']
 
 
-@pytest.mark.flaky
 def test_search_embedded_file_by_accession(workbook, testapp):
     res = testapp.get('/search/?type=ExperimentHiC&files.accession=4DNFIO67APU1').json
     assert len(res['@graph']) > 0
@@ -167,7 +160,6 @@ def test_search_embedded_file_by_accession(workbook, testapp):
         assert '46e82a90-49e5-4c33-afab-9ec90d65faa0' in file_uuids
 
 
-@pytest.fixture
 def mboI_dts(testapp, workbook):
     # returns a dictionary of strings of various date and datetimes
     # relative to the creation date of the mboI one object in test inserts
@@ -192,7 +184,6 @@ def mboI_dts(testapp, workbook):
     }
 
 
-@pytest.mark.flaky
 def test_search_date_range_find_within(mboI_dts, testapp, workbook):
     # the MboI enzyme should be returned with all the provided pairs
     gres = testapp.get('/search/?type=Enzyme&name=MboI').json
@@ -213,7 +204,6 @@ def test_search_date_range_find_within(mboI_dts, testapp, workbook):
         assert set(g_uuids).issubset(set(s_uuids))
 
 
-@pytest.mark.flaky
 def test_search_with_nested_integer(testapp, workbook):
     search0 = '/search/?type=ExperimentHiC'
     s0res = testapp.get(search0).json
@@ -234,7 +224,6 @@ def test_search_with_nested_integer(testapp, workbook):
     assert set(s1_uuids) | set(s2_uuids) == set(s0_uuids)
 
 
-@pytest.mark.flaky
 def test_search_date_range_dontfind_without(mboI_dts, testapp, workbook):
     # the MboI enzyme should be returned with all the provided pairs
     dts = {k: v.replace(':', '%3A') for k, v in mboI_dts.items()}
@@ -248,14 +237,12 @@ def test_search_date_range_dontfind_without(mboI_dts, testapp, workbook):
         assert testapp.get(search, status=404)
 
 
-@pytest.mark.flaky
 def test_search_query_string_AND_NOT_cancel_out(workbook, testapp):
     # if you use + and - with same field you should get no result
     search = '/search/?q=cell+-cell&type=Biosource'
     assert testapp.get(search, status=404)
 
 
-@pytest.mark.flaky
 def test_search_query_string_with_booleans(workbook, testapp):
     """
     moved references to res_not_induced and not_induced_uuids,
@@ -288,7 +275,6 @@ def test_search_query_string_with_booleans(workbook, testapp):
     assert swag_bios not in not_uuids
 
 
-@pytest.mark.flaky
 def test_metadata_tsv_view(workbook, htmltestapp):
 
     FILE_ACCESSION_COL_INDEX = 3
@@ -356,7 +342,6 @@ def test_metadata_tsv_view(workbook, htmltestapp):
     check_tsv(result_rows, len(res2_post_data['accession_triples']))
 
 
-@pytest.mark.flaky
 def test_default_schema_and_non_schema_facets(workbook, testapp, registry):
     from snovault import TYPES
     from snovault.util import add_default_embeds
@@ -378,7 +363,6 @@ def test_default_schema_and_non_schema_facets(workbook, testapp, registry):
     assert 'biosource.biosource_type' in facet_fields
 
 
-@pytest.mark.flaky
 def test_search_query_string_no_longer_functional(workbook, testapp):
     # since we now use simple_query_string, cannot use field:value or range
     # expect 404s, since simple_query_string doesn't return exceptions
@@ -391,7 +375,6 @@ def test_search_query_string_no_longer_functional(workbook, testapp):
     assert len(res_search.json['@graph']) == 0
 
 
-@pytest.mark.flaky
 def test_search_with_added_display_title(workbook, testapp, registry):
     # 4DNBS1234567 is display_title for biosample
     search = '/search/?type=ExperimentHiC&biosample=4DNBS1234567'
@@ -422,7 +405,6 @@ def test_search_with_added_display_title(workbook, testapp, registry):
     assert added_ff_facet[0]['title'] == ff_title + ' (Title)'
 
 
-@pytest.mark.flaky
 def test_search_with_no_value(workbook, testapp):
     search = '/search/?description=No+value&description=GM12878+prepared+for+HiC&type=Biosample'
     res_json = testapp.get(search).json
@@ -446,13 +428,11 @@ def test_search_with_no_value(workbook, testapp):
 
 from .test_views import TYPE_LENGTH
 
-@pytest.mark.flaky
 def test_collection_limit(workbook, testapp):
     res = testapp.get('/biosamples/?limit=2', status=301)
     assert len(res.follow().json['@graph']) == 2
 
 
-@pytest.mark.flaky
 def test_collection_actions_filtered_by_permission(workbook, testapp, anontestapp):
     res = testapp.get('/biosamples/')
     assert any(action for action in res.follow().json.get('actions', []) if action['name'] == 'add')
@@ -462,7 +442,6 @@ def test_collection_actions_filtered_by_permission(workbook, testapp, anontestap
     assert len(res.json['@graph']) == 0
 
 
-@pytest.mark.flaky
 def test_index_data_workbook(app, workbook, testapp, indexer_testapp, htmltestapp):
     from snovault.elasticsearch import create_mapping
     es = app.registry['elasticsearch']
@@ -517,7 +496,6 @@ def test_index_data_workbook(app, workbook, testapp, indexer_testapp, htmltestap
 ######################################
 
 
-@pytest.mark.flaky
 def test_barplot_aggregation_endpoint(workbook, testapp):
 
     # Check what we get back -

--- a/src/encoded/tests/test_static_page.py
+++ b/src/encoded/tests/test_static_page.py
@@ -2,8 +2,9 @@ import pytest
 import time
 from .features.conftest import app_settings, app, teardown
 from webtest import AppError
+from .test_search import delay_rerun
 
-pytestmark = [pytest.mark.indexing, pytest.mark.working, pytest.mark.flaky]
+pytestmark = [pytest.mark.indexing, pytest.mark.working, pytest.mark.flaky(rerun_filter=delay_rerun)]
 
 
 @pytest.fixture(scope='module')

--- a/src/encoded/tests/test_static_page.py
+++ b/src/encoded/tests/test_static_page.py
@@ -3,7 +3,7 @@ import time
 from .features.conftest import app_settings, app, teardown
 from webtest import AppError
 
-pytestmark = [pytest.mark.indexing, pytest.mark.working]
+pytestmark = [pytest.mark.indexing, pytest.mark.working, pytest.mark.flaky]
 
 
 @pytest.fixture(scope='module')

--- a/src/encoded/tests/test_validation_errors.py
+++ b/src/encoded/tests/test_validation_errors.py
@@ -1,6 +1,7 @@
 import pytest
 from .features.conftest import app_settings, workbook
-pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky]
+from .test_search import delay_rerun
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun)]
 
 def test_validation_err_facet(workbook, testapp):
     res = testapp.get('/search/?type=ExperimentSetReplicate').json

--- a/src/encoded/tests/test_validation_errors.py
+++ b/src/encoded/tests/test_validation_errors.py
@@ -1,6 +1,6 @@
 import pytest
 from .features.conftest import app_settings, workbook
-pytestmark = [pytest.mark.working, pytest.mark.indexing]
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky]
 
 def test_validation_err_facet(workbook, testapp):
     res = testapp.get('/search/?type=ExperimentSetReplicate').json


### PR DESCRIPTION
- Adds flaky to setup.py

- Adds flaky flag to all tests that are marked as indexing tests, as these can experience intermittent failures. It's likely we are being overly generous with this tag but its cleaner to just mark them all rather than individually.

- Adds flaky flag with delay to search tests that require a timeout to properly re-run in the presence of intermittent failure.