### PR TITLE
Misc test fixes (2020-01-26)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-========================
+============================
  Fourfront Metadata Database
-========================
+============================
 
 
 |Build status|_
@@ -32,7 +32,6 @@ Step 1: Verify that homebrew is working properly::
 
     $ brew doctor
 
-
 Step 2: Install or update dependencies::
 
     $ brew install libevent libmagic libxml2 libxslt openssl postgresql graphviz nginx python3
@@ -40,11 +39,10 @@ Step 2: Install or update dependencies::
     $ brew cask install adoptopenjdk8
     $ brew install elasticsearch@5.6 node@10
 
-
-You may need to link the brew-installed elasticsearch::
+If you try to invoke elasticsearch and it is not found,
+you may need to link the brew-installed elasticsearch::
 
     $ brew link --force elasticsearch@5.6
-
 
 If you need to update dependencies::
 
@@ -52,28 +50,39 @@ If you need to update dependencies::
     $ brew upgrade
     $ rm -rf encoded/eggs
 
-
 Step 3: Run buildout::
 
     $ pip install -U zc.buildout setuptools
     $ buildout bootstrap --buildout-version 2.9.5 --setuptools-version 36.6.0
     $ bin/buildout
 
-    NOTE:
-    If you have issues with postgres or the python interface to it (psycogpg2) you probably need to install postgresql
-    via homebrew (as above)
-    If you have issues with Pillow you may need to install new xcode command line tools:
-    - First update Xcode from AppStore (reboot)
-    $ xcode-select --install
-    If you are running macOS Mojave, you may need to run the below command as well:
-    sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+NOTES:
 
+ * If you have issues with postgres or the python interface to it (psycogpg2)
+   you probably need to install postgresql via homebrew (as above)
 
+ * If you have issues with Pillow you may need to install new xcode command line tools.
 
-If you wish to completely rebuild the application, or have updated dependencies:
-    $ make clean
+   - First update Xcode from AppStore (reboot)::
 
-    Then goto Step 3.
+       $ xcode-select --install
+
+   - If you are running macOS Mojave (though this is fixed in Catalina), you may need to run this command as well::
+
+       $ sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+
+   - If you have trouble with zlib, especially in Catalina, it is probably because brew installed it
+     in a different location. In that case, you'll want to do the following
+     in place of the regular call to buildout::
+
+       $ CFLAGS="-I$(brew --prefix zlib)/include" LDFLAGS="-L$(brew --prefix zlib)/lib" bin/buildout
+
+ * If you wish to completely rebuild the application, or have updated dependencies,
+   before you go ahead, you'll probably want to do::
+
+     $ make clean
+
+   Then goto Step 3.
 
 Step 4: Start the application locally
 

--- a/README.rst
+++ b/README.rst
@@ -18,39 +18,67 @@
 .. |Quality| image:: https://api.codacy.com/project/badge/Grade/f5fc54006b4740b5800e83eb2aeeeb43
 .. _Quality: https://www.codacy.com/app/4dn/fourfront?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=4dn-dcic/fourfront&amp;utm_campaign=Badge_Grade
 
+Overview
+========
 
 This is a fork from `ENCODE-DCC/encoded <https://github.com/ENCODE-DCC/encoded>`_ .  We are working to modularize the project and adapted to our needs for the 4D Nucleome project.
 
+Installation
+============
 
 Fourfront is known to work with Python 3.6.x and will not work with Python 3.7 or greater. If part of the 4DN team, it is recommended to use Python 3.4.3, since that's what is running on our servers. It is best practice to create a fresh Python virtualenv using one of these versions before proceeding to the following steps.
 
+Step 0: Obtain Credentials
+--------------------------
 
-Step 0: Obtain AWS keys. These will need to added to your environment variables or through the AWS CLI (installed later in this process).
+Obtain AWS keys. These will need to added to your environment variables or through the AWS CLI (installed later in this process).
 
 
-Step 1: Verify that homebrew is working properly::
+Step 1: Verify Homebrew Itself
+------------------------------
+
+Verify that homebrew is working properly::
 
     $ brew doctor
 
-Step 2: Install or update dependencies::
+Step 2: Install Homebrewed Dependencies
+---------------------------------------
+
+Install or update dependencies::
 
     $ brew install libevent libmagic libxml2 libxslt openssl postgresql graphviz nginx python3
     $ brew install freetype libjpeg libtiff littlecms webp  # Required by Pillow
     $ brew cask install adoptopenjdk8
     $ brew install elasticsearch@5.6 node@10
 
-If you try to invoke elasticsearch and it is not found,
-you may need to link the brew-installed elasticsearch::
+NOTES:
+
+* If installation of adtopopenjdk8 fails due to an ambiguity, it should work to do this instead::
+
+    $ brew cask install homebrew/cask-versions/adoptopenjdk8
+
+* If you try to invoke elasticsearch and it is not found,
+  you may need to link the brew-installed elasticsearch::
 
     $ brew link --force elasticsearch@5.6
 
-If you need to update dependencies::
+* If you need to update dependencies::
+
+    $ brew update
+    $ rm -rf encoded/eggs
+
+* If you need to upgrade brew-installed packages that don't have pinned versions,
+  you can use the following. However, take care because there is no command to directly
+  undo this effect::
 
     $ brew update
     $ brew upgrade
     $ rm -rf encoded/eggs
 
-Step 3: Run buildout::
+Step 3: Running Buildout
+------------------------
+
+Run buildout::
 
     $ pip install -U zc.buildout setuptools
     $ buildout bootstrap --buildout-version 2.9.5 --setuptools-version 36.6.0
@@ -58,33 +86,36 @@ Step 3: Run buildout::
 
 NOTES:
 
- * If you have issues with postgres or the python interface to it (psycogpg2)
-   you probably need to install postgresql via homebrew (as above)
+* If you have issues with postgres or the python interface to it (psycogpg2)
+  you probably need to install postgresql via homebrew (as above)
 
- * If you have issues with Pillow you may need to install new xcode command line tools.
+* If you have issues with Pillow you may need to install new xcode command line tools.
 
-   - First update Xcode from AppStore (reboot)::
+  - First update Xcode from AppStore (reboot)::
 
-       $ xcode-select --install
+      $ xcode-select --install
 
-   - If you are running macOS Mojave (though this is fixed in Catalina), you may need to run this command as well::
+  - If you are running macOS Mojave (though this is fixed in Catalina), you may need to run this command as well::
 
-       $ sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
+      $ sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
 
-   - If you have trouble with zlib, especially in Catalina, it is probably because brew installed it
-     in a different location. In that case, you'll want to do the following
-     in place of the regular call to buildout::
+  - If you have trouble with zlib, especially in Catalina, it is probably because brew installed it
+    in a different location. In that case, you'll want to do the following
+    in place of the regular call to buildout::
 
-       $ CFLAGS="-I$(brew --prefix zlib)/include" LDFLAGS="-L$(brew --prefix zlib)/lib" bin/buildout
+      $ CFLAGS="-I$(brew --prefix zlib)/include" LDFLAGS="-L$(brew --prefix zlib)/lib" bin/buildout
 
- * If you wish to completely rebuild the application, or have updated dependencies,
-   before you go ahead, you'll probably want to do::
+* If you wish to completely rebuild the application, or have updated dependencies,
+  before you go ahead, you'll probably want to do::
 
-     $ make clean
+    $ make clean
 
-   Then goto Step 3.
+  Then goto Step 3.
 
-Step 4: Start the application locally
+Step 4: Running the Application Locally
+---------------------------------------
+
+Start the application locally
 
 In one terminal startup the database servers and nginx proxy with::
 

--- a/src/encoded/tests/test_create_mapping.py
+++ b/src/encoded/tests/test_create_mapping.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from .datafixtures import ORDER
 from snovault import COLLECTIONS
 from encoded.types.experiment import *

--- a/src/encoded/tests/test_types_init_collections.py
+++ b/src/encoded/tests/test_types_init_collections.py
@@ -229,12 +229,10 @@ def test_tracking_item_display_title_google_analytic(google_analytics):
 
 
 def test_tracking_item_display_title_download(download_tracking):
-    from datetime import datetime
     assert download_tracking.get('display_title') == 'Download Tracking Item from ' + utc_today_str()
 
 
 def test_tracking_item_display_title_other(jupyterhub_session):
-    from datetime import datetime
     assert jupyterhub_session.get('display_title') == 'Tracking Item from ' + utc_today_str()
 
 

--- a/src/encoded/tests/test_types_init_collections.py
+++ b/src/encoded/tests/test_types_init_collections.py
@@ -1,5 +1,10 @@
+import datetime
 import pytest
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
+
+
+def utc_today_str():
+    return datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y-%m-%d")
 
 
 @pytest.fixture
@@ -68,10 +73,9 @@ def test_document_display_title_w_attachment(testapp, protocol_data, attachment)
 
 
 def test_document_display_title_wo_attachment(testapp, protocol_data):
-    from datetime import datetime
     del(protocol_data['protocol_type'])
     res = testapp.post_json('/document', protocol_data).json['@graph'][0]
-    assert res.get('display_title') == 'Document from ' + str(datetime.now())[:10]
+    assert res.get('display_title') == 'Document from ' + utc_today_str()
 
 
 def test_organism_display_title_standard_scientific_name(testapp, human_data):
@@ -113,16 +117,14 @@ def test_protocol_display_title_w_title(testapp, protocol_data, attachment):
 
 
 def test_protocol_display_title_wo_attachment(testapp, protocol_data):
-    from datetime import datetime
     protocol = testapp.post_json('/protocol', protocol_data).json['@graph'][0]
-    assert protocol['display_title'] == 'Experimental protocol from ' + str(datetime.now())[:10]
+    assert protocol['display_title'] == 'Experimental protocol from ' + utc_today_str()
 
 
 def test_protocol_other_display_title_wo_attachment(testapp, protocol_data):
-    from datetime import datetime
     protocol_data['protocol_type'] = 'Other'
     protocol = testapp.post_json('/protocol', protocol_data).json['@graph'][0]
-    assert protocol['display_title'] == 'Protocol from ' + str(datetime.now())[:10]
+    assert protocol['display_title'] == 'Protocol from ' + utc_today_str()
 
 
 @pytest.fixture
@@ -228,12 +230,12 @@ def test_tracking_item_display_title_google_analytic(google_analytics):
 
 def test_tracking_item_display_title_download(download_tracking):
     from datetime import datetime
-    assert download_tracking.get('display_title') == 'Download Tracking Item from ' + str(datetime.now())[:10]
+    assert download_tracking.get('display_title') == 'Download Tracking Item from ' + utc_today_str()
 
 
 def test_tracking_item_display_title_other(jupyterhub_session):
     from datetime import datetime
-    assert jupyterhub_session.get('display_title') == 'Tracking Item from ' + str(datetime.now())[:10]
+    assert jupyterhub_session.get('display_title') == 'Tracking Item from ' + utc_today_str()
 
 
 @pytest.fixture


### PR DESCRIPTION
* Some cosmetic and substantive changes to README.rst

  - Better section headings.
  - Better choice of when something is an RST code block. (PyCharm really helped to debug this.)
  - Add substantive notes about how to repair various kinds of problems such a JDK issues, zlib issues, and various brew issues.
  - Be more careful about suggesting `brew upgrade`.

* Fix an import in test_create_mapping.py since it was failing locally for Kent (maybe a Python 3.4 vs 3.5 issue?)

* In test_types_init_collections, fix some uses of `datetime.datetime.now` that needed to be `datetime.datetime.utcnow`. At the same time, use more abstract operations to extract the date, not string operations, and factor out some imports to the top of the file.

