### PR TITLE
Move in (+quickfix) CSS for ItemPageTable from SPC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3604,8 +3604,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#3ee351d4b44d48059c3b1f4fe21bd603e2ffb97e",
-      "from": "github:4dn-dcic/shared-portal-components#0.0.2.67",
+      "version": "github:4dn-dcic/shared-portal-components#b3fd1e79ca9cc340d31d25e786c49438a0459f14",
+      "from": "github:4dn-dcic/shared-portal-components#0.0.2.68",
       "requires": {
         "auth0-lock": "^11.25.1",
         "aws-sdk": "^2.714.0",
@@ -4211,6 +4211,11 @@
         }
       }
     },
+    "@popperjs/core": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
+      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+    },
     "@restart/context": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
@@ -4353,6 +4358,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/yargs": {
       "version": "13.0.2",
@@ -5398,9 +5408,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.727.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.727.0.tgz",
-      "integrity": "sha512-otAkNVJlTkydet+/FhYU+Ftrye/fZ0lDCliaO3aYPdqJvlMA8QnJWQjPxao73qUHHOgo89Kw2YJ4VK0S8Ph/RA==",
+      "version": "2.730.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.730.0.tgz",
+      "integrity": "sha512-hYHplsbgUDP0XuaVJaHx2L/nC0E1i+4dGlkAQpkJz3qQ4NDfLnrbUFsA2g3AyWAsrnjrBNCkexPvwnV82Qng1g==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4211,11 +4211,6 @@
         }
       }
     },
-    "@popperjs/core": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
-      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
-    },
     "@restart/context": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
@@ -4358,11 +4353,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
-    },
-    "@types/warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/yargs": {
       "version": "13.0.2",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "4dn-microscopy-metadata-tool": "github:WU-BIMAC/4DNMicroscopyMetadataToolReact#0.0.0.18",
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.67",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.68",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",
     "detect-browser": "^3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.8.7"
+version = "1.8.8"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/FileView.js
+++ b/src/encoded/static/components/item-pages/FileView.js
@@ -92,59 +92,53 @@ export default class FileView extends WorkflowRunTracingView {
 }
 
 
-class FileViewOverview extends React.PureComponent {
 
-    static getTabObject({ context, schemas, windowWidth, href }, width){
-        return {
-            'tab' : <span><i className="icon icon-file-alt fas icon-fw"/> Overview</span>,
-            'key' : 'file-overview',
-            //'disabled' : !Array.isArray(context.experiments),
-            'content' : (
-                <div className="overflow-hidden">
-                    <h3 className="tab-section-title">
-                        <span>More Information</span>
-                    </h3>
-                    <hr className="tab-section-title-horiz-divider"/>
-                    <FileViewOverview {...{ context, width, windowWidth, schemas, href }} />
-                </div>
-            )
-        };
-    }
-
-    static propTypes = {
-        'context' : PropTypes.shape({
-            'experiments' : PropTypes.arrayOf(PropTypes.shape({
-                'experiment_sets' : PropTypes.arrayOf(PropTypes.shape({
-                    '@id' : PropTypes.string.isRequired
-                }))
-            })),
-            'experiment_sets' : PropTypes.arrayOf(PropTypes.shape({
-                'experiments_in_set' : PropTypes.arrayOf(PropTypes.shape({
-                    '@id' : PropTypes.string.isRequired
-                }))
-            }))
-        }).isRequired
-    };
-
-    render(){
-        const { context, windowWidth, width, schemas, href } = this.props;
-        const experimentSetUrls = expFxn.experimentSetsFromFile(context, 'ids');
-
-        return (
-            <div>
-                <div className="row overview-blocks">
-                    <ExternalVisualizationButtons file={context} href={href} wrapInColumn="col-12" />
-                    <QualityControlResults file={context} wrapInColumn="col-md-6" hideIfNoValue schemas={schemas} />
-                    <RelatedFilesOverViewBlock file={context} property="related_files" wrapInColumn="col-md-6" hideIfNoValue schemas={schemas} />
-                </div>
-                { experimentSetUrls && experimentSetUrls.length > 0 ?
-                    <ExperimentSetTablesLoaded {...{ experimentSetUrls, width, windowWidth }} defaultOpenIndices={[0]} id={object.itemUtil.atId(context)} />
-                    : null }
+function FileViewOverview (props) {
+    const { context, windowWidth, width, schemas, href } = props;
+    const experimentSetUrls = expFxn.experimentSetsFromFile(context, 'ids');
+    return (
+        <div>
+            <div className="row overview-blocks">
+                <ExternalVisualizationButtons file={context} href={href} wrapInColumn="col-12" />
+                <QualityControlResults file={context} wrapInColumn="col-md-6" hideIfNoValue schemas={schemas} />
+                <RelatedFilesOverViewBlock file={context} property="related_files" wrapInColumn="col-md-6" hideIfNoValue schemas={schemas} />
             </div>
-        );
-    }
-
+            { experimentSetUrls && experimentSetUrls.length > 0 ?
+                <ExperimentSetTablesLoaded {...{ experimentSetUrls, width, windowWidth }} defaultOpenIndices={[0]} id={object.itemUtil.atId(context)} />
+                : null }
+        </div>
+    );
 }
+FileViewOverview.propTypes = {
+    'context' : PropTypes.shape({
+        'experiments' : PropTypes.arrayOf(PropTypes.shape({
+            'experiment_sets' : PropTypes.arrayOf(PropTypes.shape({
+                '@id' : PropTypes.string.isRequired
+            }))
+        })),
+        'experiment_sets' : PropTypes.arrayOf(PropTypes.shape({
+            'experiments_in_set' : PropTypes.arrayOf(PropTypes.shape({
+                '@id' : PropTypes.string.isRequired
+            }))
+        }))
+    }).isRequired
+};
+FileViewOverview.getTabObject = function({ context, schemas, windowWidth, href }, width){
+    return {
+        'tab' : <span><i className="icon icon-file-alt fas icon-fw"/> Overview</span>,
+        'key' : 'file-overview',
+        //'disabled' : !Array.isArray(context.experiments),
+        'content' : (
+            <div className="overflow-hidden">
+                <h3 className="tab-section-title">
+                    <span>More Information</span>
+                </h3>
+                <hr className="tab-section-title-horiz-divider"/>
+                <FileViewOverview {...{ context, width, windowWidth, schemas, href }} />
+            </div>
+        )
+    };
+};
 
 
 export class FileOverviewHeading extends React.PureComponent {

--- a/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
+++ b/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
@@ -164,7 +164,7 @@ export class ItemPageTable extends React.Component {
                             );
                         }
                     }
-    
+
                     return (
                         <DisplayTitleColumnWrapper {...{ rowNumber, detailOpen, toggleDetailOpen }} result={result}>
                             <DisplayTitleColumnDefault />

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -84,7 +84,7 @@ $search-results-above-results-row-height: 40px;
 
 // Extensions to shared-portal-components searchview table(s):
 .search-result-row .result-table-row .search-result-column-block,
-.item-page-table-container .item-page-table-row-container .table-row > .column {
+.item-page-table-container .item-page-table-row-container .table-row > .column { // Carry/re-use table cell styles over to ItemPageTable (to be deprecated).
 	&[data-field="status"] {
 		> .inner {
 			i.item-status-indicator-dot {
@@ -148,6 +148,83 @@ $search-results-above-results-row-height: 40px;
 		}
 	}
 }
+
+/**********************************************************
+			In Experiment Sets Table (Item Pages)
+			// Carry/re-use table cell styles over to ItemPageTable (to be deprecated).
+**********************************************************/
+
+
+.item-page-table-container {
+	
+	overflow-x: auto;
+
+	.item-page-table-row-container {
+		position: relative;
+		border-bottom: 1px solid #eee;
+
+		> .inner-wrapper {
+			padding-left: 0;
+			border-top: 1px solid #eee;
+			padding-left: 47px;
+			@include generic-results-flex-description-container;
+			@include generic-results-item-detail;
+			
+		}
+
+		.table-row {
+			.column {
+				@include search-result-column-block;
+				float: none;
+				display: inline-block;
+				vertical-align: middle;
+				&:first-child {
+
+					> .inner {
+						height: auto;
+						white-space: normal;
+
+						padding-right: 0;
+
+						.title-wrapper {
+							padding-left: 7px;
+							line-height: 1.25rem;
+							max-width: 100%;
+						}
+
+						@include search-result-toggle-open-button-container;
+						&.open {
+							@include search-result-toggle-open-button-container-open;
+							.toggle-detail-button-container {
+								bottom: 0px;
+							}
+							.icon-container {
+								top: 15px !important;
+							}
+						}
+					}
+				}
+
+			}
+
+			&.no-detail-pane {
+				.column {
+					&[data-first-visible-column] {
+						> .inner {
+							padding-left: 17px;
+							padding-right: 0;
+						}
+					}
+				}
+			}
+
+		}
+
+	}
+
+}
+
+
 
 /********************************/
 /***** Search Table Wrapper *****/


### PR DESCRIPTION
2020-08-10 - Pushed SPC PR https://github.com/4dn-dcic/shared-portal-components/pull/36 which removes this block of CSS there

### TODO:
- Merge above SPC PR, release new SPC version (SPCv).
- Update shared-portal-components version (SPCv) in package.json, along w. lockfile in this branch, review+merge.

