### PR TITLE
Rewrite pytest mocker fixture uses as unittest.mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.7.18"
+version = "1.7.19"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/check_rendering.py
+++ b/src/encoded/commands/check_rendering.py
@@ -24,6 +24,7 @@ EPILOG = __doc__
 
 logger = logging.getLogger(__name__)
 
+
 def check_path(testapp, path):
     try:
         res = testapp.get(path, status='*').maybe_follow(status='*')
@@ -54,16 +55,15 @@ def run(testapp, collections=None):
         collection_path = resource_path(collection, '')
         check_path(testapp, collection_path)
         failed = 0
+        count = -1  # PyCharm worries the 'count' variable won't get set in the next loop if the collection is empty.
         for count, item in enumerate(itervalues(collection)):
             path = resource_path(item, '')
             if not check_path(testapp, path):
                 failed += 1
         if failed:
-            logger.info('Collection %s: %d of %d failed to render.',
-                collection_path, failed, count)
+            logger.info('Collection %s: %d of %d failed to render.', collection_path, failed, count)
         else:
-            logger.info('Collection %s: all %d rendered ok',
-                collection_path, count)
+            logger.info('Collection %s: all %d rendered ok', collection_path, count)
 
 
 def internal_app(configfile, app_name=None, username='TEST', accept='text/html'):
@@ -82,8 +82,7 @@ def main():
     )
     parser.add_argument('--item-type', action='append', help="Item type")
     parser.add_argument('--app-name', help="Pyramid app name in configfile")
-    parser.add_argument('--username', '-u', default='TEST',
-        help="User uuid/email")
+    parser.add_argument('--username', '-u', default='TEST', help="User uuid/email")
     parser.add_argument('config_uri', help="path to configfile")
     parser.add_argument('path', nargs='*', help="path to test")
     args = parser.parse_args()
@@ -99,8 +98,7 @@ def main():
             if not check_path(testapp, path):
                 failed += 1
         if failed:
-            logger.info('Paths: %d of %d failed to render.',
-                failed, len(args.path))
+            logger.info('Paths: %d of %d failed to render.', failed, len(args.path))
         else:
             logger.info('Paths: all %d rendered ok', len(args.path))
     else:

--- a/src/encoded/commands/clear_db_es_contents.py
+++ b/src/encoded/commands/clear_db_es_contents.py
@@ -31,7 +31,8 @@ def clear_db_tables(app):
     """
     success = False
     session = app.registry[DBSESSION]
-    meta = MetaData(bind=session.connection(), reflect=True)
+    meta = MetaData(bind=session.connection())
+    meta.reflect()
     connection = session.connection().connect()
     try:
         # truncate tables by only deleting contents

--- a/src/encoded/commands/load_access_keys.py
+++ b/src/encoded/commands/load_access_keys.py
@@ -122,7 +122,6 @@ def main():
             except AppError:
                 log.error('load_access_keys: key_id: %s does not exist in database but exists in ES' % key_id)
 
-
         key = generate_access_key(testapp, env, user_props['uuid'], key_name)
         s3.put_object(Bucket=s3_bucket,
                       Key=key_name,

--- a/src/encoded/commands/purge_item_type.py
+++ b/src/encoded/commands/purge_item_type.py
@@ -49,7 +49,8 @@ def purge_item_type_from_storage(app, item_types, prod=False):
         try:
             pstorage.purge_uuid(uuid)
         except Exception as e:  # XXX: handle recoverable exceptions?
-            logger.error('Encountered exception purging an item type from the DB: %s' % str(e))
+            logger.error('Encountered exception purging an item type (uuid: %s) from the DB: %s'
+                         % (uuid, e))
             transaction.abort()
             return False
 

--- a/src/encoded/loadxl.py
+++ b/src/encoded/loadxl.py
@@ -40,7 +40,7 @@ ORDER = [
     'biosample',
     'organism',  # allow the 'default' linkTo in individuals work
     'workflow',
-    'vendor'
+    'vendor',
 ]
 
 IS_ATTACHMENT = [

--- a/src/encoded/memlimit.py
+++ b/src/encoded/memlimit.py
@@ -1,3 +1,8 @@
+import humanfriendly
+import logging
+import psutil
+
+
 # https://code.google.com/p/modwsgi/wiki/RegisteringCleanupCode
 
 
@@ -31,11 +36,6 @@ class ExecuteOnCompletion2:
             self.__callback(environ)
             raise
         return Generator2(result, self.__callback, environ)
-
-
-import logging
-import psutil
-import humanfriendly
 
 
 def rss_checker(rss_limit=None, rss_percent_limit=None):

--- a/src/encoded/tests/test_download.py
+++ b/src/encoded/tests/test_download.py
@@ -1,6 +1,7 @@
 import pytest
 
 from base64 import b64decode
+from unittest import mock
 
 
 pytestmark = [pytest.mark.working, pytest.mark.setone]
@@ -154,7 +155,7 @@ def test_download_remove_one(testapp, testing_download):
     assert 'attachment2' not in res.json
 
     url = testing_download + '/@@download/attachment2/red-dot.png'
-    res = testapp.get(url, status=404)
+    testapp.get(url, status=404)
 
 
 @pytest.mark.parametrize(
@@ -215,7 +216,8 @@ def test_download_create_w_wrong_md5sum(testapp):
     }}
     testapp.post_json(url, item, status=422)
 
-def test_download_item_with_attachment(testapp, award, lab, mocker):
+
+def test_download_item_with_attachment(testapp, award, lab):
     item = {
         'attachment': {
             'download': 'red-dot.png',
@@ -227,5 +229,5 @@ def test_download_item_with_attachment(testapp, award, lab, mocker):
     }
     res = testapp.post_json('/document', item).json['@graph'][0]
 
-    with mocker.patch('encoded.types.get_s3_presigned_url', return_value=''):
-        res = testapp.get(res['@id'] + res['attachment']['href'], status=200)
+    with mock.patch('encoded.types.get_s3_presigned_url', return_value=''):
+        testapp.get(res['@id'] + res['attachment']['href'], status=200)

--- a/src/encoded/tests/test_owltools.py
+++ b/src/encoded/tests/test_owltools.py
@@ -1,21 +1,16 @@
 import pytest
 
-from rdflib import (
-    # RDFS,
-    BNode,
-    # URIRef,
-    Literal
-)
+from rdflib import BNode, Literal
+from unittest import mock
 from ..commands import owltools as ot
 
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
-
 @pytest.fixture
-def owler(mocker):
-    return mocker.patch.object(ot, 'Owler')
+def owler():
+    return mock.patch.object(ot, 'Owler')
 
 
 # def emptygen(*args, **kwargs):
@@ -46,9 +41,9 @@ def rdf_objects_2_3():
     return [Literal(rdfobj) for rdfobj in rdfobjs]
 
 
-def test_get_rdfobjects_one_type_two_rdfobjs(mocker, owler, rdf_objects):
+def test_get_rdfobjects_one_type_two_rdfobjs(owler, rdf_objects):
     checks = ['testrdfobj1', 'testrdfobj2']
-    with mocker.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
+    with mock.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
         graph.objects.return_value = rdf_objects
         owler = ot.Owler('http://test.com')
         owler.rdfGraph = graph
@@ -60,9 +55,9 @@ def test_get_rdfobjects_one_type_two_rdfobjs(mocker, owler, rdf_objects):
             assert rdfobj in checks
 
 
-def test_get_rdfobjects_two_types_one_rdfobj(mocker, owler, rdf_objects_2_1):
+def test_get_rdfobjects_two_types_one_rdfobj(owler, rdf_objects_2_1):
     check = 'testrdfobj1'
-    with mocker.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
+    with mock.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
         graph.objects.return_value = rdf_objects_2_1
         owler = ot.Owler('http://test.com')
         owler.rdfGraph = graph
@@ -72,9 +67,9 @@ def test_get_rdfobjects_two_types_one_rdfobj(mocker, owler, rdf_objects_2_1):
         assert rdfobjects[0] == check
 
 
-def test_get_rdfobjects_two_types_three_rdfobj(mocker, rdf_objects_2_3):
+def test_get_rdfobjects_two_types_three_rdfobj(rdf_objects_2_3):
     checks = ['testrdfobj1', 'testrdfobj2', 'testrdfobj3']
-    with mocker.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
+    with mock.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
         graph.objects.return_value = rdf_objects_2_3
         owler = ot.Owler('http://test.com')
         owler.rdfGraph = graph
@@ -86,8 +81,8 @@ def test_get_rdfobjects_two_types_three_rdfobj(mocker, rdf_objects_2_3):
             assert rdfobj in checks
 
 
-def test_get_rdfobjects_none_there(mocker, owler):
-    with mocker.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
+def test_get_rdfobjects_none_there(owler):
+    with mock.patch('encoded.commands.owltools.ConjunctiveGraph') as graph:
         graph.objects.return_value = []
         owler = ot.Owler('http://test.com')
         owler.rdfGraph = graph

--- a/src/encoded/tests/test_owltools.py
+++ b/src/encoded/tests/test_owltools.py
@@ -8,20 +8,9 @@ from ..commands import owltools as ot
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def owler():
-    with mock.patch.object(ot, 'Owler') as mocked:
-        yield mocked
-
-
-# def emptygen(*args, **kwargs):
-#    return
-#    yield  # necessary to produce generator
-
-
-# def rdfobject_generator(rdfobj_list):
-#    for rdfobj in rdfobj_list:
-#        yield rdfobj
+    return mock.patch.object(ot, 'Owler')
 
 
 @pytest.fixture

--- a/src/encoded/tests/test_owltools.py
+++ b/src/encoded/tests/test_owltools.py
@@ -8,9 +8,10 @@ from ..commands import owltools as ot
 pytestmark = [pytest.mark.setone, pytest.mark.working]
 
 
-@pytest.fixture
+@pytest.yield_fixture
 def owler():
-    return mock.patch.object(ot, 'Owler')
+    with mock.patch.object(ot, 'Owler') as mocked:
+        yield mocked
 
 
 # def emptygen(*args, **kwargs):

--- a/src/encoded/tests/test_static_page.py
+++ b/src/encoded/tests/test_static_page.py
@@ -131,7 +131,10 @@ def test_page_unique_name(testapp, help_page, help_page_deleted):
     new_page = {'name': help_page['name']}
     res = testapp.post_json('/page', new_page, status=422)
     expected_val_err = "%s already exists with name '%s'" % (help_page['uuid'], new_page['name'])
-    assert expected_val_err in res.json['errors'][0]['description']
+    actual_error_description = res.json['errors'][0]['description']
+    print("expected:", expected_val_err)
+    print("actual:", actual_error_description)
+    assert expected_val_err in actual_error_description
 
     # also test PATCH of an existing page with another name
     res = testapp.patch_json(help_page_deleted['@id'], {'name': new_page['name']}, status=422)

--- a/src/encoded/tests/test_types_gene.py
+++ b/src/encoded/tests/test_types_gene.py
@@ -1,5 +1,6 @@
 import pytest
 
+from unittest import mock
 from ..types.gene import (
     fetch_gene_info_from_ncbi,
     get_gene_info_from_response_text,
@@ -109,18 +110,18 @@ class MockedResponse(object):
         self.text = text
 
 
-def test_fetch_gene_info_from_ncbi_429_response(mocker):
-    ''' mocking a bad ncbi response - because this sleeps it's slow'''
+def test_fetch_gene_info_from_ncbi_429_response():
+    """ mocking a bad ncbi response - because this sleeps it's slow"""
     geneid = '5885'  # human rad21
-    with mocker.patch('encoded.types.gene.requests.get', side_effect=[MockedResponse(429, 'response')] * 5):
+    with mock.patch('encoded.types.gene.requests.get', side_effect=[MockedResponse(429, 'response')] * 5):
         result = fetch_gene_info_from_ncbi(geneid)
         assert not result
 
 
-def test_fetch_gene_info_from_ncbi_200_bogus_response(mocker):
-    ''' mocking a bad but 200 ncbi response'''
+def test_fetch_gene_info_from_ncbi_200_bogus_response():
+    """ mocking a bad but 200 ncbi response"""
     geneid = '5885'  # human rad21
-    with mocker.patch('encoded.types.gene.requests.get', return_value=MockedResponse(200, 'response')):
+    with mock.patch('encoded.types.gene.requests.get', return_value=MockedResponse(200, 'response')):
         result = fetch_gene_info_from_ncbi(geneid)
         assert not result
 


### PR DESCRIPTION
This rewrites Fourfront's uses of pytest `mocker` to use `unittest.mock` instead.

(There are also a few stray cosmetic changes riding along that came up due to leveling with CGAP, etc.)
