### PR TITLE
Set "Within Results" as default in Browse/Search pages

### DIFF
--- a/src/encoded/static/components/navigation/components/SearchBar.js
+++ b/src/encoded/static/components/navigation/components/SearchBar.js
@@ -37,12 +37,9 @@ export class SearchBar extends React.PureComponent {
         return href && typeof href === 'string' && (href.indexOf('/browse/') > -1 || href.indexOf('/search/') > -1);
     }
 
-    static deriveSearchItemTypeFromHref(href, searchItemType = null){
-        if (searchItemType === "within" && SearchBar.isBrowseOrSearchPage(href)) {
+    static deriveSearchItemTypeFromHref(href, searchItemType = null) {
+        if (SearchBar.isBrowseOrSearchPage(href)) {
             return "within";
-        }
-        if (navigate.isSearchHref(href)) {
-            return "all";
         }
         return "sets";
     }


### PR DESCRIPTION
Minor fix to set "Within Results" as default option in Browse/Search pages.