### PR TITLE
Fix: Higlass Height In Collapsible Section and Preserve Height If Cloned

### DIFF
--- a/src/encoded/schemas/higlass_view_config.json
+++ b/src/encoded/schemas/higlass_view_config.json
@@ -706,6 +706,7 @@
             }
         },
         "instance_height": {
+            "title": "Instance Height",
             "type": "integer",
             "default": 500
         }

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -326,6 +326,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
             'title'          : viewConfTitle,
             'description'    : viewConfDesc,
             'viewconfig'     : currentViewConf,
+            'instance_height': context.instance_height,
             // We don't include other properties and let them come from schema default values.
             // For example, default status is 'draft', which will be used.
             // Lab and award do not carry over as current user might be from different lab.

--- a/src/encoded/static/components/static-pages/components/BasicUserContentBody.js
+++ b/src/encoded/static/components/static-pages/components/BasicUserContentBody.js
@@ -131,7 +131,7 @@ export class ExpandableStaticHeader extends OverviewHeadingContainer {
 
         return (
             <div className="static-section-header pt-1 clearfix">
-                <BasicUserContentBody context={context} href={href} height={isHiGlass ? 300 : null} parentComponentType={ExpandableStaticHeader} />
+                <BasicUserContentBody context={context} href={href} parentComponentType={ExpandableStaticHeader} />
             </div>
         );
     }


### PR DESCRIPTION
- **Fix:** Embedded HiGlass display height overridden as 300px even if `instance_height` is defined explicitly when the component is collapsible.
- **Fix:** `HiGlassViewConfigView` page's clone button excludes `instance_height` of cloned item.
- Missing `instance_height`'s title added in `higlass_view_config.json`