### PR TITLE
Higlass Display View Height

### DIFF
--- a/src/encoded/schemas/higlass_view_config.json
+++ b/src/encoded/schemas/higlass_view_config.json
@@ -704,6 +704,10 @@
                     }
                 }
             }
+        },
+        "instance_height": {
+            "type": "integer",
+            "default": 500
         }
     },
     "facets" : {

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -647,7 +647,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
     }
 
     render(){
-        const { isFullscreen, windowWidth, windowHeight, width, session } = this.props;
+        const { context, isFullscreen, windowWidth, windowHeight, width, session } = this.props;
         const { addFileLoading, genome_assembly, viewConfig, modal } = this.state;
 
         const hiGlassComponentWidth = isFullscreen ? windowWidth : width + 20;
@@ -659,7 +659,11 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             hiGlassComponentHeight = windowHeight - 120;
         }
         else {
-            hiGlassComponentHeight = 600;
+            if (context && context.instance_height && context.instance_height > 0) {
+                hiGlassComponentHeight = context.instance_height;
+            } else {
+                hiGlassComponentHeight = 600;
+            }
         }
 
         // If the user isn't logged in, add a tooltip reminding them to log in.

--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
@@ -122,8 +122,13 @@ export class HiGlassAjaxLoadContainer extends React.PureComponent {
         });
     }
     render(){
-        var { higlassItem, loading } = this.state;
-        var { height } = this.props;
+        const { higlassItem, loading } = this.state;
+        let { height } = this.props;
+
+        //if height not defined by container then use instance defined value
+        if (!height && higlassItem && higlassItem.instance_height && higlassItem.instance_height > 0) {
+            height = higlassItem.instance_height;
+        }
 
         // Use the height to make placeholder message when loading.
         var placeholderStyle = { "height" : height || 600 };
@@ -148,6 +153,6 @@ export class HiGlassAjaxLoadContainer extends React.PureComponent {
         // Scale the higlass config so it fits the given container.
         const adjustedViewconfig = HiGlassAjaxLoadContainer.scaleViewconfToHeight(higlassItem.viewconfig, height);
         // Pass the viewconfig to the HiGlassPlainContainer
-        return <HiGlassPlainContainer {..._.omit(this.props, 'higlassItem')} viewConfig={adjustedViewconfig} ref={this.containerRef}/>;
+        return <HiGlassPlainContainer {..._.omit(this.props, 'higlassItem', 'height')} viewConfig={adjustedViewconfig} ref={this.containerRef} height={height} />;
     }
 }

--- a/src/encoded/static/components/static-pages/StaticPage.js
+++ b/src/encoded/static/components/static-pages/StaticPage.js
@@ -50,11 +50,16 @@ export const parseSectionsContent = memoize(function(context){
         } else if (Array.isArray(section['@type']) && section['@type'].indexOf('HiglassViewConfig') > -1){
             // HiglassViewConfig Parsing
             if (!section.viewconfig) throw new Error('No viewconfig setup for this section.');
+            let hiGlassComponentHeight;
+            if (section.instance_height && section.instance_height > 0) {
+                hiGlassComponentHeight = section.instance_height;
+            }
+
             section =  _.extend({}, section, {
                 'content' : (
                     <React.Fragment>
                         <EmbeddedHiglassActions context={section} style={{ marginTop : -10 }} />
-                        <HiGlassPlainContainer viewConfig={section.viewconfig} mountDelay={4000} />
+                        <HiGlassPlainContainer viewConfig={section.viewconfig} mountDelay={4000} height={hiGlassComponentHeight} />
                     </React.Fragment>
                 )
             });


### PR DESCRIPTION
**Problem**: Both HiglassViewConfigView and static/embedded pages initiate the Higlass instance height by hard-coded default prop value. (600 px and 500px respectively)

**Solution**: a new `instance_height` property is introducted in `schemas/higlass_view_config.json` to obtain height from context.