### PR TITLE
Check obsoletes

### DIFF
--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -1085,7 +1085,7 @@ def main():
         if obsoletes:
             problems = []
             for obsolete in obsoletes:
-                result = get_metadata(obsolete['uuid'] + '/@@links', ff_env=args.env)
+                result = get_metadata(obsolete['uuid'] + '/@@links', connection)
                 if result.get('uuids_linking_to'):
                     for item in result['uuids_linking_to']:
                         if 'parents' not in item.get('field', ''):


### PR DESCRIPTION
- for ontology terms to be obsoleted, will perform a get_metadata search using @@links url and print warning to console about linked items (not counting parents/children, which should be covered by the script already).
- IDMAP warnings condensed in console output