### PR TITLE
Go exempt inserts

### DIFF
--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -408,7 +408,12 @@ def get_existing_ontology_terms(connection):  # , ontologies=None):
     '''
     search_suffix = 'search/?type=OntologyTerm&status=released&status=obsolete'  # + ont_list
     db_terms = search_metadata(search_suffix, connection, page_limit=200, is_generator=True)
-    return {t['term_id']: t for t in db_terms}
+    ignore = [
+        "111112bc-8535-4448-903e-854af460a233", "111113bc-8535-4448-903e-854af460a233",
+        "111114bc-8535-4448-903e-854af460a233", "111116bc-8535-4448-903e-854af460a233",
+        "111117bc-8535-4448-903e-854af460a233"
+    ]
+    return {t['term_id']: t for t in db_terms if t['uuid'] not in ignore}
 
 
 def get_ontologies(connection, ont_list):

--- a/src/encoded/tests/data/master-inserts/ontology_term.json
+++ b/src/encoded/tests/data/master-inserts/ontology_term.json
@@ -1,14 +1,5 @@
 [
     {
-        "uuid": "111111bc-8535-4448-903e-854af460a233",
-        "term_name": "alternative_term",
-        "term_id": "EFO:alternative_term",
-        "source_ontologies": ["540026bc-8535-4448-903e-854af460b254"],
-        "term_url": "http://www.ebi.ac.uk/efo/alternative_term",
-        "definition": "An alternative label for a given entity such as a commonly used abbreviation or synonym.",
-        "namespace": "http://www.ebi.ac.uk/efo"
-    },
-    {
         "uuid": "111112bc-8535-4448-903e-854af460a233",
         "term_name": "has_exact_synonym",
         "term_id": "oboInOwl:hasExactSynonym",
@@ -32,14 +23,6 @@
         "source_ontologies": ["540026bc-8535-4448-903e-854af460b254"],
         "term_url": "http://www.geneontology.org/formats/oboInOwl#RelatedSynonym",
         "namespace": "http://www.geneontology.org/formats/oboInOwl"
-    },
-    {
-        "uuid": "111115bc-8535-4448-903e-854af460a233",
-        "term_name": "definition",
-        "term_id": "EFO:definition",
-        "source_ontologies": ["540026bc-8535-4448-903e-854af460b254"],
-        "term_url": "http://www.ebi.ac.uk/efo/definition",
-        "namespace": "http://www.ebi.ac.uk/efo"
     },
     {
         "uuid": "111116bc-8535-4448-903e-854af460a233",


### PR DESCRIPTION
Fix for ontology_term inserts that were wrongly being marked as obsolete
- get_existing_ontology_terms now removes the 5 property uuids from dbterms to compare to
- outdated inserts removed