### PR TITLE
Use new version of snovault with no dynamic imports.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.7.4b0"
+version = "1.7.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Accept new branch of snovault with no dynamic imports.
I accidentally merged the real change to master in a [thug commit](https://github.com/4dn-dcic/fourfront/commit/371a40b0839e5c94ebd97c294805da112db8097e), which this PR is intended to cover as well.
If a new version of snovault is issued with a non-beta version, I'll update this PR to use that.