### PR TITLE
Generate ontology keyarg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.7.14"
+version = "1.7.15"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -968,7 +968,7 @@ def parse_args(args):
     parser.add_argument('--key',
                         default=None,
                         help="An access key dictionary including key, secret and server.\
-                        {'key'='ABCDEF', 'secret'='supersecret', 'server'='https://data.4dnucleome.org'}")
+                        \"{'key': 'ABCDEF', 'secret': 'supersecret', 'server': 'https://data.4dnucleome.org'}\" ")
     parser.add_argument('--keyfile',
                         default='',
                         help="A file where access keys are stored.")

--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -444,7 +444,6 @@ def connect2server(env=None, key=None):
         sys.exit(1)
 
     print("Running on: {server}".format(server=auth.get('server')))
-    print(auth)
     return auth
 
 

--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -434,10 +434,7 @@ def connect2server(env=None, key=None):
        reached with that key.
        Also handles keyfiles stored in s3"""
 
-    if key == 's3':
-        assert env
-        key = None
-    elif all([v in key for v in ['key', 'secret', 'server']]):
+    if key and all([v in key for v in ['key', 'secret', 'server']]):
         key = ast.literal_eval(key)
 
     try:
@@ -447,6 +444,7 @@ def connect2server(env=None, key=None):
         sys.exit(1)
 
     print("Running on: {server}".format(server=auth.get('server')))
+    print(auth)
     return auth
 
 
@@ -969,7 +967,7 @@ def parse_args(args):
                         help="The environment to use i.e. data, webdev, mastertest.\
                         Default is 'data')")
     parser.add_argument('--key',
-                        default='s3',
+                        default=None,
                         help="An access key dictionary including key, secret and server.\
                         {'key'='ABCDEF', 'secret'='supersecret', 'server'='https://data.4dnucleome.org'}")
     parser.add_argument('--keyfile',
@@ -1003,12 +1001,12 @@ def main():
     print('Writing to %s' % postfile)
 
     # fourfront connection
-    if args.key == 's3' and args.keyfile:
+    if args.keyfile:
         with open(args.keyfile, 'r') as keyfile:
             keys = json.load(keyfile)
         key = str(keys[args.keyname])
     else:
-        key = str(args.key)
+        key = args.key
     connection = connect2server(args.env, key)
     print("Pre-processing")
     ontologies = get_ontologies(connection, args.ontology)

--- a/src/encoded/tests/test_generate_ontology.py
+++ b/src/encoded/tests/test_generate_ontology.py
@@ -14,7 +14,7 @@ def test_parse_args_defaults():
     args = []
     args = go.parse_args(args)
     assert args.ontology == 'all'
-    assert args.key == 's3'
+    assert args.key is None
     assert args.env == 'data'
 
 


### PR DESCRIPTION
This changes the default for the `--key` argument for generate_ontology from `"s3"` to `None`. Basic authentication behavior remains the same.
- If keyfile is specified, will try to look up key from file.
- Otherwise, if key is specified, will use key for authentication.
- Otherwise, will try to look up key from s3 using env. 