### PR TITLE
quick tweak to facet of biosource cell to use preferred_name rather t…

### DIFF
--- a/src/encoded/schemas/biosource.json
+++ b/src/encoded/schemas/biosource.json
@@ -136,10 +136,10 @@
         "biosource_type": {
             "title": "Biosource Type"
         },
-        "cell_line.term_name": {
+        "cell_line.preferred_name": {
             "title": "Cells"
         },
-        "tissue.term_name": {
+        "tissue.preferred_name": {
             "title": "Tissue"
         },
         "individual.organism.name": {


### PR DESCRIPTION
The biosample cell facet was using term_name rather than preferred_name so WTC-11 was not showing up in the facet. Fixed.