### PR TITLE
ENC to ENCODE changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.6.4"
+version = "1.6.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -328,7 +328,7 @@
             "@type": "@id",
             "rdfs:subPropertyOf": "rdfs:seeAlso",
             "title": "External identifiers",
-            "comment": "Enter as a database name:identifier eg. HGNC:PARK2",
+            "comment": "Enter as a database name:identifier eg. GEO:GSM403896",
             "description": "Unique identifiers from external resources.",
             "type": "array",
             "ff_flag": "clear clone",

--- a/src/encoded/tests/data/inserts/file_vistrack.json
+++ b/src/encoded/tests/data/inserts/file_vistrack.json
@@ -13,7 +13,7 @@
     "biosource": "331111bc-8535-4448-903e-854ab460b254",
     "file_type": "fold change over control",
     "genome_assembly": "GRCh38",
-    "dbxrefs": ["ENC:ENCFF798HCY", "ENC:ENCSR301HRV"],
+    "dbxrefs": ["ENCODE:ENCFF798HCY", "ENCODE:ENCSR301HRV"],
     "dataset_description": "Reference Epigenome: ChIP-Seq Analysis of H3K79me2 in hESC Cells",
     "override_experiment_type": "ChIP-seq",
     "override_lab_name": "Bing Ren, UCSD",

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -994,7 +994,7 @@ class FileVistrack(File):
     })
     def display_title(self, request, file_format, accession=None, external_accession=None, dbxrefs=None):
         if dbxrefs:
-            acclist = [d.replace('ENC:', '') for d in dbxrefs if 'ENCFF' in d]
+            acclist = [d.replace('ENCODE:', '') for d in dbxrefs if 'ENCFF' in d]
             if acclist:
                 accession = acclist[0]
         if not accession:


### PR DESCRIPTION
After replacing ENC with ENCODE in namespaces and patching all items, I found a couple of occurrences of "ENC" in fourfront. This PR changes those to "ENCODE".

Also, it changes the dbxrefs example in the schema to a more relevant one.