### PR TITLE
Avoid scaling of gene annotation tracks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.2.4"
+version = "1.2.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.2.2"
+version = "1.2.3"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassAjaxLoadContainer.js
@@ -57,14 +57,21 @@ export class HiGlassAjaxLoadContainer extends React.PureComponent {
                 scaledHeightFor1DTracks = (heightPerView / 3) | 0;
             }
 
+            const tracksEligibleForScaling = _.filter(view["tracks"]["top"], function(track) { 
+                // Don't scale gene annotation tracks, they need to be completely visible
+                return (("height" in track) && track["type"] !== "horizontal-gene-annotations");
+            });
+
+            if (tracksEligibleForScaling.length === 0) { return; }
+
             const sumOfOriginal1DTracks = _.reduce(
-                _.filter(view["tracks"]["top"], function(track) { return ("height" in track);}),
+                tracksEligibleForScaling,
                 function(memo, track) { return memo + track["height"];},
                 0
             );
             // Resize each 1D track to fit the given display height (round to the nearest integer so Higlass can use them)
             _.each(
-                _.filter(view["tracks"]["top"], function(track) { return ("height" in track);}),
+                tracksEligibleForScaling,
                 function (track) {
                     track["height"] = (track["height"] * scaledHeightFor1DTracks / sumOfOriginal1DTracks) | 0;
                 }

--- a/src/encoded/tests/data/master-inserts/user.json
+++ b/src/encoded/tests/data/master-inserts/user.json
@@ -156,6 +156,17 @@
         "submits_for": ["4dn-dcic-lab"]
     },
     {
+        "email": "alexander_veit@hms.harvard.edu",
+        "first_name": "Alexander",
+        "job_title": "Software Developer",
+        "lab": "4dn-dcic-lab",
+        "last_name": "Veit",
+        "uuid": "e820dc86-0ed5-4c42-98dc-501f91036419",
+        "viewing_groups": ["4DN"],
+        "groups": ["admin"],
+        "submits_for": ["4dn-dcic-lab"]
+    },
+    {
         "timezone": "US/Eastern",
         "email": "ud4dntest@gmail.com",
         "status": "current",


### PR DESCRIPTION
We need to explicitly specify the `height` property for gene annotation tracks in Higlass viewconfigs going forward. However, they should not be scaled in the front end to ensure complete visibility.