### PR TITLE
schemas/higlass_view_config.json updated

### DIFF
--- a/src/encoded/schemas/higlass_view_config.json
+++ b/src/encoded/schemas/higlass_view_config.json
@@ -177,7 +177,7 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["name", "server", "tilesetUid"],
+                                            "required" : ["server", "tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
                                                 "name" : {
@@ -291,7 +291,7 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["name", "server", "tilesetUid"],
+                                            "required" : ["server", "tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
                                                 "name" : {
@@ -405,7 +405,7 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["name", "server", "tilesetUid"],
+                                            "required" : ["server", "tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
                                                 "name" : {
@@ -519,7 +519,7 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["name", "server", "tilesetUid"],
+                                            "required" : ["server", "tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
                                                 "name" : {


### PR DESCRIPTION
**Problem:**  In staging, on HiGlass pages, the save and clone buttons are giving an `HTTP 422 Unprocessable Entity` exception, since viewConfig schema validation fails due to an update of HiGlass viewConfig. (some fields are not required anymore, see the validation report below)

**Minor Fix:** schema's `track.[top/right/bottom/left].items.name` required rule is removed.

**Validation Report:**
![HiGlass ViewConfig vs Schema Validation Error](https://user-images.githubusercontent.com/49978017/64255168-809ea480-cf29-11e9-826d-3acf41b8aa05.png)

**After Fix:**
![After Schema Update](https://user-images.githubusercontent.com/49978017/64256505-4aaeef80-cf2c-11e9-920e-c6974efcd647.png)
