### PR TITLE
Added mixed_enzymes property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.7.3"
+version = "1.7.4"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.7.4b0"
+version = "1.7.5b0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/enzyme.json
+++ b/src/encoded/schemas/enzyme.json
@@ -63,18 +63,31 @@
             "pattern": "^[ATGCYRWSKMDVHBN]+$"
         },
         "site_length": {
-          "title": "Site Length",
-          "description": "The length of the enzyme recognition sequence.",
-          "type": "integer",
-          "lookup": 70,
-          "internal_comment": "this can be calculated if a recognition sequence is provided but can be set even without recognition sequence"
+            "title": "Site Length",
+            "description": "The length of the enzyme recognition sequence.",
+            "type": "integer",
+            "lookup": 70,
+            "internal_comment": "this can be calculated if a recognition sequence is provided but can be set even without recognition sequence"
         },
         "cut_position": {
-          "title": "Cut position",
-          "description": "The position in the provided recognition sequence at which the enzyme cuts AFTER - relative to base 1 of site.",
-          "type": "integer",
-          "lookup": 80,
-          "internal_comment": "has a dependency on either cut_sequence or site_length"
+            "title": "Cut Position",
+            "description": "The position in the provided recognition sequence at which the enzyme cuts AFTER - relative to base 1 of site.",
+            "type": "integer",
+            "lookup": 80,
+            "internal_comment": "has a dependency on either cut_sequence or site_length"
+        },
+        "mixed_enzymes": {
+            "title": "Mixed Enzymes",
+            "description": "The enzymes that are combined",
+            "type": "array",
+            "lookup": 90,
+            "uniqueItems": true,
+            "items": {
+                "title": "Enzyme",
+                "description": "The restriction enzyme",
+                "type": "string",
+                "linkTo": "Enzyme"
+            }
         },
         "url": {
             "title": "URL",

--- a/src/encoded/schemas/enzyme.json
+++ b/src/encoded/schemas/enzyme.json
@@ -79,6 +79,7 @@
         "mixed_enzymes": {
             "title": "Mixed Enzymes",
             "description": "The enzymes that are combined",
+            "comment": "If this is a multi-enzyme item, list here each single Enzyme item",
             "type": "array",
             "lookup": 90,
             "uniqueItems": true,

--- a/src/encoded/schemas/enzyme.json
+++ b/src/encoded/schemas/enzyme.json
@@ -1,6 +1,6 @@
 {
     "title": "Enzyme",
-    "description": "DNA restriction enzymes like HindIII or DNaseI",
+    "description": "DNA digestion enzymes like HindIII or DNaseI",
     "id": "/profiles/enzyme.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
@@ -30,7 +30,7 @@
         },
         "name": {
             "title": "Enzyme Name",
-            "description": "The name of the restriction enzyme.",
+            "description": "The name of the digestion enzyme.",
             "type": "string",
             "lookup": 20,
             "uniqueKey": "enzyme:name"

--- a/src/encoded/schemas/enzyme.json
+++ b/src/encoded/schemas/enzyme.json
@@ -85,7 +85,7 @@
             "uniqueItems": true,
             "items": {
                 "title": "Enzyme",
-                "description": "The restriction enzyme",
+                "description": "The DNA digestion enzyme",
                 "type": "string",
                 "linkTo": "Enzyme"
             }

--- a/src/encoded/schemas/enzyme.json
+++ b/src/encoded/schemas/enzyme.json
@@ -1,6 +1,6 @@
 {
     "title": "Enzyme",
-    "description": "DNA digestion enzymes like HindIII or DNaseI",
+    "description": "DNA restriction enzymes like HindIII or DNaseI",
     "id": "/profiles/enzyme.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
@@ -30,7 +30,7 @@
         },
         "name": {
             "title": "Enzyme Name",
-            "description": "The name of the digestion enzyme.",
+            "description": "The name of the restriction enzyme.",
             "type": "string",
             "lookup": 20,
             "uniqueKey": "enzyme:name"


### PR DESCRIPTION
In case an Enzyme item is a mix of multiple enzymes, this property is used to link to the single Enzymes that belong to the mix, where all the related metadata is captured.