### PR TITLE
C4-132 Make load_access_keys recoverable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.2.2"
+version = "1.2.3"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/load_access_keys.py
+++ b/src/encoded/commands/load_access_keys.py
@@ -5,6 +5,7 @@ import json
 import os
 import boto3
 from pyramid.paster import get_app
+from pyramid.exceptions import HTTPNotFound
 from webtest import TestApp
 from dcicutils.beanstalk_utils import get_beanstalk_real_url
 
@@ -117,7 +118,11 @@ def main():
 
         key_ids = get_existing_key_ids(testapp,  user_props['uuid'], key_name)
         for key_id in key_ids:
-            testapp.patch_json(key_id, {'status': 'deleted'})
+            try:
+                testapp.patch_json(key_id, {'status': 'deleted'})
+            except HTTPNotFound:
+                log.error('load_access_keys: key_id: %s does not exist in database but exists in ES' % key_id)
+
 
         key = generate_access_key(testapp, env, user_props['uuid'], key_name)
         s3.put_object(Bucket=s3_bucket,


### PR DESCRIPTION
- Currently, if Elasticsearch is not aligned with the database, it can have stale data in it that causes the deployment to fail.
- To fix this, do not fail the deployment if we try to patch an access key that is not found in the DB. Log this information instead to be investigated later.