### PR TITLE
Add "Tools" NavItem + slide in SearchBar from right (desktop)

### DIFF
--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -79,14 +79,14 @@ function DataNavItem(props){
         // Figure out if any items are active
         const { query = {}, pathname = "/a/b/c/d/e" } = memoizedUrlParse(href);
         const browseHref = navigate.getBrowseBaseHref(browseBaseState);
-        const seqencingDataHref = browseHref + "&experiments_in_set.experiment_type.experiment_category=Sequencing";
+        const sequencingDataHref = browseHref + "&experiments_in_set.experiment_type.experiment_category=Sequencing";
         const microscopyDataHref = "/microscopy-data-overview";
         const isMicroscopyActive = pathname === microscopyDataHref;
         let isBrowseActive = pathname === "/browse/";
         let isSequencingActive = false;
         if (isBrowseActive) {
             isSequencingActive = true;
-            const { query: sequencingQuery = {} } = url.parse(seqencingDataHref, true);
+            const { query: sequencingQuery = {} } = url.parse(sequencingDataHref, true);
             const seqKeys = Object.keys(sequencingQuery);
             for (var i = 0; i < seqKeys.length; i++){
                 if (sequencingQuery[seqKeys[i]] !== query[seqKeys[i]]){
@@ -98,7 +98,7 @@ function DataNavItem(props){
                 isBrowseActive = false;
             }
         }
-        return { browseHref, seqencingDataHref, microscopyDataHref, isMicroscopyActive, isBrowseActive, isSequencingActive };
+        return { browseHref, sequencingDataHref, microscopyDataHref, isMicroscopyActive, isBrowseActive, isSequencingActive };
     }, [ href, browseBaseState ]);
 
     const isAnyActive = (bodyProps.isBrowseActive || bodyProps.isMicroscopyActive || bodyProps.isSequencingActive);
@@ -119,7 +119,7 @@ function DataNavItem(props){
 
 const DataNavItemBody = React.memo(function DataNavItemBody(props) {
     const {
-        browseHref, seqencingDataHref, microscopyDataHref,
+        browseHref, sequencingDataHref, microscopyDataHref,
         isBrowseActive = false,
         isSequencingActive = false,
         isMicroscopyActive = false,
@@ -135,7 +135,7 @@ const DataNavItemBody = React.memo(function DataNavItemBody(props) {
                 </div>
             </BigDropdownBigLink>
 
-            <BigDropdownBigLink href={seqencingDataHref} isActive={isSequencingActive} titleIcon="dna fas">
+            <BigDropdownBigLink href={sequencingDataHref} isActive={isSequencingActive} titleIcon="dna fas">
                 <h4>Browse Sequencing Data</h4>
                 <div className="description">
                     Search Sequencing Experiment Sets in the 4D Nucleome Database

--- a/src/encoded/static/components/navigation/components/SearchBar.js
+++ b/src/encoded/static/components/navigation/components/SearchBar.js
@@ -34,31 +34,40 @@ export class SearchBar extends React.PureComponent{
 
     constructor(props){
         super(props);
+        this.onToggleVisibility     = this.onToggleVisibility.bind(this);
         this.toggleSearchAllItems   = this.toggleSearchAllItems.bind(this);
         this.onSearchInputChange    = this.onSearchInputChange.bind(this);
         this.onResetSearch          = this.onResetSearch.bind(this);
         this.onSearchInputBlur      = this.onSearchInputBlur.bind(this);
         this.selectItemTypeDropdown = this.selectItemTypeDropdown.bind(this);
 
-        var initialQuery = '';
+        let initialQuery = '';
         if (props.href){
             initialQuery = searchFilters.searchQueryStringFromHref(props.href) || '';
         }
+
         this.state = {
             'searchAllItems'    : props.href && navigate.isSearchHref(props.href),
-            'typedSearchQuery'  : initialQuery
+            'typedSearchQuery'  : initialQuery,
+            'isVisible'         : isSelectAction(props.currentAction) || SearchBar.hasInput(initialQuery) || false
         };
+
+        this.inputElemRef = React.createRef();
     }
 
     componentDidUpdate(pastProps){
-        const { href } = this.props;
-        if (pastProps.href !== href){
-            const query = searchFilters.searchQueryStringFromHref(href) || '';
-            this.setState(function({ typedSearchQuery }){
-                if (query !== typedSearchQuery){
-                    return { 'typedSearchQuery' : query };
-                }
-                return null;
+        const { href, currentAction } = this.props;
+        const { href: pastHref } = pastProps;
+
+        if (pastHref !== href){
+            // Since is PureComponent, if state values are updated to be same value, will not update/rerender.
+            this.setState(function(currState){
+                const typedSearchQuery = searchFilters.searchQueryStringFromHref(href) || '';
+                return {
+                    // We don't want to hide if was already open.
+                    isVisible : isSelectAction(currentAction) || currState.isVisible || SearchBar.hasInput(typedSearchQuery) || false,
+                    typedSearchQuery
+                };
             });
         }
     }
@@ -76,6 +85,19 @@ export class SearchBar extends React.PureComponent{
         });
     }
 
+    onToggleVisibility(evt){
+        const { currentAction } = this.props;
+        this.setState(function({ isVisible, typedSearchQuery }){
+            return { isVisible: isSelectAction(currentAction) || !isVisible };
+        }, ()=> {
+            // Guaranteed to be up to date in callback.
+            const { isVisible } = this.state;
+            if (isVisible && this.inputElemRef.current) {
+                this.inputElemRef.current.focus();
+            }
+        });
+    }
+
     onSearchInputChange(e){
         const newValue = e.target.value;
         const state = { 'typedSearchQuery': newValue };
@@ -86,24 +108,36 @@ export class SearchBar extends React.PureComponent{
     }
 
     onSearchInputBlur(e){
-        const lastQuery = searchFilters.searchQueryStringFromHref(this.props.href);
-        if (SearchBar.hasInput(lastQuery) && !SearchBar.hasInput(this.state.typedSearchQuery)) {
-            this.setState({ 'typedSearchQuery' : lastQuery });
-        }
+        const { href, currentAction } = this.props;
+        const lastQuery = searchFilters.searchQueryStringFromHref(href);
+
+        this.setState(function({ typedSearchQuery: currQueryStr }){
+            let typedSearchQuery = currQueryStr; // No change - default
+            if (SearchBar.hasInput(lastQuery) && !SearchBar.hasInput(currQueryStr)) {
+                // Replace new value entered with current search query in URL if new value is empty string
+                typedSearchQuery = lastQuery;
+            }
+            // Prevent closing onBlur if on selection view, or if have input.
+            const isVisible = isSelectAction(currentAction) || SearchBar.hasInput(typedSearchQuery) || false;
+            return { typedSearchQuery, isVisible };
+        });
     }
 
-    onResetSearch (e){
-        const { href } = this.props;
+    onResetSearch(e){
+        const { href, currentAction } = this.props;
         const hrefParts = _.clone(memoizedUrlParse(href));
         hrefParts.query = _.clone(hrefParts.query || {});
         if (typeof hrefParts.search === 'string'){
             delete hrefParts.query['q'];
             delete hrefParts.search;
         }
-        this.setState(
-            { 'searchAllItems' : false, 'typedSearchQuery' : '' },
-            navigate.bind(navigate, url.format(hrefParts))
-        );
+        this.setState({
+            'searchAllItems' : false,
+            'typedSearchQuery' : '',
+            'isVisible' : isSelectAction(currentAction) || false
+        }, () => { // Doesn't refer to `this` so could be plain/pure function; but navigation is kind of big 'side effect' so... eh
+            navigate(url.format(hrefParts));
+        });
     }
 
     selectItemTypeDropdown(visible = false){
@@ -128,7 +162,7 @@ export class SearchBar extends React.PureComponent{
 
     render() {
         const { href, currentAction } = this.props;
-        const { searchAllItems, typedSearchQuery } = this.state;
+        const { searchAllItems, typedSearchQuery, isVisible } = this.state;
         const hrefParts = memoizedUrlParse(href);
         const searchQueryFromHref = (hrefParts && hrefParts.query && hrefParts.query.q) || '';
         const searchTypeFromHref = (hrefParts && hrefParts.query && hrefParts.query.type) || '';
@@ -139,10 +173,11 @@ export class SearchBar extends React.PureComponent{
         const query = {}; // Don't preserve facets.
         const browseBaseParams = navigate.getBrowseBaseParams();
         const formClasses = [
-            'form-inline',
-            'navbar-search-form-container',
-            searchQueryFromHref && 'has-query',
-            searchBoxHasInput && 'has-input'
+            "form-inline",
+            "navbar-search-form-container",
+            searchQueryFromHref && "has-query",
+            searchBoxHasInput && "has-input",
+            isVisible && "form-is-visible"
         ];
 
         if (isSelectAction(currentAction)) {
@@ -155,40 +190,45 @@ export class SearchBar extends React.PureComponent{
 
         return ( // Form submission gets serialized and AJAXed via onSubmit handlers in App.js
             <form className={_.filter(formClasses).join(' ')} action={searchAllItems ? "/search/" : "/browse/" } method="GET">
-                <SelectItemTypeDropdownBtn currentAction={currentAction} visible={!!(searchBoxHasInput || searchQueryFromHref)}
-                    toggleSearchAllItems={this.toggleSearchAllItems} searchAllItems={searchAllItems} />
-                <input className="form-control search-query" id="navbar-search" type="search" placeholder="Search"
-                    name="q" value={typedSearchQuery} onChange={this.onSearchInputChange} key="search-input" onBlur={this.onSearchInputBlur} />
-                { showingCurrentQuery ? <i className="reset-button icon icon-times fas" onClick={this.onResetSearch}/> : null }
-                { showingCurrentQuery ? null : (
-                    <button type="submit" className="search-icon-button">
+                <div className="form-inputs-container">
+                    <SelectItemTypeDropdownBtn {...{ currentAction, searchAllItems }} disabled={!(searchBoxHasInput || searchQueryFromHref)}
+                        toggleSearchAllItems={this.toggleSearchAllItems} />
+                    <input className="form-control search-query" id="navbar-search" type="search" placeholder="Search" ref={this.inputElemRef}
+                        name="q" value={typedSearchQuery} onChange={this.onSearchInputChange} key="search-input" onBlur={this.onSearchInputBlur} />
+                    { showingCurrentQuery ? <i className="reset-button icon icon-times fas" onClick={this.onResetSearch}/> : null }
+                    { showingCurrentQuery ? null : (
+                        <button type="submit" className="search-icon-button">
+                            <i className="icon icon-fw icon-search fas"/>
+                        </button>
+                    ) }
+                    { SearchBar.renderHiddenInputsForURIQuery(query) }
+                </div>
+                <div className="form-visibility-toggle">
+                    <button type="button" onClick={this.onToggleVisibility}>
                         <i className="icon icon-fw icon-search fas"/>
                     </button>
-                ) }
-                { SearchBar.renderHiddenInputsForURIQuery(query) }
+                </div>
             </form>
         );
     }
 }
 
 const SelectItemTypeDropdownBtn = React.memo(function SelectItemTypeDropdownBtn(props){
-    const { currentAction, searchAllItems, toggleSearchAllItems, visible } = props;
-    if (isSelectAction(currentAction) || !visible) return null;
+    const { currentAction, searchAllItems, toggleSearchAllItems, disabled = true } = props;
+    if (isSelectAction(currentAction)) return null;
     return (
-        <Fade in={visible} appear>
-            <div className="search-item-type-wrapper">
-                <DropdownButton id="search-item-type-selector" size="sm" variant="outline-secondary"
-                    onSelect={(eventKey, evt)=>{ toggleSearchAllItems(eventKey === 'all' ? true : false); }}
-                    title={searchAllItems ? 'All Items' : 'Experiment Sets'}>
-                    <DropdownItem eventKey="sets" data-key="sets" active={!searchAllItems}>
-                        Experiment Sets
-                    </DropdownItem>
-                    <DropdownItem eventKey="all" data-key="all" active={searchAllItems}>
-                        All Items (advanced)
-                    </DropdownItem>
-                </DropdownButton>
-            </div>
-        </Fade>
+        <div className="search-item-type-wrapper">
+            <DropdownButton id="search-item-type-selector" size="sm" variant="outline-secondary" disabled={disabled}
+                onSelect={(eventKey, evt)=>{ toggleSearchAllItems(eventKey === 'all' ? true : false); }}
+                title={searchAllItems ? 'All Items' : 'Experiment Sets'}>
+                <DropdownItem eventKey="sets" data-key="sets" active={!searchAllItems}>
+                    Experiment Sets
+                </DropdownItem>
+                <DropdownItem eventKey="all" data-key="all" active={searchAllItems}>
+                    All Items (advanced)
+                </DropdownItem>
+            </DropdownButton>
+        </div>
     );
 });
 

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -402,31 +402,67 @@ div#top-nav.navbar-fixed-top {
             // Navbar search
             > form.form-inline.navbar-search-form-container {
                 position: relative;
+                width: 100%;
 
-                > input#navbar-search {
-                    font-size: 1em;
-                    width: 140px;
-                    color: rgba(0,0,0,0.5);
-                    border-radius: 3px;
-                    border: 1px solid rgb(125,125,125);
+                > .form-inputs-container {
+                    display: flex; // Made visible on mobile size or if open/visible at desktop size
+                    position: relative; // Overriden to be absolute if fixed-position navbar
+                    align-items: center;
+
+                    > input#navbar-search {
+                        flex-grow: 1;
+                        font-size: 1em;
+                        color: rgba(0,0,0,0.5);
+                        width: 100%;
+                        border-radius: 3px;
+                        border: 1px solid rgb(125,125,125);
+                        height: 30px;
+                        padding: 4px 5px 4px 5px;
+                        @include transition(opacity .15s .25s ease-out);
+                        &::-webkit-search-cancel-button {
+                            display: none;
+                        }
+                    }
+
+                }
+
+                > .form-visibility-toggle {
+                    display: none; // Visible only if SearchBar input itself is hidden. At non-mobile sizes.
                     height: inherit;
-                    padding: 4px 5px 3px 5px;
-                    -ms-transition: width 0.3s ease-out;
-                    -moz-transition: width 0.3s ease-out;
-                    -webkit-transition: width 0.3s ease-out;
-                    transition: width 0.3s ease-out;
-                    margin-left: 5px;
-                    &::-webkit-search-cancel-button {
-                        display: none;
+                    position: relative;
+                    z-index: 100;
+                    width: 50px;
+                    margin-right: -10px;
+                    // Similar in look to .search-icon-button
+                    > button {
+                        display: block;
+                        line-height: 14px;
+                        font-size: 1.25rem;
+                        opacity: 0.5;
+                        border: none;
+                        background: none;
+                        outline: none;
+                        padding: 0;
+                        width: inherit;
+                        height: inherit;
+                        &:hover {
+                            opacity: 1;
+                            background-color: $navbar-link-hover-bg;
+                        }
                     }
                 }
 
                 .search-item-type-wrapper {
+                    padding-right: 5px;
                     > div.dropdown {
-                        > #search-item-type-selector {
+                        > button#search-item-type-selector {
                             height: 30px; // Match that of navbar-search <input>
                             margin-top: -1px;
                             padding-top: 5px;
+
+                            &:disabled {
+                                color: $gray-600; // Slightly darker than default
+                            }
 
                             + .dropdown-menu {
                                 line-height: $line-height-base;
@@ -445,19 +481,53 @@ div#top-nav.navbar-fixed-top {
                     border-top: 1px solid #ddd;
                     border-bottom: 1px solid #ddd;
 
-                    > input#navbar-search {
+                    > .form-inputs-container {
+                        width: 100%;
                         flex-grow: 1;
                     }
+
                 }
 
                 @include navbar-fixed-position {
 
-                    .search-item-type-wrapper {
-                        display: none; // Hidden until lg size
+                    // Enough width for search icon to fit
+                    width: 50px;
+                    text-align: center;
+                    justify-content: flex-end;
+                    height: inherit;
+
+                    > .form-inputs-container {
+                        position: absolute;
+                        right: 0;
+                        width: 360px;
+                        height: inherit;
+                        @include transition(width 0.4s ease-out, opacity 0.25s 0.05s ease-out);
+                        background-color: #f8f8f8; // Matches NavBar itself
+                        padding-left: 12px;
+                        border-left: 1px solid #d0d0d0;
+                        box-shadow: -4px 0px 5px -5px #bbb;
                     }
 
-                    input#navbar-search {
-                        width: 150px;
+                    &:not(.form-is-visible) {
+                        > .form-inputs-container {
+                            width: 0px !important;
+                            opacity: 0;
+                            pointer-events: none;
+                            z-index: -100;
+                            overflow: hidden;
+                            @include transition(width 0.5s ease-in, opacity 0.25s 0.05s ease-out);
+                            > #navbar-search {
+                                opacity: 0;
+                                @include transition(opacity .2s ease-out);
+                            }
+                        }
+                        > .form-visibility-toggle {
+                            display: block;
+                        }
+                    }
+    
+                    &.form-is-visible {
+                        width: auto;
                     }
 
                     &.has-input #navbar-search,
@@ -470,11 +540,8 @@ div#top-nav.navbar-fixed-top {
                 }
 
                 @include media-breakpoint-up(lg){
-                    .search-item-type-wrapper {
-                        display: block;
-                    }
-                    input#navbar-search {
-                        width: 200px;
+                    > .form-inputs-container {
+                        width: 420px;
                     }
                     &.has-input input#navbar-search,
                     input#navbar-search:focus {
@@ -487,6 +554,7 @@ div#top-nav.navbar-fixed-top {
                     position: absolute;
                     top: 50%;
                     margin-top: -7px;
+                    margin-top: -6.5px;
                     right: 10px;
                     opacity: 0.33;
                     cursor: pointer;
@@ -500,12 +568,12 @@ div#top-nav.navbar-fixed-top {
                     line-height: 14px;
                     position: absolute;
                     top: 50%;
-                    margin-top: -12px;
+                    margin-top: -11px;
                     right: 2px;
                     opacity: 0.25;
                     border: none;
                     background: none;
-                    padding: 4px 4px 2px;
+                    padding: 4px;
                 }
 
             }
@@ -766,16 +834,20 @@ body[data-pathname="/search/"][data-current-action="multiselect"] {
            display: none;
        }
    }
-   .test-warning {display:none;}
+   .test-warning {
+       display:none;
+    }
    .form-inline.navbar-search-form-container {
-        width: 100%;
-        input#navbar-search {
+        width: 100% !important;
+        > .form-inputs-container {
+            position: relative !important; // Override position absolute (default for navbar-fixed-position)
             width: 100% !important;
-            margin-left: 0 !important;
+            .search-item-type-wrapper {
+                display: none; /* redundant since handled already in JS */
+            }
+                
         }
-        .search-item-type-wrapper {
-            display: none; /* redundant since handled already in JS */
-        }
+        
     }
 }
 
@@ -916,7 +988,8 @@ body[data-pathname="/search/"][data-current-action="multiselect"] {
                         display: inline-block;
                         @include after-big-link-append;
                     }
-                    &:hover {
+                    &:hover,
+                    &.active {
                         > div > div > h3,
                         > div > div > h5,
                         > div > div > h4 {

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -432,7 +432,6 @@ div#top-nav.navbar-fixed-top {
                     position: relative;
                     z-index: 100;
                     width: 50px;
-                    margin-right: -10px;
                     // Similar in look to .search-icon-button
                     > button {
                         display: block;
@@ -445,7 +444,7 @@ div#top-nav.navbar-fixed-top {
                         padding: 0;
                         width: inherit;
                         height: inherit;
-                        &:hover {
+                        &:hover:not(:disabled) {
                             opacity: 1;
                             background-color: $navbar-link-hover-bg;
                         }
@@ -498,24 +497,26 @@ div#top-nav.navbar-fixed-top {
 
                     > .form-inputs-container {
                         position: absolute;
-                        right: 0;
+                        right: -7px;
                         width: 360px;
                         height: inherit;
                         @include transition(width 0.4s ease-out, opacity 0.25s 0.05s ease-out);
                         background-color: #f8f8f8; // Matches NavBar itself
-                        padding-left: 12px;
+                        padding: 0 20px;
                         border-left: 1px solid #d0d0d0;
+                        //border-right: 1px solid #d0d0d0;
+                        background-color: #f8f8f8; //$navbar-link-active-bg;
                         box-shadow: -4px 0px 5px -5px #bbb;
                     }
 
                     &:not(.form-is-visible) {
                         > .form-inputs-container {
+                            @include transition(width 0.75s ease-in, opacity 0.5s 0.05s ease-out);
                             width: 0px !important;
                             opacity: 0;
                             pointer-events: none;
-                            z-index: -100;
+                            z-index: 0;
                             overflow: hidden;
-                            @include transition(width 0.5s ease-in, opacity 0.25s 0.05s ease-out);
                             > #navbar-search {
                                 opacity: 0;
                                 @include transition(opacity .2s ease-out);
@@ -556,6 +557,9 @@ div#top-nav.navbar-fixed-top {
                     margin-top: -7px;
                     margin-top: -6.5px;
                     right: 10px;
+                    @include navbar-fixed-position {
+                        right: 30px;
+                    }
                     opacity: 0.33;
                     cursor: pointer;
                     &:hover {
@@ -570,6 +574,9 @@ div#top-nav.navbar-fixed-top {
                     top: 50%;
                     margin-top: -11px;
                     right: 2px;
+                    @include navbar-fixed-position {
+                        right: 22px;
+                    }
                     opacity: 0.25;
                     border: none;
                     background: none;
@@ -835,13 +842,16 @@ body[data-pathname="/search/"][data-current-action="multiselect"] {
        }
    }
    .test-warning {
-       display:none;
+       display: none;
     }
    .form-inline.navbar-search-form-container {
         width: 100% !important;
         > .form-inputs-container {
             position: relative !important; // Override position absolute (default for navbar-fixed-position)
+            right: 0 !important;
             width: 100% !important;
+            border-left: none !important;
+            box-shadow: none !important;
             .search-item-type-wrapper {
                 display: none; /* redundant since handled already in JS */
             }


### PR DESCRIPTION
Changes SearchBar from being always present/visible when on desktop to being hidden (via opacity, width) by default unless made visible by clicking on icon. Needed in order to make room for new Nav Items, incl "Tools".

[Video Demo](https://gyazo.com/868ea20741ff6321f1f3c4b1d6d83e8c)

Existing views/states (mobile, currentAction=selection/multiselect) should look about same as before.

No insert has yet been created for the "Tools" (/tools) dropdown.