### PR TITLE
Snovault 1.3.5 compatibility

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -31,7 +31,7 @@ auto-checkout = snovault
 		dcicutils
 
 [sources]
-snovault = git https://github.com/4dn-dcic/snovault.git rev=v1.3.4
+snovault = git https://github.com/4dn-dcic/snovault.git rev=keys
 Submit4DN = git https://github.com/4dn-dcic/Submit4DN.git rev=0.9.7
 dcicutils = git https://github.com/4dn-dcic/utils.git rev=0.8.1
 jsonschema = git https://github.com/4dn-dcic/jsonschema_serialize_fork.git

--- a/src/encoded/tests/testing_views.py
+++ b/src/encoded/tests/testing_views.py
@@ -75,7 +75,7 @@ class TestingDownload(ItemWithAttachment):
         'title': 'Test keys',
         'description': 'Testing. Testing. 1, 2, 3.',
     },
-    unique_key='testing_accession',
+    traversal_key='testing_accession',
 )
 class TestingKey(Item):
     item_type = 'testing_key'
@@ -94,7 +94,7 @@ class TestingKey(Item):
     }
 
 
-@collection('testing-link-sources', unique_key='testing_link_sources:name')
+@collection('testing-link-sources', traversal_key='testing_link_sources:name')
 class TestingLinkSource(Item):
     item_type = 'testing_link_source'
     schema = {
@@ -120,7 +120,7 @@ class TestingLinkSource(Item):
     }
 
 
-@collection('testing-link-targets', unique_key='testing_link_target:name')
+@collection('testing-link-targets', traversal_key='testing_link_target:name')
 class TestingLinkTarget(Item):
     item_type = 'testing_link_target'
     name_key = 'name'

--- a/src/encoded/types/__init__.py
+++ b/src/encoded/types/__init__.py
@@ -30,7 +30,7 @@ def includeme(config):
 
 @collection(
     name='analysis-steps',
-    unique_key='analysis_step:name',
+    traversal_key='analysis_step:name',
     properties={
         'title': 'AnalysisSteps',
         'description': 'Listing of analysis steps for 4DN analyses',
@@ -94,7 +94,7 @@ class Document(ItemWithAttachment, Item):
 
 @collection(
     name='enzymes',
-    unique_key='enzyme:name',
+    traversal_key='enzyme:name',
     properties={
         'title': 'Enzymes',
         'description': 'Listing of enzymes',
@@ -110,7 +110,7 @@ class Enzyme(Item):
 
 @collection(
     name='file-formats',
-    unique_key='file_format:file_format',
+    traversal_key='file_format:file_format',
     lookup_key='file_format',
     properties={
         'title': 'File Formats',
@@ -169,7 +169,7 @@ class GenomicRegion(Item):
 
 @collection(
     name='organisms',
-    unique_key='organism:taxon_id',
+    traversal_key='organism:taxon_id',
     lookup_key='name',
     properties={
         'title': 'Organisms',
@@ -318,7 +318,7 @@ class TrackingItem(Item):
 
 @collection(
     name='vendors',
-    unique_key='vendor:name',
+    traversal_key='vendor:name',
     properties={
         'title': 'Vendors',
         'description': 'Listing of sources and vendors for 4DN material',

--- a/src/encoded/types/access_key.py
+++ b/src/encoded/types/access_key.py
@@ -33,7 +33,7 @@ from snovault.validators import (
 
 @collection(
     name='access-keys',
-    unique_key='access_key:access_key_id',
+    traversal_key='access_key:access_key_id',
     properties={
         'title': 'Access keys',
         'description': 'Programmatic access keys',

--- a/src/encoded/types/antibody.py
+++ b/src/encoded/types/antibody.py
@@ -16,7 +16,7 @@ import re
 
 @collection(
     name='antibodys',
-    unique_key='antibody:antibody_id',
+    traversal_key='antibody:antibody_id',
     properties={
         'title': 'Antibodies',
         'description': 'Listing of antibodies',

--- a/src/encoded/types/award.py
+++ b/src/encoded/types/award.py
@@ -20,7 +20,7 @@ import re
 
 @collection(
     name='awards',
-    unique_key='award:name',
+    traversal_key='award:name',
     properties={
         'title': 'Awards (Grants)',
         'description': 'Listing of awards (aka grants)',

--- a/src/encoded/types/badge.py
+++ b/src/encoded/types/badge.py
@@ -13,7 +13,7 @@ from .base import (
 
 @collection(
     name='badges',
-    unique_key='badge:badge_name',
+    traversal_key='badge:badge_name',
     properties={
         'title': 'Badges',
         'description': 'Listing of badges for 4DN items',

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -13,7 +13,7 @@ from .base import (
 
 @collection(
     name='biosamples',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Biosamples',
         'description': 'Biosamples used in the 4DN project',

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -27,7 +27,7 @@ from .base import (
 
 @collection(
     name='biosources',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Biosources',
         'description': 'Cell lines and tissues used for biosamples',

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -51,7 +51,7 @@ EXP_CATEGORIZER_SCHEMA = {
 
 @abstract_collection(
     name='experiments',
-    unique_key='accession',
+    traversal_key='accession',
     acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': "Experiments",
@@ -344,7 +344,7 @@ class Experiment(Item):
 
 @collection(
     name='experiments-hi-c',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments Hi-C',
         'description': 'Listing Hi-C Experiments',
@@ -384,7 +384,7 @@ class ExperimentHiC(Experiment):
 
 @collection(
     name='experiments-capture-c',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments Capture Hi-C',
         'description': 'Listing Capture Hi-C Experiments',
@@ -447,7 +447,7 @@ class ExperimentCaptureC(Experiment):
 
 @collection(
     name='experiments-repliseq',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments Repli-seq',
         'description': 'Listing of Repli-seq Experiments',
@@ -504,7 +504,7 @@ class ExperimentRepliseq(Experiment):
 
 @collection(
     name='experiments-atacseq',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments ATAC-seq',
         'description': 'Listing ATAC-seq Experiments',
@@ -540,7 +540,7 @@ class ExperimentAtacseq(Experiment):
 
 @collection(
     name='experiments-chiapet',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments CHIA-pet',
         'description': 'Listing CHIA-pet and PLAC-seq Experiments',
@@ -584,7 +584,7 @@ class ExperimentChiapet(Experiment):
 
 @collection(
     name='experiments-damid',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments DAM-ID',
         'description': 'Listing DAM-ID Experiments',
@@ -629,7 +629,7 @@ class ExperimentDamid(Experiment):
 
 @collection(
     name='experiments-seq',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments CHIPseq, RNAseq ...',
         'description': 'Listing of ChIP and RNA seq type experiments',
@@ -673,7 +673,7 @@ class ExperimentSeq(ItemWithAttachment, Experiment):
 
 @collection(
     name='experiments-tsaseq',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiments TSA-Seq',
         'description': 'Listing of TSA-seq type experiments',
@@ -717,7 +717,7 @@ class ExperimentTsaseq(ItemWithAttachment, Experiment):
 
 @collection(
     name='experiments-mic',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Microscopy Experiments',
         'description': 'Listing of Microscopy Experiments',

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -33,7 +33,7 @@ import datetime
 
 @collection(
     name='experiment-sets',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Experiment Sets',
         'description': 'Listing Experiment Sets',
@@ -314,7 +314,7 @@ class ExperimentSet(Item):
 
 @collection(
     name='experiment-set-replicates',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Replicate Experiment Sets',
         'description': 'Experiment set covering biological and technical experiments',

--- a/src/encoded/types/experiment_type.py
+++ b/src/encoded/types/experiment_type.py
@@ -11,7 +11,7 @@ from .base import (
 
 @collection(
     name='experiment-types',
-    unique_key='experiment_type:experiment_name',
+    traversal_key='experiment_type:experiment_name',
     lookup_key='title',
     properties={
         'title': 'Experiment Types',

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -142,7 +142,7 @@ def property_closure(request, propname, root_uuid):
 
 @collection(
     name='file-sets',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'File Sets',
         'description': 'Listing of File Sets',
@@ -156,7 +156,7 @@ class FileSet(Item):
 
 @collection(
     name='file-set-calibrations',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Calibration File Sets',
         'description': 'Listing of File Sets',
@@ -181,7 +181,7 @@ class FileSetCalibration(FileSet):
 
 @collection(
     name='file-set-microscope-qcs',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Microscope QC File Sets',
         'description': 'Listing of File Sets',
@@ -206,7 +206,7 @@ class FileSetMicroscopeQc(ItemWithAttachment, FileSet):
 
 @abstract_collection(
     name='files',
-    unique_key='accession',
+    traversal_key='accession',
     acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': 'Files',
@@ -728,7 +728,7 @@ class File(Item):
 
 @collection(
     name='files-fastq',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'FASTQ Files',
         'description': 'Listing of FASTQ Files',
@@ -778,7 +778,7 @@ class FileFastq(File):
 
 @collection(
     name='files-processed',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Processed Files',
         'description': 'Listing of Processed Files',
@@ -880,7 +880,7 @@ class FileProcessed(File):
 
 @collection(
     name='files-reference',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Reference Files',
         'description': 'Listing of Reference Files',
@@ -895,7 +895,7 @@ class FileReference(File):
 
 @collection(
     name='files-vistrack',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Visualization Track Files',
         'description': 'Listing of External Files available as HiGlass visualization tracks',
@@ -972,7 +972,7 @@ class FileVistrack(File):
 
 @collection(
     name='files-calibration',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Calibration Files',
         'description': 'Listing of Calibration Files',
@@ -987,7 +987,7 @@ class FileCalibration(ItemWithAttachment, File):
 
 @collection(
     name='files-microscopy',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Microscopy Files',
         'description': 'Listing of Microscopy Files',

--- a/src/encoded/types/gene.py
+++ b/src/encoded/types/gene.py
@@ -77,7 +77,7 @@ def map_ncbi2schema(geneinfo):
 
 @collection(
     name='genes',
-    unique_key='gene:geneid',
+    traversal_key='gene:geneid',
     lookup_key='preferred_symbol',
     properties={
         'title': 'Genes',

--- a/src/encoded/types/image.py
+++ b/src/encoded/types/image.py
@@ -13,7 +13,7 @@ from snovault.attachment import ItemWithAttachment
 
 @collection(
     name='images',
-    unique_key='image:filename',
+    traversal_key='image:filename',
     properties={
         'title': 'Image',
         'description': 'Listing of portal images',

--- a/src/encoded/types/individual.py
+++ b/src/encoded/types/individual.py
@@ -15,7 +15,7 @@ from .base import (
 
 @abstract_collection(
     name='individuals',
-    unique_key='accession',
+    traversal_key='accession',
     acl=ALLOW_SUBMITTER_ADD,
     properties={
         'title': "Individuals",
@@ -32,7 +32,7 @@ class Individual(Item):
 
 @collection(
     name='individuals-human',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Individuals-Humans',
         'description': 'Listing Biosample Human Individuals',
@@ -47,7 +47,7 @@ class IndividualHuman(Individual):
 
 @collection(
     name='individuals-primate',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Individuals-Primates',
         'description': 'Listing Biosample Primate Individuals',
@@ -62,7 +62,7 @@ class IndividualPrimate(Individual):
 
 @collection(
     name='individuals-mouse',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Individuals-Mice',
         'description': 'Listing Biosample Mouse Individuals',
@@ -77,7 +77,7 @@ class IndividualMouse(Individual):
 
 @collection(
     name='individuals-fly',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Individuals-Flies',
         'description': 'Listing Biosample Fly Individuals',
@@ -92,7 +92,7 @@ class IndividualFly(Individual):
 
 @collection(
     name='individuals-chicken',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Individuals-Chickens',
         'description': 'Listing Biosample Chicken Individuals',
@@ -107,7 +107,7 @@ class IndividualChicken(Individual):
 
 @collection(
     name='individuals-zebrafish',
-    unique_key='accession',
+    traversal_key='accession',
     properties={
         'title': 'Individuals-Zebrafish',
         'description': 'Listing Zebrafish Sources',

--- a/src/encoded/types/lab.py
+++ b/src/encoded/types/lab.py
@@ -41,7 +41,7 @@ ALLOW_EVERYONE_VIEW_AND_SUBMITTER_EDIT = [
 
 @collection(
     name='labs',
-    unique_key='lab:name',
+    traversal_key='lab:name',
     properties={
         'title': 'Labs',
         'description': 'Listing of 4D Nucleome labs',

--- a/src/encoded/types/ontology.py
+++ b/src/encoded/types/ontology.py
@@ -11,7 +11,7 @@ from .base import (
 
 @collection(
     name='ontology-terms',
-    unique_key='ontology_term:term_id',
+    traversal_key='ontology_term:term_id',
     lookup_key='preferred_name',
     properties={
         'title': 'Ontology Terms',
@@ -56,7 +56,7 @@ class OntologyTerm(Item):
 
 @collection(
     name='ontologys',
-    unique_key='ontology:ontology_prefix',
+    traversal_key='ontology:ontology_prefix',
     properties={
         'title': 'Ontologies',
         'description': 'Listing of Ontologies',

--- a/src/encoded/types/publication_tracking.py
+++ b/src/encoded/types/publication_tracking.py
@@ -13,7 +13,7 @@ from .base import (
 
 @collection(
     name='publication-trackings',
-    unique_key='publication:PMID',
+    traversal_key='publication:PMID',
     properties={
         'title': 'Publication Tracking',
         'description': 'Abstract title collection for future 4DN publications',

--- a/src/encoded/types/sop_map.py
+++ b/src/encoded/types/sop_map.py
@@ -11,7 +11,7 @@ from .base import (
 
 @collection(
     name='sop-maps',
-    unique_key='sop_map:mapid',
+    traversal_key='sop_map:mapid',
     properties={
         'title': 'SOP and field mappings',
         'description': 'Listing of SOPs with the default values for fields from them',

--- a/src/encoded/types/user.py
+++ b/src/encoded/types/user.py
@@ -57,7 +57,7 @@ USER_DELETED = [
 
 @collection(
     name='users',
-    unique_key='user:email',
+    traversal_key='user:email',
     properties={
         'title': '4D Nucleome Users',
         'description': 'Listing of current 4D Nucleome DCIC users',

--- a/src/encoded/types/user_content.py
+++ b/src/encoded/types/user_content.py
@@ -23,7 +23,7 @@ import requests
 
 @abstract_collection(
     name='user-contents',
-    unique_key='user_content:name',
+    traversal_key='user_content:name',
     properties={
         'title': "User Content Listing",
         'description': 'Listing of all types of content which may be created by people.',
@@ -98,7 +98,7 @@ class UserContent(Item):
 
 @collection(
     name='static-sections',
-    unique_key='user_content:name',
+    traversal_key='user_content:name',
     properties={
         'title': 'Static Sections',
         'description': 'Static Sections for the Portal',
@@ -153,7 +153,7 @@ class StaticSection(UserContent):
 
 @collection(
     name='higlass-view-configs',
-    unique_key='user_content:name',
+    traversal_key='user_content:name',
     properties={
         'title': 'HiGlass Displays',
         'description': 'Displays and view configurations for HiGlass',


### PR DESCRIPTION
- Snovault 1.3.5 renames the collection decorator argument `unique_key` to `traversal_key` 
- This change must be propagated across all item types in FF to be compatible.