### PR TITLE
Tune flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
 - if test -n "$NPM"; then bin/test -v -v --aws-auth -m "not performance and not indexing and working" --durations=10
   --cov src/encoded --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
   fi
-- if test -n "$UNIT"; then travis_wait bin/test -v -v --aws-auth -m "not performance and indexing and working" --durations=10
+- if test -n "$UNIT"; then travis_wait 30 bin/test -v -v --aws-auth -m "not performance and indexing and working" --durations=10
   --cov src/encoded --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
   fi
 - if test -n "$CYPRESS"; then travis_wait 30 deploy/run_cypress_tests_on_travis.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
 - if test -n "$NPM"; then bin/test -v -v --aws-auth -m "not performance and not indexing and working" --durations=10
   --cov src/encoded --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
   fi
-- if test -n "$UNIT"; then bin/test -v -v --aws-auth -m "not performance and indexing and working" --durations=10
+- if test -n "$UNIT"; then travis_wait bin/test -v -v --aws-auth -m "not performance and indexing and working" --durations=10
   --cov src/encoded --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80;
   fi
 - if test -n "$CYPRESS"; then travis_wait 30 deploy/run_cypress_tests_on_travis.sh;

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -11,7 +11,7 @@ from snovault.elasticsearch.interfaces import INDEXER_QUEUE
 from .features.conftest import app_settings, app as conf_app
 from .test_search import delay_rerun
 
-pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun)]
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun, max_retries=3)]
 
 # subset of collections to run test on
 TEST_COLLECTIONS = ['testing_post_put_patch', 'file_processed']

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -11,7 +11,7 @@ from snovault.elasticsearch.interfaces import INDEXER_QUEUE
 from .features.conftest import app_settings, app as conf_app
 from .test_search import delay_rerun
 
-pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun, max_retries=3)]
+pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun, max_runs=3)]
 
 # subset of collections to run test on
 TEST_COLLECTIONS = ['testing_post_put_patch', 'file_processed']

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -8,7 +8,7 @@ from snovault import TYPES
 
 def delay_rerun(*args):
     """ Rerun function for flaky """
-    time.sleep(90)
+    time.sleep(120)
     return True
 
 


### PR DESCRIPTION
- Up test timeout from 90 seconds to 120 seconds
- Set max_runs for indexing tests to 3
- Make test_real_validation_error more robust