### PR TITLE
Display Search Header Static Section: search-info-header.<Item type>

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -92,6 +92,7 @@ def search(context, request, search_type=None, return_generator=False, forced_ty
             result['search_header'] = {}
             result['search_header']['content'] = item['content']
             result['search_header']['title'] = item.get('title', item['display_title'])
+            result['search_header']['filetype'] = item['filetype']
 
     from_, size = get_pagination(request)
 

--- a/src/encoded/static/components/browse/SearchView.js
+++ b/src/encoded/static/components/browse/SearchView.js
@@ -11,6 +11,7 @@ import { console, isSelectAction } from '@hms-dbmi-bgm/shared-portal-components/
 import { columnExtensionMap } from './columnExtensionMap';
 import { memoizedUrlParse } from './../globals';
 import { Schemas } from './../util';
+import { replaceString as placeholderReplacementFxn } from './../static-pages/placeholders';
 
 
 /**
@@ -105,7 +106,7 @@ export default class SearchView extends React.PureComponent {
         const facetColumnClassName = "col-12 col-sm-5 col-lg-4 col-xl-" + (isFullscreen ? '2' : '3');
         return (
             <div className="container" id="content">
-                <CommonSearchView {...this.props} {...{ columnExtensionMap, tableColumnClassName, facetColumnClassName, facets }}
+                <CommonSearchView {...this.props} {...{ columnExtensionMap, tableColumnClassName, facetColumnClassName, facets, placeholderReplacementFxn }}
                     termTransformFxn={Schemas.Term.toName} separateSingleTermFacets />
             </div>
         );


### PR DESCRIPTION
Pls handle this PR w/ https://github.com/4dn-dcic/shared-portal-components/pull/19

**Problem**: Previously sysinfo item is used to map certain static sections to searches for specific item types. When a search on one item type was done, the given static section content was shown at the top of the search page. Now, search.py will look for a static section with name `search-info-header.<Item type>` when searching for one type, and add it to the search response. At some point, the search JS needs to be adjusted to use the new content in the response instead of looking for the now-deprecated sysinfo object.

**Solution**: Minor updates for both back-end and front-end solved the problem:

<img width="1147" alt="Screen Shot 2019-12-28 at 00 25 29" src="https://user-images.githubusercontent.com/49978017/71533207-94bb4700-2908-11ea-8cab-28ed1c288e8a.png">
