### PR TITLE
Use Postgres 11 for Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ addons:
     - make
     - graphviz
     - nginx
-  postgresql: '9.4'
 env:
   global:
+  - PGPORT=5433
   - BOTO_CONFIG=/bogus
-  - PATH="/usr/share/elasticsearch/bin:/usr/lib/postgresql/9.4/bin:$PATH"
+  - PATH="/usr/share/elasticsearch/bin:/usr/lib/postgresql/11/bin:$PATH"
   - ELASTIC_BEANSTALK_LABEL=$TRAVIS_COMMIT
   - USER="4dn-dcic"
   - SNO_REPO="snovault"
@@ -35,19 +35,27 @@ notifications:
   slack:
     secure: DQyUTk6evwPpO0P5+OPhBSgl+fGEerOjBlBwQliXAkDaMKH3Cpi4cTQ3ETR/+3g6bGqPGK+QJ1R+6Ht+hJD7dNomyVIoQmvF0P5afJtpk/A3cDILe90t76ET9jc/iBjWeUFQdokFUJ7Gt1GGYtI6e5XcVu/Qc/xqCvFMtsBN6mnBFuvcQki+WkoIIPPawyhfryCNOLo5vvbi4SZ5dZI+M0MGq9HQjOyF1sdIgKuXhxjupmL+kVPVXAq9kiOANYFkwbNsP9j0BTYW5wFHpAztBqz3NT6EchgCdue8tgV4hC4rRFvM/bsA4qz/TJ5wRRLBRXtnNtPcyhAqTiU+wC6qWt++fjSEMGe4KYqtRRV1YuxQiTVHN84t77DILLNfMh/6uSs0KijwOT+Oazwd/UsN1zYOH93AM4FZ0h92yyb6j6JQ+DUk4WFel1Zr4kZzhtHSPGw+K4fxY0zIt1qpaDPXjtZHQ0+LwIIMtwMp5bBcwDn9d1ADnUhUAuuIN2hHaXrVy4vP2hIcd0LzezBqvc7JXimyd5yRgUeOCTrKGkAeSo8VA7XIj0ZmlpQRYKNTJP+gz4Y6C/RCxISnFDF/vcX+IsDdvreZXJMplE1Aqxf0uR6Zj8Sr8q+QWGKydv6ettlLZuqDuv0l/l/9qpzYfRqLSZcetGRVFHHcR9wuQiDyums=
 before_install:
+- ls -dal /usr/lib/postgresql/*/bin/postgres
+- find /usr/lib/postgresql -name 'postgres' -print
+- ps auxww | grep postgres
+- sudo apt-get install -yq --no-install-suggests --no-install-recommends postgresql-common
+- sudo service postgresql stop
+- sudo apt install -yq --no-install-suggests --no-install-recommends postgresql-11 postgresql-client-11
+- sudo service postgresql status
+- sudo service postgresql start 11
+- sudo service postgresql status
 - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 - echo $tibanna_deploy
 - postgres --version
 - initdb --version
+- ls -dal /usr/lib/postgresql/*/bin/postgres
+- find /usr/lib/postgresql -name 'postgres' -print
+- ps auxww | grep postgres
 - nvm install 10 || (echo "Retrying nvm install" && sleep 5 && nvm install 10)
 - node --version
 - npm config set python /usr/bin/python2.7
 install:
-# need to manually change the version of six used by Travis for some reason
-- pip install --upgrade pip==19.0.3
-- pip uninstall -y six
-- pip install six==1.11.0
-- pip install --upgrade pip==19.0.3
+- pip install --upgrade pip
 - pip install poetry
 - pip install coveralls
 - pip install codacy-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,11 @@ before_install:
 - node --version
 - npm config set python /usr/bin/python2.7
 install:
-- pip install --upgrade pip
+# need to manually change the version of six used by Travis for some reason
+- pip install --upgrade pip==19.0.3
+- pip uninstall -y six
+- pip install six==1.11.0
+- pip install --upgrade pip==19.0.3
 - pip install poetry
 - pip install coveralls
 - pip install codacy-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,7 @@ before_install:
 - node --version
 - npm config set python /usr/bin/python2.7
 install:
-# need to manually change the version of six used by Travis for some reason
-- pip install --upgrade pip==19.0.3
-- pip uninstall -y six
-- pip install six==1.11.0
-- pip install --upgrade pip==19.0.3
+- pip install --upgrade pip
 - pip install poetry
 - pip install coveralls
 - pip install codacy-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ install:
 - pip install poetry
 - pip install coveralls
 - pip install codacy-coverage
-- make build
+- poetry install
+- make npm-setup
 before_script:
 - configure-kibana-index --es-endpoint search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80
 script:

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ kibana-stop:
 kill:  # kills back-end processes associated with the application. Use with care.
 	pkill -f postgres &
 	pkill -f elasticsearch &
+	pkill -f moto_server &
 
 clean-python:
 	@echo -n "Are you sure? This will wipe all libraries installed on this virtualenv [y/N] " && read ans && [ $${ans:-N} = y ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.7.12"
+version = "1.7.13"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/extract_test_data.py
+++ b/src/encoded/commands/extract_test_data.py
@@ -146,7 +146,7 @@ def main():
     except Exception:
         type, value, tb = sys.exc_info()
         traceback.print_exc()
-        import pdb; pdb.post_mortem(tb)
+        # import pdb; pdb.post_mortem(tb)
 
 
 if __name__ == '__main__':

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -9,6 +9,7 @@ import json
 import os
 import pkg_resources
 import pytest
+import re
 import time
 import transaction
 import uuid
@@ -25,7 +26,7 @@ from snovault.elasticsearch.create_mapping import (
 )
 from snovault.elasticsearch.interfaces import INDEXER_QUEUE
 from snovault.elasticsearch.indexer_utils import get_namespaced_index
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, func
 from timeit import default_timer as timer
 from unittest import mock
 from zope.sqlalchemy import mark_changed
@@ -40,6 +41,18 @@ notice_pytest_fixtures(app_settings, wrangler, wrangler_testapp)
 
 
 pytestmark = [pytest.mark.working, pytest.mark.indexing, pytest.mark.flaky(rerun_filter=delay_rerun, max_runs=2)]
+
+
+POSTGRES_MAJOR_VERSION_EXPECTED = 11
+
+
+def test_postgres_version(session):
+
+    (version_info,) = session.query(func.version()).one()
+    print("version_info=", version_info)
+    assert isinstance(version_info, str)
+    assert re.match("PostgreSQL %s([.][0-9]+)? " % POSTGRES_MAJOR_VERSION_EXPECTED, version_info)
+
 
 # subset of collections to run test on
 TEST_COLLECTIONS = ['testing_post_put_patch', 'file_processed']


### PR DESCRIPTION
Upgrade from Postgres 9.4 to Postgres 11 for Travis testing.

Also, opportunistically:

* Because @willronchetti asked for it, add `moto_server` to the list of things that `make kill` will kill.

* Promised from a previous PR's code review, remove the call to `import pdb; pdb.post_mortem(tb)` in the `src/encoded/commands/extract_test_data.py` script.