### PR TITLE
Higlass Edit View Config Problem Fixed

### DIFF
--- a/src/encoded/static/scss/encoded/modules/_item-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_item-pages.scss
@@ -1996,6 +1996,12 @@ $badge-item-min-height: 90px;
 			}
 		}
 
+		div[class^="ViewConfigEditor-module_view-config-editor-"] {
+			textarea, pre, pre span {
+				font-family: $font-family-monospace !important;
+			}
+		}
+
 		.glyphicon.glyphicon-search {
 			&:before {
 				content : "\f002";


### PR DESCRIPTION
**Problem:** Higlass edit view config is displayed as a modal popup on higlass instance to edit configuration on the fly. But a css problem prevents to locate the cursor on the line and select/edit it.

**Solution:** Higlass edit view config's editor is rendered as `pre` control over a `textarea`. `Textarea`'s font is transparent, and `pre`'s text is overlapping on `textarea`. `Pre`'s inner html is used to format text, on the other hand `textarea`'s text is for edit. This works as is in **higlass.io** page, but a css reset problem hinders it on FF. (`textarea` and `pre`'s `font-family` is `Fira Code` but `pre > span` is `Mada`.) This difference results in formatting and editing lines not overlapping. Css rule added to fix this problem.

<img width="1155" alt="Screen Shot 2019-10-18 at 21 59 08" src="https://user-images.githubusercontent.com/49978017/67120728-8c50dc80-f1f2-11e9-8737-3313cbfc4893.png">