### PR TITLE
Fix of Some Cypress Tests

### DIFF
--- a/deploy/post_deploy_testing/cypress/integration/01c_static_content_joint_analysis.js
+++ b/deploy/post_deploy_testing/cypress/integration/01c_static_content_joint_analysis.js
@@ -120,7 +120,7 @@ describe('Joint Analysis Page', function () {
 
         it("HiGlass initializes (very basic)", function(){
             cy.window().scrollTo('bottom').end()
-                .wait(2000).end().get('div.CenterTrack-module_center-track-3ptRW', { 'timeout' : (10 * 60 * 1000) }).wait(500);
+                .wait(2000).end().get('div.tiled-plot-div div.track-renderer-div div.center-track-container', { 'timeout' : (10 * 60 * 1000) }).wait(500);
         });
 
     });

--- a/deploy/post_deploy_testing/cypress/integration/03d_browse_views_files_selection.js
+++ b/deploy/post_deploy_testing/cypress/integration/03d_browse_views_files_selection.js
@@ -46,7 +46,7 @@ describe('Browse Views - Files Selection', function () {
                 .get('.search-headers-row .search-headers-column-block[data-field="date_created"] .column-sort-icon')
                 .should('have.class', 'active')
                 .within(()=>{
-                    cy.get('i').should('have.class', 'icon-sort-desc');
+                    cy.get('i').should('have.class', 'icon-sort-down');
                 }).end()
                 // Close columns panel
                 .get('#content div.above-results-table-row div.right-buttons button.btn[data-tip="Configure visible columns"]').click().end();
@@ -76,7 +76,7 @@ describe('Browse Views - Files Selection', function () {
                 .click({ 'force' : true })
                 .should('have.class', 'active').end()
                 .get('.search-headers-row .search-headers-column-block[data-field="date_created"] .column-sort-icon i')
-                .should('have.class', 'icon-sort-asc').end();
+                .should('have.class', 'icon-sort-up').end();
         });
 
         it('"Select All Files" button works & becomes "Deselect All" after.', function(){

--- a/deploy/post_deploy_testing/cypress/integration/05b_item_pages_file_processed.js
+++ b/deploy/post_deploy_testing/cypress/integration/05b_item_pages_file_processed.js
@@ -23,7 +23,7 @@ describe("Individual Item Views", function(){
                 .get('.search-headers-row .search-headers-column-block[data-field="date_created"] .column-sort-icon')
                 .should('have.class', 'active')
                 .within(()=>{
-                    cy.get('i').should('have.class', 'icon-sort-desc');
+                    cy.get('i').should('have.class', 'icon-sort-down');
                 });
         });
 


### PR DESCRIPTION
**HiGlass initializes (very basic)** section of `/cypress/integration/01c_static_content_joint_analysis.js` updated. Broken css query rule fixed due to higlass update as @alexkb0009 remarked.

**03d_browse_views_files_selection.js** rules fixed:
`icon-sort-desc` changed as `icon-sort-down`
`icon-sort-asc` changed as `icon-sort-up`

**05b_item_pages_file_processed.js** rules fixed:
`icon-sort-desc` changed as `icon-sort-down`

<img width="1381" alt="Screen Shot 2019-09-24 at 17 23 04" src="https://user-images.githubusercontent.com/49978017/65520442-3db06b00-def0-11e9-874c-a5ffc4d56cd1.png">

<img width="1669" alt="Screen Shot 2019-09-24 at 18 24 32" src="https://user-images.githubusercontent.com/49978017/65525706-9edc3c80-def8-11e9-81eb-6f895fc2f79c.png">
