### PR TITLE
fix: allow any logged-in user to view access keys

### DIFF
--- a/src/encoded/static/components/item-pages/UserView.js
+++ b/src/encoded/static/components/item-pages/UserView.js
@@ -435,7 +435,7 @@ export default class UserView extends React.Component {
 
                     </div>
 
-                    { lab || submits_for ? <SyncedAccessKeyTable user={user} access_keys={access_keys} /> : null }
+                    <SyncedAccessKeyTable user={user} access_keys={access_keys} />
 
                 </div>
             </div>


### PR DESCRIPTION
**Problem:** make access keys visible to user even if they don't have a lab. (@burakalver )

**Solution:** Minor fix: Logged-in user's either `lab` or `submits_for` field is required to view Access Keys section. This requirement is removed.

<img width="1260" alt="Screen Shot 2019-09-03 at 21 43 10" src="https://user-images.githubusercontent.com/49978017/64201159-a9298e80-ce96-11e9-8426-75a7121e5f55.png">

