### PR TITLE
C4-49 small associated perf fix

### DIFF
--- a/src/encoded/search.py
+++ b/src/encoded/search.py
@@ -261,7 +261,7 @@ def collection_view(context, request):
 
 def get_collection_actions(request, type_info):
     collection = request.registry[COLLECTIONS].get(type_info.name)
-    if collection and hasattr(collection, 'actions'):
+    if hasattr(collection, 'actions'):
         return collection.actions(request)
     else:
         return None


### PR DESCRIPTION
- Do not run `if collection` as this runs `__len__` on the collection and is very expensive. `hasattr` is sufficient.