### PR TITLE
Missing QC Rnaseq Fields Added

### DIFF
--- a/src/encoded/schemas/quality_metric_rnaseq.json
+++ b/src/encoded/schemas/quality_metric_rnaseq.json
@@ -360,289 +360,309 @@
                     "type": "number",
                     "qc_order": 1
                 },
-                "lincRNA": {
+                "non_coding": {
                     "type": "number",
                     "qc_order": 2
                 },
-                "macro_lncRNA": {
+                "lincRNA": {
                     "type": "number",
                     "qc_order": 3
                 },
-                "bidirectional_promoter_lncRNA": {
+                "macro_lncRNA": {
                     "type": "number",
                     "qc_order": 4
                 },
-                "miRNA": {
+                "bidirectional_promoter_lncRNA": {
                     "type": "number",
                     "qc_order": 5
                 },
-                "rRNA": {
+                "miRNA": {
                     "type": "number",
                     "qc_order": 6
                 },
-                "snRNA": {
+                "rRNA": {
                     "type": "number",
                     "qc_order": 7
                 },
-                "snoRNA": {
+                "snRNA": {
                     "type": "number",
                     "qc_order": 8
                 },
-                "sRNA": {
+                "snoRNA": {
                     "type": "number",
                     "qc_order": 9
                 },
-                "scRNA": {
+                "sRNA": {
                     "type": "number",
                     "qc_order": 10
                 },
-                "scaRNA": {
+                "scRNA": {
                     "type": "number",
                     "qc_order": 11
                 },
-                "ribozyme": {
+                "scaRNA": {
                     "type": "number",
                     "qc_order": 12
                 },
-                "misc_RNA": {
+                "ribozyme": {
                     "type": "number",
                     "qc_order": 13
                 },
-                "Ala_tRNA": {
+                "misc_RNA": {
                     "type": "number",
                     "qc_order": 14
                 },
-                "Arg_tRNA": {
+                "Ala_tRNA": {
                     "type": "number",
                     "qc_order": 15
                 },
-                "Asn_tRNA": {
+                "Arg_tRNA": {
                     "type": "number",
                     "qc_order": 16
                 },
-                "Asp_tRNA": {
+                "Asn_tRNA": {
                     "type": "number",
                     "qc_order": 17
                 },
-                "Cys_tRNA": {
+                "Asp_tRNA": {
                     "type": "number",
                     "qc_order": 18
                 },
-                "Gln_tRNA": {
+                "Cys_tRNA": {
                     "type": "number",
                     "qc_order": 19
                 },
-                "Glu_tRNA": {
+                "Gln_tRNA": {
                     "type": "number",
                     "qc_order": 20
                 },
-                "Gly_tRNA": {
+                "Glu_tRNA": {
                     "type": "number",
                     "qc_order": 21
                 },
-                "His_tRNA": {
+                "Gly_tRNA": {
                     "type": "number",
                     "qc_order": 22
                 },
-                "Ile_tRNA": {
+                "His_tRNA": {
                     "type": "number",
                     "qc_order": 23
                 },
-                "Leu_tRNA": {
+                "Ile_tRNA": {
                     "type": "number",
                     "qc_order": 24
                 },
-                "Lys_tRNA": {
+                "Leu_tRNA": {
                     "type": "number",
                     "qc_order": 25
                 },
-                "Met_tRNA": {
+                "Lys_tRNA": {
                     "type": "number",
                     "qc_order": 26
                 },
-                "Phe_tRNA": {
+                "Met_tRNA": {
                     "type": "number",
                     "qc_order": 27
                 },
-                "Pro_tRNA": {
+                "Phe_tRNA": {
                     "type": "number",
                     "qc_order": 28
                 },
-                "SeC(e)_tRNA": {
+                "Pro_tRNA": {
                     "type": "number",
                     "qc_order": 29
                 },
-                "SeC_tRNA": {
+                "SeC(e)_tRNA": {
                     "type": "number",
                     "qc_order": 30
                 },
-                "Ser_tRNA": {
+                "SeC_tRNA": {
                     "type": "number",
                     "qc_order": 31
                 },
-                "Sup_tRNA": {
+                "Ser_tRNA": {
                     "type": "number",
                     "qc_order": 32
                 },
-                "Thr_tRNA": {
+                "Sup_tRNA": {
                     "type": "number",
                     "qc_order": 33
                 },
-                "Trp_tRNA": {
+                "Thr_tRNA": {
                     "type": "number",
                     "qc_order": 34
                 },
-                "Tyr_tRNA": {
+                "Trp_tRNA": {
                     "type": "number",
                     "qc_order": 35
                 },
-                "Val_tRNA": {
+                "Tyr_tRNA": {
                     "type": "number",
                     "qc_order": 36
                 },
-                "Undet_tRNA": {
+                "Val_tRNA": {
                     "type": "number",
                     "qc_order": 37
                 },
-                "Mt_tRNA": {
+                "Undet_tRNA": {
                     "type": "number",
                     "qc_order": 38
                 },
-                "Mt_rRNA": {
+                "Mt_tRNA": {
                     "type": "number",
                     "qc_order": 39
                 },
-                "3prime_overlapping_ncRNA": {
+                "Mt_rRNA": {
                     "type": "number",
                     "qc_order": 40
                 },
-                "sense_intronic": {
+                "3prime_overlapping_ncRNA": {
                     "type": "number",
                     "qc_order": 41
                 },
-                "sense_overlapping": {
+                "vaultRNA": {
                     "type": "number",
                     "qc_order": 42
                 },
-                "antisense": {
+                "sense_intronic": {
                     "type": "number",
                     "qc_order": 43
                 },
-                "pseudogene": {
+                "sense_overlapping": {
                     "type": "number",
                     "qc_order": 44
                 },
-                "processed_pseudogene": {
+                "antisense": {
                     "type": "number",
                     "qc_order": 45
                 },
-                "processed_transcript": {
+                "pseudogene": {
                     "type": "number",
                     "qc_order": 46
                 },
-                "polymorphic_pseudogene": {
+                "processed_pseudogene": {
                     "type": "number",
                     "qc_order": 47
                 },
-                "transcribed_processed_pseudogene": {
+                "processed_transcript": {
                     "type": "number",
                     "qc_order": 48
                 },
-                "unprocessed_pseudogene": {
+                "polymorphic_pseudogene": {
                     "type": "number",
                     "qc_order": 49
                 },
-                "transcribed_unprocessed_pseudogene": {
+                "transcribed_processed_pseudogene": {
                     "type": "number",
                     "qc_order": 50
                 },
-                "translated_unprocessed_pseudogene": {
+                "unprocessed_pseudogene": {
                     "type": "number",
                     "qc_order": 51
                 },
-                "unitary_pseudogene": {
+                "transcribed_unprocessed_pseudogene": {
                     "type": "number",
                     "qc_order": 52
                 },
-                "transcribed_unitary_pseudogene": {
+                "translated_processed_pseudogene": {
                     "type": "number",
                     "qc_order": 53
                 },
-                "IG_C_gene": {
+                "translated_unprocessed_pseudogene": {
                     "type": "number",
                     "qc_order": 54
                 },
-                "IG_C_pseudogene": {
+                "unitary_pseudogene": {
                     "type": "number",
                     "qc_order": 55
                 },
-                "IG_D_gene": {
+                "transcribed_unitary_pseudogene": {
                     "type": "number",
                     "qc_order": 56
                 },
-                "IG_D_pseudogene": {
+                "IG_C_gene": {
                     "type": "number",
                     "qc_order": 57
                 },
-                "IG_J_gene": {
+                "IG_C_pseudogene": {
                     "type": "number",
                     "qc_order": 58
                 },
-                "IG_LV_gene": {
+                "IG_D_gene": {
                     "type": "number",
                     "qc_order": 59
                 },
-                "IG_V_gene": {
+                "IG_D_pseudogene": {
                     "type": "number",
                     "qc_order": 60
                 },
-                "IG_V_pseudogene": {
+                "IG_J_gene": {
                     "type": "number",
                     "qc_order": 61
                 },
-                "IG_pseudogene": {
+                "IG_J_pseudogene": {
                     "type": "number",
                     "qc_order": 62
                 },
-                "TR_C_gene": {
+                "IG_LV_gene": {
                     "type": "number",
                     "qc_order": 63
                 },
-                "TR_D_gene": {
+                "IG_V_gene": {
                     "type": "number",
                     "qc_order": 64
                 },
-                "TR_J_gene": {
+                "IG_V_pseudogene": {
                     "type": "number",
                     "qc_order": 65
                 },
-                "TR_J_pseudogene": {
+                "IG_pseudogene": {
                     "type": "number",
                     "qc_order": 66
                 },
-                "TR_V_gene": {
+                "TR_C_gene": {
                     "type": "number",
                     "qc_order": 67
                 },
-                "TR_V_pseudogene": {
+                "TR_D_gene": {
                     "type": "number",
                     "qc_order": 68
                 },
-                "Pseudo_tRNA": {
+                "TR_J_gene": {
                     "type": "number",
                     "qc_order": 69
                 },
-                "TEC": {
+                "TR_J_pseudogene": {
                     "type": "number",
                     "qc_order": 70
                 },
-                "transcript_id_not_found": {
+                "TR_V_gene": {
                     "type": "number",
                     "qc_order": 71
                 },
-                "spikein": {
+                "TR_V_pseudogene": {
                     "type": "number",
                     "qc_order": 72
+                },
+                "Pseudo_tRNA": {
+                    "type": "number",
+                    "qc_order": 73
+                },
+                "rRNA_pseudogene": {
+                    "type": "number",
+                    "qc_order": 74
+                },
+                "TEC": {
+                    "type": "number",
+                    "qc_order": 75
+                },
+                "transcript_id_not_found": {
+                    "type": "number",
+                    "qc_order": 76
+                },
+                "spikein": {
+                    "type": "number",
+                    "qc_order": 77
                 }
             }
         }


### PR DESCRIPTION
After updating QC shemas' `additionalProperties` field as `false`, some QC Rnaseq Items getting validation errors since `gene_type_count` has missing sub-fields. (https://data.4dnucleome.org/search/?validation_errors.name!=No+value&type=Item) Those are:

1. vaultRNA
2. non_coding
3. IG_J_pseudogene
4. rRNA_pseudogene
5. translated_processed_pseudogene

This PR adds missing fields into `quality_metric_rnaseq.json` schema w/ `qc_order` value.

PS: `ff-hotseat` data also have validation errors. deployed the branch into `ff-hotseat`, reindexed the QC Items then tested. All set now. (http://fourfront-hotseat.9wzadzju3p.us-east-1.elasticbeanstalk.com/search/?validation_errors.name%21=No+value&type=Item)