### PR TITLE
Use relative imports for encoded.

### DIFF
--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -33,7 +33,7 @@ from snovault.app import (
 )
 from dcicutils.log_utils import set_logging
 from dcicutils.beanstalk_utils import whodaman as _whodaman  # don't export
-from encoded.commands.create_mapping_on_deploy import (
+from .commands.create_mapping_on_deploy import (
     ENV_WEBPROD,
     ENV_WEBPROD2,
     BEANSTALK_PROD_ENVS,

--- a/src/encoded/commands/clear_db_es_contents.py
+++ b/src/encoded/commands/clear_db_es_contents.py
@@ -1,12 +1,16 @@
 import argparse
 import logging
 import structlog
+
 from pyramid.paster import get_app
-from encoded import configure_dbsession
-from snovault.elasticsearch.create_mapping import run as run_create_mapping
 from snovault import DBSESSION
+from snovault.elasticsearch.create_mapping import run as run_create_mapping
+from .. import configure_dbsession
+
 
 log = structlog.getLogger(__name__)
+
+
 EPILOG = __doc__
 
 

--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -1,15 +1,25 @@
+import boto3
+import datetime
 import os
 import json
 import sys
 import argparse
 import re
-from dateutil.relativedelta import relativedelta
-import datetime
-import boto3
-from uuid import uuid4
+import requests
+
 from collections import Counter
+from dateutil.relativedelta import relativedelta
+from dcicutils.ff_utils import (
+    get_authentication_with_server,
+    get_metadata,
+    search_metadata,
+    unified_authentication
+)
+from dcicutils.s3_utils import s3Utils
+from pyramid.paster import get_app
 from rdflib.collection import Collection
-from encoded.commands.owltools import (
+from uuid import uuid4
+from ..commands.owltools import (
     Namespace,
     Owler,
     OBO,
@@ -24,15 +34,7 @@ from encoded.commands.owltools import (
     OnProperty,
     Deprecated
 )
-from dcicutils.ff_utils import (
-    get_authentication_with_server,
-    get_metadata,
-    search_metadata,
-    unified_authentication
-)
-from dcicutils.s3_utils import s3Utils
-import requests
-from pyramid.paster import get_app
+
 
 EPILOG = __doc__
 

--- a/src/encoded/commands/load_data.py
+++ b/src/encoded/commands/load_data.py
@@ -1,11 +1,15 @@
 import argparse
 import logging
 import structlog
-from pyramid.path import DottedNameResolver
+
 from pyramid.paster import get_app
-from encoded import configure_dbsession
+from pyramid.path import DottedNameResolver
+from .. import configure_dbsession
+
 
 log = structlog.getLogger(__name__)
+
+
 EPILOG = __doc__
 
 

--- a/src/encoded/commands/verify_item.py
+++ b/src/encoded/commands/verify_item.py
@@ -1,7 +1,10 @@
-from pyramid.paster import get_app
+import argparse
 import logging
+
+from pyramid.paster import get_app
 from webtest import TestApp
-from encoded.verifier import verify_item
+from ..verifier import verify_item
+
 
 EPILOG = __doc__
 
@@ -27,7 +30,6 @@ def run(app, uuids=None):
 def main():
     ''' Verifies and item against database / ES and checks embeds '''
 
-    import argparse
     parser = argparse.ArgumentParser(
         description="Verifies and item against database / ES and checks embeds", epilog=EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -1,18 +1,21 @@
 # -*- coding: utf-8 -*-
 """Load collections and determine the order."""
-import mimetypes
-import structlog
-import magic
+
 import json
+import magic
+import mimetypes
 import os
-from snovault.util import debug_log
+import structlog
+
+from base64 import b64encode
 from past.builtins import basestring
-from pyramid.view import view_config
+from PIL import Image
 from pyramid.paster import get_app
 from pyramid.response import Response
-from encoded.server_defaults import add_last_modified
-from base64 import b64encode
-from PIL import Image
+from pyramid.view import view_config
+from snovault.util import debug_log
+from .server_defaults import add_last_modified
+
 
 text = type(u'')
 logger = structlog.getLogger(__name__)

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -6,15 +6,12 @@ import logging
 import pytest
 import webtest
 
-from encoded import main
-
 from pyramid.request import apply_request_extensions
 from pyramid.testing import DummyRequest, setUp, tearDown
 from pyramid.threadlocal import get_current_registry, manager as threadlocal_manager
-
 from snovault import DBSESSION, ROOT, UPGRADER
 from snovault.elasticsearch import ELASTIC_SEARCH
-
+from .. import main
 from .conftest_settings import make_app_settings_dictionary
 
 

--- a/src/encoded/tests/test_access_key.py
+++ b/src/encoded/tests/test_access_key.py
@@ -1,10 +1,15 @@
 import pytest
+
+from base64 import b64encode
+from pyramid.compat import ascii_native_
+from snovault import COLLECTIONS
+from ..edw_hash import EDWHash
+
+
 pytestmark = [pytest.mark.working, pytest.mark.setone]
 
 
 def basic_auth(username, password):
-    from base64 import b64encode
-    from pyramid.compat import ascii_native_
     return 'Basic ' + ascii_native_(b64encode(('%s:%s' % (username, password)).encode('utf-8')))
 
 
@@ -164,8 +169,6 @@ def test_access_key_view_hides_secret_access_key_hash(testapp, access_key, frame
 
 
 def test_access_key_uses_edw_hash(app, access_key):
-    from encoded.edw_hash import EDWHash
-    from snovault import COLLECTIONS
     root = app.registry[COLLECTIONS]
     obj = root.by_item_type['access_key'][access_key['access_key_id']]
     pwhash = obj.properties['secret_access_key_hash']

--- a/src/encoded/tests/test_auth0.py
+++ b/src/encoded/tests/test_auth0.py
@@ -1,8 +1,10 @@
+import os
 import pytest
 import requests
-import os
+
+from ..authentication import get_jwt
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
-from encoded.authentication import get_jwt
 
 
 @pytest.fixture(scope='session')

--- a/src/encoded/tests/test_authentication.py
+++ b/src/encoded/tests/test_authentication.py
@@ -1,6 +1,13 @@
-import unittest
-from pyramid.testing import DummyRequest
 import pytest
+import unittest
+
+from ..authentication import NamespacedAuthenticationPolicy
+from pyramid.interfaces import IAuthenticationPolicy
+from pyramid.security import Authenticated, Everyone
+from pyramid.testing import DummyRequest
+from zope.interface.verify import verifyClass, verifyObject
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
@@ -8,7 +15,6 @@ class TestNamespacedAuthenticationPolicy(unittest.TestCase):
     """ This is a modified version of TestRemoteUserAuthenticationPolicy
     """
     def _getTargetClass(self):
-        from encoded.authentication import NamespacedAuthenticationPolicy
         return NamespacedAuthenticationPolicy
 
     def _makeOne(self, namespace='user',
@@ -17,14 +23,10 @@ class TestNamespacedAuthenticationPolicy(unittest.TestCase):
         return self._getTargetClass()(namespace, base, *args, **kw)
 
     def test_class_implements_IAuthenticationPolicy(self):
-        from zope.interface.verify import verifyClass
-        from pyramid.interfaces import IAuthenticationPolicy
         klass = self._makeOne().__class__
         verifyClass(IAuthenticationPolicy, klass)
 
     def test_instance_implements_IAuthenticationPolicy(self):
-        from zope.interface.verify import verifyObject
-        from pyramid.interfaces import IAuthenticationPolicy
         verifyObject(IAuthenticationPolicy, self._makeOne())
 
     def test_unauthenticated_userid_returns_None(self):
@@ -48,14 +50,11 @@ class TestNamespacedAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.authenticated_userid(request), 'user.fred')
 
     def test_effective_principals_None(self):
-        from pyramid.security import Everyone
         request = DummyRequest(environ={})
         policy = self._makeOne()
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
         request = DummyRequest(environ={'REMOTE_USER':'fred'})
         policy = self._makeOne()
         self.assertEqual(policy.effective_principals(request),

--- a/src/encoded/tests/test_clear_db_es_contents.py
+++ b/src/encoded/tests/test_clear_db_es_contents.py
@@ -1,8 +1,10 @@
 import pytest
-from encoded.commands.clear_db_es_contents import (
+
+from ..commands.clear_db_es_contents import (
     clear_db_tables,
     run_clear_db_es
 )
+
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 

--- a/src/encoded/tests/test_create_mapping.py
+++ b/src/encoded/tests/test_create_mapping.py
@@ -1,10 +1,14 @@
 import pytest
-from unittest.mock import patch, MagicMock
-from .datafixtures import ORDER
+
 from snovault import COLLECTIONS
-from encoded.types.experiment import *
-from encoded.commands.create_mapping_on_deploy import ITEM_INDEX_ORDER
-from encoded.commands.create_mapping_on_deploy import get_deployment_config
+from unittest.mock import patch, MagicMock
+from ..commands.create_mapping_on_deploy import ITEM_INDEX_ORDER
+from ..commands.create_mapping_on_deploy import get_deployment_config
+# TODO: We should not be importing *. Even stranger, PyCharm says we don't use anything from there. -kmp 14-Feb-2020
+from ..types.experiment import *
+from .datafixtures import ORDER
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 

--- a/src/encoded/tests/test_edw_hash.py
+++ b/src/encoded/tests/test_edw_hash.py
@@ -1,4 +1,8 @@
 import pytest
+
+from ..edw_hash import EDWHash
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
@@ -11,5 +15,4 @@ TEST_HASHES = {
 
 @pytest.mark.parametrize(('password', 'pwhash'), TEST_HASHES.items())
 def test_edw_hash(password, pwhash):
-    from encoded.edw_hash import EDWHash
     assert EDWHash.encrypt(password) == pwhash

--- a/src/encoded/tests/test_embedding.py
+++ b/src/encoded/tests/test_embedding.py
@@ -1,7 +1,13 @@
 import pytest
+
+from snovault import TYPES
+from snovault.util import add_default_embeds, crawl_schemas_by_embeds
+from ..types.base import get_item_if_you_can
 from .datafixtures import ORDER
 
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
+
 
 targets = [
     {'name': 'one', 'uuid': '775795d3-4410-4114-836b-8eeecf1d0c2f'},
@@ -86,8 +92,6 @@ def test_add_default_embeds(registry, item_type):
     """
     Ensure default embedding matches the schema for each object
     """
-    from snovault.util import add_default_embeds, crawl_schemas_by_embeds
-    from snovault import TYPES
     type_info = registry[TYPES].by_item_type[item_type]
     schema = type_info.schema
     embeds = add_default_embeds(item_type, registry[TYPES], type_info.embedded_list, schema)
@@ -107,8 +111,6 @@ def test_manual_embeds(registry, item_type):
     """
     Ensure manual embedding in the types files are valid
     """
-    from snovault.util import crawl_schemas_by_embeds
-    from snovault import TYPES
     type_info = registry[TYPES].by_item_type[item_type]
     schema = type_info.schema
     embeds = type_info.embedded_list
@@ -126,8 +128,6 @@ def test_fictitous_embed(registry):
     the organism subpath should be in the added_embeds even though it is
     not a terminal object
     """
-    from snovault.util import crawl_schemas_by_embeds
-    from snovault import TYPES
     type_info = registry[TYPES].by_item_type['biosample']
     schema = type_info.schema
     embed = 'biosource.individual.organism.name'
@@ -144,7 +144,6 @@ def test_get_item_if_you_can(content, dummy_request, threadlocals):
     Not necessarily the best place for this test, but test that the
     `get_item_if_you_can` function works with multiple inputs
     """
-    from encoded.types.base import get_item_if_you_can
     used_item = sources[0]
     # all of these should get the full item
     res1 = get_item_if_you_can(dummy_request, used_item)

--- a/src/encoded/tests/test_file.py
+++ b/src/encoded/tests/test_file.py
@@ -1,8 +1,14 @@
-import pytest
-from encoded.types.file import FileFastq, post_upload
-from pyramid.httpexceptions import HTTPForbidden
-import os
 import boto3
+import os
+import pytest
+import tempfile
+
+from pyramid.httpexceptions import HTTPForbidden
+from .. import source_beanstalk_env_vars
+from ..types.file import FileFastq, post_upload
+from ..types.file import external_creds
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
@@ -439,7 +445,6 @@ def test_file_post_fastq_related(testapp, fastq_json, fastq_related_file):
 def test_external_creds(mocker):
     mocker.patch('encoded.types.file.boto3', autospec=True)
 
-    from encoded.types.file import external_creds
     ret = external_creds('test-wfout-bucket', 'test-key', 'name')
     assert ret['key'] == 'test-key'
     assert ret['bucket'] == 'test-wfout-bucket'
@@ -616,8 +621,6 @@ def test_force_beanstalk_env(mocker):
     This test is a bit outdated, since env variable loading has moved to
     application __init__ from file.py. But let's keep the test...
     """
-    import tempfile
-    from encoded import source_beanstalk_env_vars
     secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
     key = os.environ.get("AWS_ACCESS_KEY_ID")
     os.environ.pop("AWS_SECRET_ACCESS_KEY")

--- a/src/encoded/tests/test_generate_ontology.py
+++ b/src/encoded/tests/test_generate_ontology.py
@@ -1,7 +1,13 @@
+import json
 import os
 import pytest
+
 from collections import OrderedDict
-from encoded.commands import generate_ontology as go
+from rdflib import URIRef
+from ..commands import generate_ontology as go
+from ..commands.owltools import Owler
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
@@ -337,7 +343,6 @@ def test_remove_obsoletes_and_unnamed_obsoletes(terms):
 
 
 def check_if_URIRef(uri):
-    from rdflib import URIRef
     return isinstance(uri, URIRef)
 
 
@@ -659,25 +664,21 @@ def test_get_termid_from_uri_funky_uri2():
 
 @pytest.fixture
 def uberon_owler():
-    from encoded.commands.owltools import Owler
     return Owler('src/encoded/tests/data/documents/test_uberon.owl')
 
 
 @pytest.fixture
 def uberon_owler2():
-    from encoded.commands.owltools import Owler
     return Owler('src/encoded/tests/data/documents/test_uberon2.owl')
 
 
 @pytest.fixture
 def uberon_owler3():
-    from encoded.commands.owltools import Owler
     return Owler('src/encoded/tests/data/documents/test_uberon3.owl')
 
 
 @pytest.fixture
 def uberon_owler4():
-    from encoded.commands.owltools import Owler
     return Owler('src/encoded/tests/data/documents/test_uberon4.owl')
 
 
@@ -883,7 +884,6 @@ def test_add_additional_term_info(mocker, simple_terms):
 
 
 def test_write_outfile_pretty(simple_terms):
-    import json
     filename = 'tmp_test_file'
     go.write_outfile(list(simple_terms.values()), filename, pretty=True)
     infile = open(filename, 'r')
@@ -897,7 +897,6 @@ def test_write_outfile_pretty(simple_terms):
 def test_write_outfile_notpretty(simple_terms):
     # import pdb; pdb.set_trace()
     print(simple_terms)
-    import json
     filename = 'tmp_test_file'
     go.write_outfile(list(simple_terms.values()), filename)
     with open(filename, 'r') as infile:

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -14,10 +14,6 @@ import transaction
 import uuid
 
 from elasticsearch.exceptions import NotFoundError
-
-from encoded import main
-from encoded.verifier import verify_item
-
 from snovault import DBSESSION, TYPES
 from snovault.elasticsearch import create_mapping, ELASTIC_SEARCH
 from snovault.elasticsearch.create_mapping import (
@@ -28,16 +24,13 @@ from snovault.elasticsearch.create_mapping import (
 )
 from snovault.elasticsearch.interfaces import INDEXER_QUEUE
 from snovault.elasticsearch.indexer_utils import get_namespaced_index
-
 from sqlalchemy import MetaData
-
 from timeit import default_timer as timer
-
 from unittest import mock
-
 from zope.sqlalchemy import mark_changed
-
+from .. import main
 from ..utils import delay_rerun
+from ..verifier import verify_item
 from .workbook_fixtures import app_settings
 
 

--- a/src/encoded/tests/test_init.py
+++ b/src/encoded/tests/test_init.py
@@ -1,10 +1,11 @@
 import pytest
-from encoded.commands.create_mapping_on_deploy import (
+
+from .. import get_mirror_env
+from ..commands.create_mapping_on_deploy import (
     ENV_WEBPROD,
     ENV_WEBPROD2,
     ENV_MASTERTEST,
 )
-from encoded import get_mirror_env
 
 
 pytestmark = pytest.mark.working

--- a/src/encoded/tests/test_inserts.py
+++ b/src/encoded/tests/test_inserts.py
@@ -1,6 +1,9 @@
 import pytest
+
+from ..commands.run_upgrader_on_inserts import get_inserts
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
-from encoded.commands.run_upgrader_on_inserts import get_inserts
 
 
 def test_check_wf_links():

--- a/src/encoded/tests/test_load_access_key.py
+++ b/src/encoded/tests/test_load_access_key.py
@@ -1,6 +1,8 @@
 import pytest
+
 from unittest import mock
-from encoded.commands.load_access_keys import generate_access_key
+from ..commands.load_access_keys import generate_access_key
+
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 

--- a/src/encoded/tests/test_loadxl.py
+++ b/src/encoded/tests/test_loadxl.py
@@ -1,10 +1,12 @@
 import pytest
-from encoded import loadxl
 import json
-from unittest import mock
+
 from past.builtins import basestring
 from pkg_resources import resource_filename
-from encoded.commands.run_upgrader_on_inserts import get_inserts
+from unittest import mock
+from .. import loadxl
+from ..commands.run_upgrader_on_inserts import get_inserts
+
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 

--- a/src/encoded/tests/test_owltools.py
+++ b/src/encoded/tests/test_owltools.py
@@ -1,7 +1,11 @@
 import pytest
+
+from rdflib import RDFS, BNode, URIRef, Literal
+from ..commands import owltools as ot
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
-from rdflib import RDFS, BNode, URIRef
-from encoded.commands import owltools as ot
+
 
 
 @pytest.fixture
@@ -21,21 +25,18 @@ def owler(mocker):
 
 @pytest.fixture
 def rdf_objects():
-    from rdflib import Literal
     rdfobjs = ['testrdfobj1', 'testrdfobj2']
     return [Literal(rdfobj) for rdfobj in rdfobjs]
 
 
 @pytest.fixture
 def rdf_objects_2_1():
-    from rdflib import Literal
     rdfobjs = ['testrdfobj1']
     return [Literal(rdfobj) for rdfobj in rdfobjs]
 
 
 @pytest.fixture
 def rdf_objects_2_3():
-    from rdflib import Literal
     rdfobjs = ['testrdfobj1', 'testrdfobj2', 'testrdfobj3']
     return [Literal(rdfobj) for rdfobj in rdfobjs]
 

--- a/src/encoded/tests/test_permissions.py
+++ b/src/encoded/tests/test_permissions.py
@@ -1,8 +1,13 @@
 import pytest
-pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
+import webtest
 
 from datetime import date
 from urllib.parse import urlencode
+from ..types.lab import Lab
+
+
+pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
+
 
 
 @pytest.fixture
@@ -149,12 +154,11 @@ def remc_submitter(testapp, remc_lab, remc_award):
 
 
 def remote_user_testapp(app, remote_user):
-    from webtest import TestApp
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'REMOTE_USER': str(remote_user),
     }
-    return TestApp(app, environ)
+    return webtest.TestApp(app, environ)
 
 
 @pytest.fixture
@@ -879,7 +883,6 @@ def test_wrangler_can_edit_lab_name_or_title(lab, submitter_testapp, wrangler_te
 
 
 def test_ac_local_roles_for_lab(registry):
-    from encoded.types.lab import Lab
     lab_data = {
         'status': 'in review by lab',
         'award': 'b0b9c607-bbbb-4f02-93f4-9895baa1334b',

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -2,8 +2,11 @@ import json
 import pytest
 import time
 
+from datetime import datetime, timedelta
 from snovault import TYPES, COLLECTIONS
+from snovault.elasticsearch import create_mapping
 from snovault.elasticsearch.indexer_utils import get_namespaced_index
+from snovault.util import add_default_embeds
 from ..commands.run_upgrader_on_inserts import get_inserts
 # Use workbook fixture from BDD tests (including elasticsearch)
 from .workbook_fixtures import app_settings, app, workbook
@@ -201,7 +204,6 @@ def test_search_embedded_file_by_accession(workbook, testapp):
 def mboI_dts(testapp, workbook):
     # returns a dictionary of strings of various date and datetimes
     # relative to the creation date of the mboI one object in test inserts
-    from datetime import (datetime, timedelta)
     enz = testapp.get('/search/?type=Enzyme&name=MboI').json['@graph'][0]
 
     cdate = enz['date_created']
@@ -388,8 +390,6 @@ def test_metadata_tsv_view(workbook, htmltestapp):
 
 
 def test_default_schema_and_non_schema_facets(workbook, testapp, registry):
-    from snovault import TYPES
-    from snovault.util import add_default_embeds
     test_type = 'biosample'
     type_info = registry[TYPES].by_item_type[test_type]
     schema = type_info.schema
@@ -511,7 +511,6 @@ def test_collection_actions_filtered_by_permission(workbook, testapp, anontestap
 
 
 def test_index_data_workbook(app, workbook, testapp, indexer_testapp, htmltestapp):
-    from snovault.elasticsearch import create_mapping
     es = app.registry['elasticsearch']
     # we need to reindex the collections to make sure numbers are correct
     create_mapping.run(app, sync_index=True)

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -7,10 +7,15 @@ from snovault.elasticsearch.indexer_utils import get_namespaced_index
 from ..commands.run_upgrader_on_inserts import get_inserts
 # Use workbook fixture from BDD tests (including elasticsearch)
 from .workbook_fixtures import app_settings, app, workbook
-from ..utils import delay_rerun
+from ..utils import customized_delay_rerun
 
 
-pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing] #pytest.mark.flaky(rerun_filter=delay_rerun)]
+pytestmark = [
+    pytest.mark.working,
+    pytest.mark.schema,
+    pytest.mark.indexing,
+    pytest.mark.flaky(rerun_filter=customized_delay_rerun(sleep_seconds=10))
+]
 
 
 ### IMPORTANT

--- a/src/encoded/tests/test_search.py
+++ b/src/encoded/tests/test_search.py
@@ -1,19 +1,17 @@
+import json
+import pytest
+import time
+
+from snovault import TYPES, COLLECTIONS
+from snovault.elasticsearch.indexer_utils import get_namespaced_index
+from ..commands.run_upgrader_on_inserts import get_inserts
 # Use workbook fixture from BDD tests (including elasticsearch)
 from .workbook_fixtures import app_settings, app, workbook
-import pytest
-from encoded.commands.run_upgrader_on_inserts import get_inserts
-from snovault.elasticsearch.indexer_utils import get_namespaced_index
-import json
-import time
-from snovault import TYPES, COLLECTIONS
-
-def delay_rerun(*args):
-    """ Rerun function for flaky """
-    time.sleep(1)
-    return True
+from ..utils import delay_rerun
 
 
 pytestmark = [pytest.mark.working, pytest.mark.schema, pytest.mark.indexing] #pytest.mark.flaky(rerun_filter=delay_rerun)]
+
 
 ### IMPORTANT
 # uses the inserts in ./data/workbook_inserts

--- a/src/encoded/tests/test_server_defaults.py
+++ b/src/encoded/tests/test_server_defaults.py
@@ -1,6 +1,11 @@
-from pytest import fixture
 import pytest
+import webtest
+
+from .. import main
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
+
 
 def test_server_defaults(admin, anontestapp):
     email = admin['email']
@@ -20,23 +25,21 @@ def test_server_defaults(admin, anontestapp):
     )
 
 
-@fixture(scope='session')
+@pytest.fixture(scope='session')
 def test_accession_app(request, check_constraints, zsa_savepoints, app_settings):
-    from encoded import main
     app_settings = app_settings.copy()
     app_settings['accession_factory'] = 'encoded.server_defaults.test_accession'
     return main({}, **app_settings)
 
 
-@fixture
+@pytest.fixture
 def test_accession_anontestapp(request, test_accession_app, external_tx, zsa_savepoints):
     '''TestApp with JSON accept header.
     '''
-    from webtest import TestApp
     environ = {
         'HTTP_ACCEPT': 'application/json',
     }
-    return TestApp(test_accession_app, environ)
+    return webtest.TestApp(test_accession_app, environ)
 
 
 def test_test_accession_server_defaults(admin, test_accession_anontestapp):

--- a/src/encoded/tests/test_types_experiment.py
+++ b/src/encoded/tests/test_types_experiment.py
@@ -1,9 +1,18 @@
-import pytest
+"""
+
+Tests for both experiment.py and experiment_set.py
+
+"""
+
 import datetime
-from encoded.types.experiment import ExperimentHiC
+import pytest
+from snovault import TYPES
 # from snovault.storage import UUID
+from uuid import uuid4
+from ..types.experiment import ExperimentHiC
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working]
-'''Has tests for both experiment.py and experiment_set.py'''
 
 
 @pytest.fixture
@@ -161,7 +170,6 @@ def test_experiment_set_replicate_update_adds_experiments_in_set(testapp, experi
 # test for default_embedding practice with embedded list
 # this test should change should any of the reference embeds below be altered
 def test_experiment_set_default_embedded_list(registry, exp_types):
-    from snovault import TYPES
     exp_data = {
         'experiment_type': exp_types['microc']['uuid'],
         'status': 'in review by lab'
@@ -836,7 +844,6 @@ def test_experiment_categorizer_cap_c_w_2regions(
 
 @pytest.fixture
 def new_exp_type(lab, award):
-    from uuid import uuid4
     data = {
         'uuid': str(uuid4()),
         'title': 'Title',

--- a/src/encoded/tests/test_types_gene.py
+++ b/src/encoded/tests/test_types_gene.py
@@ -1,9 +1,12 @@
 import pytest
-from encoded.types.gene import (
+
+from ..types.gene import (
     fetch_gene_info_from_ncbi,
     get_gene_info_from_response_text,
     map_ncbi2schema,
 )
+
+
 pytestmark = [pytest.mark.working, pytest.mark.schema]
 
 

--- a/src/encoded/tests/test_types_init_collections.py
+++ b/src/encoded/tests/test_types_init_collections.py
@@ -1,6 +1,9 @@
 import pytest
-from encoded.types.image import Image
+
+from ..types.image import Image
 from ..utils import utc_today_str
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
 

--- a/src/encoded/tests/test_types_publication.py
+++ b/src/encoded/tests/test_types_publication.py
@@ -1,5 +1,8 @@
 import pytest
-from encoded.types.publication import find_best_date
+
+from ..types.publication import find_best_date
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
 

--- a/src/encoded/tests/test_types_tracking_item.py
+++ b/src/encoded/tests/test_types_tracking_item.py
@@ -1,7 +1,10 @@
 import pytest
-from encoded.types import TrackingItem
-pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
+# Code that uses this is commented-out below.
+# from ..types import TrackingItem
+
+
+pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
 
 @pytest.fixture

--- a/src/encoded/tests/test_types_user.py
+++ b/src/encoded/tests/test_types_user.py
@@ -1,5 +1,8 @@
 import pytest
-from encoded.types.user import User
+
+from ..types.user import User
+
+
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
 @pytest.fixture

--- a/src/encoded/tests/test_utils.py
+++ b/src/encoded/tests/test_utils.py
@@ -2,7 +2,7 @@ import datetime
 import pytest
 import re
 
-from encoded.utils import compute_set_difference_one, find_other_in_pair, delay_rerun, utc_today_str
+from ..utils import compute_set_difference_one, find_other_in_pair, delay_rerun, utc_today_str
 
 
 pytestmark = pytest.mark.working

--- a/src/encoded/tests/test_utils.py
+++ b/src/encoded/tests/test_utils.py
@@ -2,7 +2,7 @@ import datetime
 import pytest
 import re
 
-from ..utils import compute_set_difference_one, find_other_in_pair, delay_rerun, utc_today_str
+from ..utils import compute_set_difference_one, find_other_in_pair, delay_rerun, utc_today_str, customized_delay_rerun
 
 
 pytestmark = pytest.mark.working
@@ -45,11 +45,25 @@ def test_find_other_in_pair():
         find_other_in_pair(None, lst)
 
 
+DELAY_FUZZ_SECONDS = 0.1
+
 def test_delay_rerun():
+    expected_delay = 1.0
     t0 = datetime.datetime.now()
     delay_rerun()
     t1 = datetime.datetime.now()
-    assert (t1 - t0).total_seconds() > 1
+    assert (t1 - t0).total_seconds() > expected_delay
+    assert (t1 - t0).total_seconds() < expected_delay + DELAY_FUZZ_SECONDS
+
+
+def test_customize_delay_rerun():
+    custom_delay = 0.5
+    half_delay_rerun = customized_delay_rerun(sleep_seconds=custom_delay)
+    t0 = datetime.datetime.now()
+    half_delay_rerun()
+    t1 = datetime.datetime.now()
+    assert (t1 - t0).total_seconds() > custom_delay
+    assert (t1 - t0).total_seconds() < custom_delay + DELAY_FUZZ_SECONDS
 
 
 def test_utc_today_str():

--- a/src/encoded/tests/test_validation_errors.py
+++ b/src/encoded/tests/test_validation_errors.py
@@ -1,7 +1,7 @@
 import pytest
 
 from .workbook_fixtures import app_settings, workbook
-from .test_search import delay_rerun
+from ..utils import delay_rerun
 
 
 pytestmark = [

--- a/src/encoded/tests/workbook_fixtures.py
+++ b/src/encoded/tests/workbook_fixtures.py
@@ -3,13 +3,10 @@ import pkg_resources
 import pytest
 import webtest
 
-from encoded import main
-
 from snovault import DBSESSION
 from snovault.elasticsearch import create_mapping
-
+from .. import main
 from ..loadxl import load_all
-
 from .conftest_settings import make_app_settings_dictionary
 
 

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -21,7 +21,7 @@ from snovault.validators import (
     validate_item_content_patch
 )
 from snovault.interfaces import CONNECTION
-from encoded.server_defaults import get_userid, add_last_modified
+from ..server_defaults import get_userid, add_last_modified
 from jsonschema_serialize_fork import NO_DEFAULT
 
 from datetime import date

--- a/src/encoded/types/page.py
+++ b/src/encoded/types/page.py
@@ -20,7 +20,7 @@ from snovault import (
     COLLECTIONS,
     CONNECTION
 )
-from encoded.search import get_iterable_search_results
+from ..search import get_iterable_search_results
 from .base import (
     Item,
     ALLOW_CURRENT, DELETED, ALLOW_LAB_SUBMITTER_EDIT, ALLOW_VIEWING_GROUP_VIEW, ONLY_ADMIN_VIEW

--- a/src/encoded/upgrade/page.py
+++ b/src/encoded/upgrade/page.py
@@ -1,9 +1,8 @@
-from snovault import (
-    upgrade_step,
-)
 import json
-from encoded.schema_formats import is_uuid
+
+from snovault import upgrade_step
 from pkg_resources import resource_filename
+from ..schema_formats import is_uuid
 
 
 def generate_content_map_for_page_1_2_upgrader():

--- a/src/encoded/upgrade/workflow.py
+++ b/src/encoded/upgrade/workflow.py
@@ -1,7 +1,5 @@
-from snovault import (
-    upgrade_step,
-)
-from encoded.schema_formats import is_uuid
+from snovault import upgrade_step
+from ..schema_formats import is_uuid
 
 
 @upgrade_step('workflow', '1', '2')

--- a/src/encoded/utils.py
+++ b/src/encoded/utils.py
@@ -31,10 +31,15 @@ def find_other_in_pair(element, pair):
     return compute_set_difference_one(set(pair), {element})
 
 
-def delay_rerun(*args):
-    """ Rerun function for flaky """
-    time.sleep(1)
-    return True
+def customized_delay_rerun(sleep_seconds=1):
+    def parameterized_delay_rerun(*args):
+        """ Rerun function for flaky """
+        time.sleep(sleep_seconds)
+        return True
+    return parameterized_delay_rerun
+
+
+delay_rerun = customized_delay_rerun(sleep_seconds=1)
 
 
 def utc_today_str():

--- a/src/encoded/verifier.py
+++ b/src/encoded/verifier.py
@@ -1,4 +1,10 @@
 from functools import wraps
+from snovault import TYPES
+
+# TODO: Production code should not depend on tests. -kmp 14-Feb-2020
+from .tests.test_create_mapping import test_create_mapping
+from .tests.test_embedding import test_add_default_embeds, test_manual_embeds
+from .tests.test_schemas import master_mixins, test_load_schema
 
 
 def verifier(func):
@@ -52,13 +58,11 @@ def verify_profile(item_type, indexer_testapp):
 @verifier
 def verify_schema(item_type_camel, registry):
     # test schema
-    from encoded.tests.test_schemas import master_mixins, test_load_schema
     test_load_schema(item_type_camel + ".json", master_mixins(), registry)
 
 
 @verifier
 def verify_can_embed(item_type_camel, es_item, indexer_testapp, registry):
-    from snovault import TYPES
     # get the embedds
     pyr_item_type = registry[TYPES].by_item_type[item_type_camel]
     embeds = pyr_item_type.embedded
@@ -77,14 +81,12 @@ def verify_indexing(item_uuid, indexer_testapp):
 
 @verifier
 def verify_embeds(registry, item_type):
-    from encoded.tests.test_embedding import test_add_default_embeds, test_manual_embeds
     test_add_default_embeds(registry, item_type)
     test_manual_embeds(registry, item_type)
 
 
 @verifier
 def verify_mapping(registry, item_type):
-    from encoded.tests.test_create_mapping import test_create_mapping
     test_create_mapping(registry, item_type)
 
 


### PR DESCRIPTION
A step on the way to poetry. This uses relative imports rather than absolute imports for encoded.