### PR TITLE
Added pre-release to `canDownloadStatuses` list in file.js utils

### DIFF
--- a/src/encoded/static/components/util/file.js
+++ b/src/encoded/static/components/util/file.js
@@ -45,6 +45,7 @@ export function FileDownloadButtonAuto(props){
 FileDownloadButtonAuto.defaultProps = {
     'canDownloadStatuses' : [
         'uploaded',
+        'pre-release',
         'released',
         'replaced',
         'submission in progress',


### PR DESCRIPTION
Currently uploaded and released statuses have a Download button on
file page, but others have a button that says Not Ready for Download.
Doesn't make sense to indicate as Downloadable on uploaded but not
pre-release, so Download button now also appears on pre-release.