### PR TITLE
Rewrite get_item_if_you_can as get_item_or_none to match CGAP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,10 @@ clean-python:
 	pip freeze | xargs pip uninstall -y
 
 test:
-	bin/test -vv --timeout=200 -m "working and not performance"
+	bin/test -vv --timeout=240 -m "working and not performance"
 
 test-any:
-	bin/test -vv --timeout=200
+	bin/test -vv --timeout=240
 
 travis-test-npm:  # Note this only does the 'not indexing' tests
 	bin/test -vv --timeout=200 -m "working and not performance and not indexing" --aws-auth --durations=10 --cov src/encoded --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,10 @@ clean-python:
 	pip freeze | xargs pip uninstall -y
 
 test:
-	bin/test -vv --timeout=240 -m "working and not performance"
+	bin/test -vv --timeout=200 -m "working and not performance"
 
 test-any:
-	bin/test -vv --timeout=240
+	bin/test -vv --timeout=200
 
 travis-test-npm:  # Note this only does the 'not indexing' tests
 	bin/test -vv --timeout=200 -m "working and not performance and not indexing" --aws-auth --durations=10 --cov src/encoded --es search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.7.17"
+version = "1.7.18"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.7.16"
+version = "1.7.17"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.7.13"
+version = "1.7.14"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_embedding.py
+++ b/src/encoded/tests/test_embedding.py
@@ -2,7 +2,7 @@ import pytest
 
 from snovault import TYPES
 from snovault.util import add_default_embeds, crawl_schemas_by_embeds
-from ..types.base import get_item_if_you_can
+from ..types.base import get_item_or_none
 from .datafixtures import ORDER
 
 
@@ -139,17 +139,17 @@ def test_fictitous_embed(registry):
     assert error is None
 
 
-def test_get_item_if_you_can(content, dummy_request, threadlocals):
+def test_get_item_or_none(content, dummy_request, threadlocals):
     """
     Not necessarily the best place for this test, but test that the
-    `get_item_if_you_can` function works with multiple inputs
+    `get_item_or_none` function works with multiple inputs
     """
     used_item = sources[0]
     # all of these should get the full item
-    res1 = get_item_if_you_can(dummy_request, used_item)
-    res2 = get_item_if_you_can(dummy_request, {'uuid': used_item['uuid']})
-    res3 = get_item_if_you_can(dummy_request, used_item['uuid'])
-    res4 = get_item_if_you_can(dummy_request, used_item['uuid'], '/testing-link-sources/')
+    res1 = get_item_or_none(dummy_request, used_item)
+    res2 = get_item_or_none(dummy_request, {'uuid': used_item['uuid']})
+    res3 = get_item_or_none(dummy_request, used_item['uuid'])
+    res4 = get_item_or_none(dummy_request, used_item['uuid'], '/testing-link-sources/')
     for res in [res1, res2, res3, res4]:
         assert res['uuid'] == used_item['uuid']
         assert res['name'] == used_item['name']

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -105,7 +105,7 @@ ALLOW_ANY_USER_ADD = [
 ] + ALLOW_EVERYONE_VIEW
 
 
-def get_item_if_you_can(request, value, itype=None, frame='object'):
+def get_item_or_none(request, value, itype=None, frame='object'):
     """
     Return the view of an item with given frame. Can specify different types
     of `value` for item lookup

--- a/src/encoded/types/bio_feature.py
+++ b/src/encoded/types/bio_feature.py
@@ -8,7 +8,7 @@ from snovault import (
 from .base import (
     Item,
     lab_award_attribution_embed_list,
-    get_item_if_you_can
+    get_item_or_none
 )
 
 
@@ -36,7 +36,7 @@ class BioFeature(Item):
                       organism_name=None, relevant_genes=[], feature_mods=[], genome_location=[]):
         if preferred_label:
             return preferred_label
-        ftype = get_item_if_you_can(request, feature_type)
+        ftype = get_item_or_none(request, feature_type)
         ftype = ftype.get('preferred_name', '') if ftype is not None else ''
 
         # first pass will not assume combined fields
@@ -54,7 +54,7 @@ class BioFeature(Item):
 
         # gene trumps location
         for g in relevant_genes:
-            gene = get_item_if_you_can(request, g)
+            gene = get_item_or_none(request, g)
             if gene is not None:
                 symb = gene.get('display_title')
                 featstr = featstr + symb + ', '
@@ -71,7 +71,7 @@ class BioFeature(Item):
         if not relevant_genes:
             for loc in genome_location:
                 try:
-                    locstr = get_item_if_you_can(request, loc).get('display_title')
+                    locstr = get_item_or_none(request, loc).get('display_title')
                 except AttributeError:
                     pass
                 else:

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -7,7 +7,7 @@ from snovault import (
 from .base import (
     Item,
     lab_award_attribution_embed_list,
-    get_item_if_you_can
+    get_item_or_none
 )
 
 
@@ -83,7 +83,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
         if modifications:
             ret_str = ''
             for mod in modifications:
-                mod_props = get_item_if_you_can(request, mod, 'modifications')
+                mod_props = get_item_or_none(request, mod, 'modifications')
                 if mod_props and mod_props.get('modification_name'):
                     ret_str += (mod_props['modification_name'] + ' and ')
             if len(ret_str) > 0:
@@ -100,7 +100,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
     def modifications_summary_short(self, request, modifications=None):
         if modifications:
             # use only the first modification
-            mod_props = get_item_if_you_can(request, modifications[0], 'modifications')
+            mod_props = get_item_or_none(request, modifications[0], 'modifications')
             if mod_props and mod_props.get('modification_name_short'):
                 return mod_props['modification_name_short']
         return 'None'
@@ -114,7 +114,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
         if treatments:
             treat_list = []
             for tmt in treatments:
-                treat_props = get_item_if_you_can(request, tmt, 'treatments')
+                treat_props = get_item_or_none(request, tmt, 'treatments')
                 treat_list.append(treat_props.get('display_title'))
             return ' and '.join(sorted([t for t in treat_list if t]))
         return 'None'
@@ -127,13 +127,13 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
     def biosource_summary(self, request, biosource, cell_culture_details=None):
         ret_str = ''
         for bios in biosource:
-            bios_props = get_item_if_you_can(request, bios, 'biosources')
+            bios_props = get_item_or_none(request, bios, 'biosources')
             if bios_props and bios_props.get('biosource_name'):
                 ret_str += (bios_props['biosource_name'] + ' and ')
         if len(ret_str) > 0:
             ret_str = ret_str[:-5]
             if cell_culture_details and len(cell_culture_details) == 1:
-                cc_props = get_item_if_you_can(request, cell_culture_details[0], 'biosample_cell_cultures', frame='embedded')
+                cc_props = get_item_or_none(request, cell_culture_details[0], 'biosample_cell_cultures', frame='embedded')
                 if cc_props and 'tissue' in cc_props:
                     ret_str = ret_str + ' differentiated to ' + cc_props['tissue'].get('display_title')
             return ret_str
@@ -148,7 +148,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
         biosource_types = []
         for bs in biosource:
             # silliness in case we ever have multiple biosources
-            biosource = get_item_if_you_can(request, bs, 'biosources')
+            biosource = get_item_or_none(request, bs, 'biosources')
             if biosource:
                 btype = biosource.get('biosource_type')
                 biosource_types.append(btype)
@@ -162,7 +162,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
 
         # we've got a single type of biosource
         if cell_culture_details:  # this is now an array but just check the first
-            cell_culture = get_item_if_you_can(request, cell_culture_details[0], 'biosample_cell_cultures')
+            cell_culture = get_item_or_none(request, cell_culture_details[0], 'biosample_cell_cultures')
             if cell_culture:
                 if cell_culture.get('in_vitro_differentiated') == 'Yes':
                     return 'in vitro differentiated cells'
@@ -187,11 +187,11 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
         if len(biosource) > 1:
             return ['Mixed samples']
         categories = []
-        biosource = get_item_if_you_can(request, biosource[0], 'biosources')
+        biosource = get_item_or_none(request, biosource[0], 'biosources')
         if biosource:
             categories = biosource.get('biosource_category', [])
         if cell_culture_details:  # this is now an array but just check the first
-            cell_culture = get_item_if_you_can(request, cell_culture_details[0], 'biosample_cell_cultures')
+            cell_culture = get_item_or_none(request, cell_culture_details[0], 'biosample_cell_cultures')
             if cell_culture:
                 if cell_culture.get('in_vitro_differentiated') == 'Yes':
                     categories.append('In vitro Differentiation')

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -27,7 +27,7 @@ from snovault.util import debug_log
 from .base import (
     Item,
     ALLOW_SUBMITTER_ADD,
-    get_item_if_you_can,
+    get_item_or_none,
     lab_award_attribution_embed_list
 )
 
@@ -839,7 +839,7 @@ def validate_exp_type_validity_for_experiment(context, request):
     """
     data = request.json
     if 'experiment_type' in data:
-        exp_type_item = get_item_if_you_can(request, data['experiment_type'], 'experiment-types')
+        exp_type_item = get_item_or_none(request, data['experiment_type'], 'experiment-types')
         if not exp_type_item:  # pragma: no cover
             # item level validation will take care of generating the error
             return

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -27,7 +27,7 @@ from snovault.util import debug_log
 from .base import (
     Item,
     lab_award_attribution_embed_list,
-    get_item_if_you_can
+    get_item_or_none
 )
 import datetime
 
@@ -394,7 +394,7 @@ class ExperimentSetReplicate(ExperimentSet):
             # We only need to check Microscopy Experiments
             return None
 
-        first_experiment_obj = get_item_if_you_can(request, first_experiment_id, frame='raw')
+        first_experiment_obj = get_item_or_none(request, first_experiment_id, frame='raw')
         if not first_experiment_obj:  # Not yet in DB?
             return None
 

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -60,7 +60,7 @@ from ..search import make_search_subreq
 from .base import (
     Item,
     ALLOW_SUBMITTER_ADD,
-    get_item_if_you_can,
+    get_item_or_none,
     lab_award_attribution_embed_list
 )
 
@@ -278,7 +278,7 @@ class File(Item):
     })
     def display_title(self, request, file_format, accession=None, external_accession=None):
         accession = accession or external_accession
-        file_format_item = get_item_if_you_can(request, file_format, 'file-formats')
+        file_format_item = get_item_or_none(request, file_format, 'file-formats')
         try:
             file_extension = '.' + file_format_item.get('standard_file_extension')
         except AttributeError:
@@ -292,7 +292,7 @@ class File(Item):
     })
     def file_type_detailed(self, request, file_format, file_type=None):
         outString = (file_type or 'other')
-        file_format_item = get_item_if_you_can(request, file_format, 'file-formats')
+        file_format_item = get_item_or_none(request, file_format, 'file-formats')
         try:
             fformat = file_format_item.get('file_format')
             outString = outString + ' (' + fformat + ')'
@@ -363,7 +363,7 @@ class File(Item):
 
         # here we have either an expid or a repsetid
         if repsetid:  # get 2 fields and get an expt to get other info
-            rep_set_info = get_item_if_you_can(request, repsetid)
+            rep_set_info = get_item_or_none(request, repsetid)
             if not rep_set_info:
                 return info
             # pieces of info to get from the repset if there is one
@@ -383,10 +383,10 @@ class File(Item):
             expid = expts_in_set[0]
 
         if expid:
-            exp_info = get_item_if_you_can(request, expid)
+            exp_info = get_item_or_none(request, expid)
             if not exp_info:  # sonmethings fishy - abort
                 return info
-            exp_type = get_item_if_you_can(request, exp_info.get('experiment_type'))
+            exp_type = get_item_or_none(request, exp_info.get('experiment_type'))
             if exp_type is not None:
                 info['experiment_type'] = exp_type.get('title')
             if 'experiment_bucket' not in info:  # did not get it from rep_set
@@ -401,7 +401,7 @@ class File(Item):
                 repset = [rs for rs in possible_repsets if 'replicate' in rs]
                 if repset:
                     repset = repset[0]
-                    rep_set_info = get_item_if_you_can(request, repset)
+                    rep_set_info = get_item_or_none(request, repset)
                     if rep_set_info is not None:
                         ds, c = self._get_ds_cond_from_repset(rep_set_info)
                         info['dataset'] = ds
@@ -414,7 +414,7 @@ class File(Item):
             if 'biosource_name' not in currinfo:
                 sample_id = exp_info.get('biosample')
                 if sample_id is not None:
-                    sample = get_item_if_you_can(request, sample_id)
+                    sample = get_item_or_none(request, sample_id)
                     if sample is not None:
                         info['biosource_name'] = sample.get('biosource_summary')
         return {k: v for k, v in info.items() if v is not None}
@@ -477,7 +477,7 @@ class File(Item):
 
             if 'lab_name' not in track_info:
                 labid = props.get('lab')
-                lab = get_item_if_you_can(request, labid)
+                lab = get_item_or_none(request, labid)
                 if lab is not None:
                     track_info['lab_name'] = lab.get('display_title')
 
@@ -645,7 +645,7 @@ class File(Item):
         "description": "Use this link to download this file."
     })
     def href(self, request, file_format, accession=None, external_accession=None):
-        fformat = get_item_if_you_can(request, file_format, 'file-formats')
+        fformat = get_item_or_none(request, file_format, 'file-formats')
         try:
             file_extension = '.' + fformat.get('standard_file_extension')
         except AttributeError:
@@ -999,7 +999,7 @@ class FileVistrack(File):
                 accession = acclist[0]
         if not accession:
             accession = accession or external_accession
-        file_format_item = get_item_if_you_can(request, file_format, 'file-formats')
+        file_format_item = get_item_or_none(request, file_format, 'file-formats')
         try:
             file_extension = '.' + file_format_item.get('standard_file_extension')
         except AttributeError:
@@ -1085,7 +1085,7 @@ def post_upload(context, request):
         bucket = request.registry.settings['file_upload_bucket']
         # maybe this should be properties.uuid
         uuid = context.uuid
-        file_format = get_item_if_you_can(request, properties.get('file_format'), 'file-formats')
+        file_format = get_item_or_none(request, properties.get('file_format'), 'file-formats')
         try:
             file_extension = '.' + file_format.get('standard_file_extension')
         except AttributeError:
@@ -1190,8 +1190,8 @@ def download(context, request):
     # or one of the files in extra files, the following logic will
     # search to find the "right" file and redirect to a download link for that one
     properties = context.upgrade_properties()
-    file_format = get_item_if_you_can(request, properties.get('file_format'), 'file-formats')
-    lab = properties.get('lab') and get_item_if_you_can(request, properties.get('lab'), 'labs')
+    file_format = get_item_or_none(request, properties.get('file_format'), 'file-formats')
+    lab = properties.get('lab') and get_item_or_none(request, properties.get('lab'), 'labs')
     _filename = None
     if request.subpath:
         _filename, = request.subpath
@@ -1199,7 +1199,7 @@ def download(context, request):
     if not filename:
         found = False
         for extra in properties.get('extra_files', []):
-            eformat = get_item_if_you_can(request, extra.get('file_format'), 'file-formats')
+            eformat = get_item_or_none(request, extra.get('file_format'), 'file-formats')
             filename = is_file_to_download(extra, eformat, _filename)
             if filename:
                 found = True
@@ -1409,12 +1409,12 @@ def get_file_experiment_type(request, context, properties):
             rev_exp_sets = context.experiment_sets(request)
             if rev_exp_sets:
                 for exp_set in rev_exp_sets:
-                    exp_set_info = get_item_if_you_can(request, exp_set)
+                    exp_set_info = get_item_or_none(request, exp_set)
                     if exp_set_info:
                         experiments_using_file.extend(exp_set_info.get('experiments_in_set', []))
     found_experiment_type = 'None'
     for file_experiment in experiments_using_file:
-        exp_info = get_item_if_you_can(request, file_experiment)
+        exp_info = get_item_or_none(request, file_experiment)
         if exp_info is None:
             continue
         exp_type = exp_info.get('experiment_type')
@@ -1423,7 +1423,7 @@ def get_file_experiment_type(request, context, properties):
         else:  # multiple experiment types
             return 'Integrative analysis'
     if found_experiment_type != 'None':
-        found_item = get_item_if_you_can(request, found_experiment_type)
+        found_item = get_item_or_none(request, found_experiment_type)
         if found_item is None:
             found_experiment_type = 'None'
         else:
@@ -1436,7 +1436,7 @@ def validate_file_format_validity_for_file_type(context, request):
     """
     data = request.json
     if 'file_format' in data:
-        file_format_item = get_item_if_you_can(request, data['file_format'], 'file-formats')
+        file_format_item = get_item_or_none(request, data['file_format'], 'file-formats')
         if not file_format_item:
             # item level validation will take care of generating the error
             return
@@ -1464,7 +1464,7 @@ def validate_file_filename(context, request):
     ff = data.get('file_format')
     if not ff:
         ff = context.properties.get('file_format')
-    file_format_item = get_item_if_you_can(request, ff, 'file-formats')
+    file_format_item = get_item_or_none(request, ff, 'file-formats')
     if not file_format_item:
         msg = 'Problem getting file_format for %s' % filename
         request.errors.add('body', 'File: no format', msg)
@@ -1543,7 +1543,7 @@ def validate_processed_file_produced_from_field(context, request):
     files2chk = data['produced_from']
     for i, f in enumerate(files2chk):
         try:
-            fid = get_item_if_you_can(request, f, 'files').get('uuid')
+            fid = get_item_or_none(request, f, 'files').get('uuid')
         except AttributeError:
             files_ok = False
             request.errors.add('body', 'File: invalid produced_from id', "'%s' not found" % f)
@@ -1570,7 +1570,7 @@ def validate_extra_file_format(context, request):
     ff = data.get('file_format')
     if not ff:
         ff = context.properties.get('file_format')
-    file_format_item = get_item_if_you_can(request, ff, 'file-formats')
+    file_format_item = get_item_or_none(request, ff, 'file-formats')
     if not file_format_item or 'standard_file_extension' not in file_format_item:
         request.errors.add('body', 'File: no extra_file format', "Can't find parent file format for extra_files")
         return
@@ -1585,7 +1585,7 @@ def validate_extra_file_format(context, request):
     else:
         valid_ext_formats = []
         for ok_format in schema_eformats:
-            ok_format_item = get_item_if_you_can(request, ok_format, 'file-formats')
+            ok_format_item = get_item_or_none(request, ok_format, 'file-formats')
             try:
                 off_uuid = ok_format_item.get('uuid')
             except AttributeError:
@@ -1598,7 +1598,7 @@ def validate_extra_file_format(context, request):
         eformat = ef.get('file_format')
         if eformat is None:
             return  # will fail the required extra_file.file_format
-        eformat_item = get_item_if_you_can(request, eformat, 'file-formats')
+        eformat_item = get_item_or_none(request, eformat, 'file-formats')
         try:
             ef_uuid = eformat_item.get('uuid')
         except AttributeError:

--- a/src/encoded/types/individual.py
+++ b/src/encoded/types/individual.py
@@ -9,7 +9,7 @@ from snovault import (
 from .base import (
     Item,
     ALLOW_SUBMITTER_ADD,
-    get_item_if_you_can,
+    get_item_or_none,
     lab_award_attribution_embed_list
 )
 
@@ -158,7 +158,7 @@ def validate_individual_relations(context, request):
         data = request.json
         individual_uuid = data.get('uuid')
     organism_id = data.get('organism')
-    organism = get_item_if_you_can(request, organism_id, 'organisms')
+    organism = get_item_or_none(request, organism_id, 'organisms')
 
     # Max 2 parents per individual
     if len(related_individuals) > 2:
@@ -174,8 +174,8 @@ def validate_individual_relations(context, request):
         if len(a_related_individual.keys()) < 2:
             continue
         parent = a_related_individual.get('individual')
-        parent_props = get_item_if_you_can(request, parent, 'individuals')
-        parent_organism = get_item_if_you_can(request, parent_props.get('organism'), 'organisms')
+        parent_props = get_item_or_none(request, parent, 'individuals')
+        parent_organism = get_item_or_none(request, parent_props.get('organism'), 'organisms')
         parent_uuid = parent_props.get('uuid')
 
         # Same species

--- a/src/encoded/types/treatment.py
+++ b/src/encoded/types/treatment.py
@@ -10,7 +10,7 @@ from .base import (
     Item,
     ALLOW_SUBMITTER_ADD,
     lab_award_attribution_embed_list,
-    get_item_if_you_can
+    get_item_or_none
 )
 
 
@@ -70,7 +70,7 @@ class TreatmentAgent(Treatment):
             disp_title = chemical + " " + action + conditions
         elif treatment_type == "Transient Transfection" and constructs:
             plasmids = ", ".join(
-                [get_item_if_you_can(request, construct).get('name') for construct in constructs]
+                [get_item_or_none(request, construct).get('name') for construct in constructs]
             )
             disp_title = "Transient transfection of " + plasmids + conditions
         elif treatment_type == "Biological" and biological_agent:

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -26,7 +26,7 @@ from .types.workflow import (
     WorkflowRunTracingException,
     item_model_to_object
 )
-from .types.base import get_item_if_you_can
+from .types.base import get_item_or_none
 
 def includeme(config):
     config.add_route('trace_workflow_runs',         '/trace_workflow_run_steps/{file_uuid}/', traverse='/{file_uuid}')
@@ -452,7 +452,7 @@ def add_files_to_higlass_viewconf(context, request):
     if not higlass_viewconfig:
         
         # @todo: this block will be removed when a workaround to run tests correctly.
-        default_higlass_viewconf = get_item_if_you_can(request, "00000000-1111-0000-1111-000000000000")
+        default_higlass_viewconf = get_item_or_none(request, "00000000-1111-0000-1111-000000000000")
         higlass_viewconfig = default_higlass_viewconf["viewconfig"]
         # Add a view section if the default higlass_viewconfig lacks one
         if "views" not in higlass_viewconfig:
@@ -555,7 +555,7 @@ def get_file_higlass_information(request, file_uuids):
     for file_uuid in file_uuids:
         data = {
             "uuid" : file_uuid,
-            "data" : get_item_if_you_can(request, file_uuid),
+            "data" : get_item_or_none(request, file_uuid),
         }
 
         if data["data"] == None:


### PR DESCRIPTION
In CGAP, we renamed `get_item_if_you_can` to `get_item_or_none`. This does the same for Fourfront so that diffs of the two repos aren't gratuitously different in a bunch of places.

That's all this PR does. Nothing else riding along, so should be easy to review. :)