### PR TITLE
ExpSet Tab View's Ajax Query Fixed to Include External Data

### DIFF
--- a/src/encoded/static/components/item-pages/BiosampleView.js
+++ b/src/encoded/static/components/item-pages/BiosampleView.js
@@ -25,7 +25,7 @@ export default class BiosampleView extends DefaultItemView {
             ...this.props,
             'requestHref' : (
                 "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate&" +
-                (browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
+                //(browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
                 "experiments_in_set.biosample.display_title=" + context.display_title
             ),
             'title' : function(props, { totalCount }){

--- a/src/encoded/static/components/item-pages/BiosourceView.js
+++ b/src/encoded/static/components/item-pages/BiosourceView.js
@@ -21,7 +21,7 @@ export default class BiosourceView extends DefaultItemView {
         initTabs.push(ExperimentSetTableTabView.getTabObject(_.extend({}, this.props, {
             'requestHref' : (
                 "/search/?type=ExperimentSetReplicate&experimentset_type=replicate&" +
-                (browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
+                //(browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
                 "experiments_in_set.biosample.biosource.display_title=" + encodeURIComponent(context.display_title)
             ),
             'title' : function(props, { totalCount }){

--- a/src/encoded/static/components/item-pages/ExperimentTypeView.js
+++ b/src/encoded/static/components/item-pages/ExperimentTypeView.js
@@ -22,7 +22,7 @@ export default class ExperimentTypeView extends DefaultItemView {
         const expSetTableProps = _.extend({}, this.props, {
             'requestHref' : (
                 "/search/?type=ExperimentSetReplicate&experimentset_type=replicate&" +
-                (browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
+                //(browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
                 "experiments_in_set.experiment_type.display_title=" + encodeURIComponent(context.display_title)
             ),
             'title' : function(props, { totalCount }){

--- a/src/encoded/static/components/item-pages/FileView.js
+++ b/src/encoded/static/components/item-pages/FileView.js
@@ -63,7 +63,7 @@ export default class FileView extends WorkflowRunTracingView {
                 ...this.props,
                 'requestHref': (
                     "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate&" +
-                    (browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
+                    //(browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
                     "experiments_in_set.reference_files.accession=" + context.accession
                 ),
                 'title': function (props, { totalCount }) {

--- a/src/encoded/static/components/item-pages/PublicationView.js
+++ b/src/encoded/static/components/item-pages/PublicationView.js
@@ -25,7 +25,7 @@ export default class PublicationView extends DefaultItemView {
             const expSetTableProps = _.extend({}, this.props, {
                 'requestHref' : (
                     "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate&sort=experiments_in_set.experiment_type.display_title&" +
-                    (browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
+                    //(browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
                     "publications_of_set.display_title=" + context.display_title
                 )
             });

--- a/src/encoded/static/components/item-pages/PublicationView.js
+++ b/src/encoded/static/components/item-pages/PublicationView.js
@@ -26,7 +26,7 @@ export default class PublicationView extends DefaultItemView {
                 'requestHref' : (
                     "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate&sort=experiments_in_set.experiment_type.display_title&" +
                     //(browseBaseState === "only_4dn" ? "award.project=4DN&" : "") +
-                    "publications_of_set.display_title=" + context.display_title
+                    "publications_of_set.display_title=" + encodeURIComponent(context.display_title)
                 )
             });
             tabs.push(ExperimentSetTableTabView.getTabObject(expSetTableProps, width));


### PR DESCRIPTION
ExpSet tab view content is loaded via an ajax query. But recent query is not including external data in search result. It is fixed by removing `(browseBaseState === "only_4dn" ? "award.project=4DN&" : "")` from query.