### PR TITLE
File Type and Format Fields Added To ExpSet Raw Files Table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.7.21"
+version = "1.7.22"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/components/file-tables.js
+++ b/src/encoded/static/components/browse/components/file-tables.js
@@ -892,6 +892,22 @@ export class RawFilesStackedTableExtendedColumns extends React.PureComponent {
                 }
             ]);
         }
+        else { //if files do not have qc metric columns, then display default file format and type columns
+            extendedPropColHeaders = columnHeaders.slice().concat([
+                {
+                    columnClass: 'file-detail',
+                    title: 'File Format',
+                    initialWidth: 110,
+                    field : "file_format.display_title"
+                },
+                {
+                    columnClass: 'file-detail',
+                    title: 'File Type',
+                    initialWidth: 110,
+                    field : "file_type"
+                }
+            ]);
+        }
 
         return <RawFilesStackedTable {...this.props} columnHeaders={extendedPropColHeaders} />;
     }


### PR DESCRIPTION
**From Trello:**

For microscopy experiment sets, we don’t have file format or filetype for the raw files
i.e. https://data.4dnucleome.org/experiment-set-replicates/4DNES6MUQJPB/#raw-files
If I go to experiments page, they are available
https://data.4dnucleome.org/experiments-mic/4DNEX4V6R1P2/#raw-files
So the desired behaviour is: For fastq files, we show fastq specific info, as we do. For other files, we show file format and file type?

**Solution:**

If raw files table does not have any quality metrics column(s), then we add file format and file type columns instead of qc columns. This behaviour works for all type of files, e.g. if fastq files lack QC metrics, then file format and file type columns are rendered instead.

Files not having QC metrics (file type and format rendered):
<img width="1167" alt="Screen Shot 2020-07-16 at 14 55 56" src="https://user-images.githubusercontent.com/49978017/87668255-7ae23400-c774-11ea-8d7f-2e0a8c5616f3.png">

Files having QC metrics (file type and format not rendered):
<img width="1153" alt="Screen Shot 2020-07-16 at 14 57 08" src="https://user-images.githubusercontent.com/49978017/87668372-a533f180-c774-11ea-8241-2c84a979a284.png">
