### PR TITLE
changes to owltools to parse version from SO versionIRI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.2.0"
+version = "1.2.1"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/owltools.py
+++ b/src/encoded/commands/owltools.py
@@ -1,3 +1,4 @@
+import re
 from rdflib import ConjunctiveGraph, exceptions, Namespace
 from rdflib import RDFS, RDF, BNode, URIRef
 from rdflib.collection import Collection
@@ -160,7 +161,11 @@ class Owler(object):
                 if 'releases' in v:
                     v = v[v.index('releases') + 1]
                 else:
-                    v = uris[0]
+                    match = re.search('(20)?([0-9]{2})-[0-9]{2}-(20)?[0-9]{2}', uris[0])
+                    if match:
+                        v = match.group()
+                    else:
+                        v = uris[0]
                 if return_as_string:
                     return str(v)
                 else:


### PR DESCRIPTION
**Issue:** Sequence Ontology version not being parsed properly by owltools

**In this PR:**
Change in `__get_OntologyVersion` method in owltools to parse date out of versionIRI string (when 'releases' substring is not present)