### PR TITLE
GRCz11/danRer11 as new genome_assembly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "1.8.2"
+version = "1.8.3"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -118,7 +118,8 @@
                 "GRCh38",
                 "GRCm38",
                 "dm6",
-                "galGal5"
+                "galGal5",
+                "GRCz11"
             ]
         },
         "produced_from": {

--- a/src/encoded/schemas/file_reference.json
+++ b/src/encoded/schemas/file_reference.json
@@ -69,7 +69,8 @@
                 "GRCh38",
                 "GRCm38",
                 "dm6",
-                "galGal5"
+                "galGal5",
+                "GRCz11"
             ]
         }
     }

--- a/src/encoded/schemas/file_vistrack.json
+++ b/src/encoded/schemas/file_vistrack.json
@@ -61,7 +61,8 @@
                 "GRCh38",
                 "GRCm38",
                 "dm6",
-                "galGal5"
+                "galGal5",
+                "GRCz11"
             ]
         },
         "biosource": {

--- a/src/encoded/schemas/genomic_region.json
+++ b/src/encoded/schemas/genomic_region.json
@@ -36,7 +36,8 @@
                 "GRCh38",
                 "GRCm38",
                 "dm6",
-                "galGal5"
+                "galGal5",
+                "GRCz11"
             ]
         },
         "chromosome": {

--- a/src/encoded/schemas/higlass_view_config.json
+++ b/src/encoded/schemas/higlass_view_config.json
@@ -36,7 +36,7 @@
                 "dm6",
                 "galGal5",
                 "chlSab2",
-                "GRCz10"
+                "GRCz11"
             ]
         },
         "viewconfig": {
@@ -172,8 +172,8 @@
                                     "static" : {
                                         "type" : "boolean",
                                         "default" : true
-                                    }                                   
-                                   
+                                    }
+
                                 }
                             },
                             "tracks" : {
@@ -197,7 +197,7 @@
                                                 },
                                                 "height" : {
                                                     "type" : "integer"
-                                                },                                               
+                                                },
                                                 "orientation" : {
                                                     "type" : "string",
                                                     "comment" : "This might be an ENUM, need to figure out.",
@@ -268,7 +268,7 @@
                                                                 "default": false,
                                                                 "description": "Applicable for BigWig and other 1D track files."
                                                                                                        }
-                                                       
+
                                                     }
                                                 }
                                             }
@@ -365,7 +365,7 @@
                                                             "type" : "boolean",
                                                             "default": false,
                                                             "description": "Applicable for BigWig and other 1D track files."
-                                                        }                                                    
+                                                        }
                                                     }
                                                 }
                                             }
@@ -389,7 +389,7 @@
                                                 },
                                                 "height" : {
                                                     "type" : "integer"
-                                                },                                                
+                                                },
                                                 "orientation" : {
                                                     "type" : "string",
                                                     "comment" : "This might be an ENUM, need to figure out.",
@@ -643,7 +643,7 @@
                     "https://higlass.4dnucleome.org/api/v1"
                 ],
                 "views": []
-            }     
+            }
         },
         "instance_height": {
             "title": "Instance Height",

--- a/src/encoded/schemas/organism.json
+++ b/src/encoded/schemas/organism.json
@@ -70,7 +70,7 @@
                 "dm6",
                 "galGal5",
                 "chlSab2",
-                "GRCz10"
+                "GRCz11"
             ]
         }
     }

--- a/src/encoded/tests/data/master-inserts/organism.json
+++ b/src/encoded/tests/data/master-inserts/organism.json
@@ -37,7 +37,7 @@
         "name": "zebrafish",
         "scientific_name": "Danio rerio",
         "taxon_id": "7955",
-        "genome_assembly": "GRCz10",
+        "genome_assembly": "GRCz11",
         "uuid": "30b53150-cff7-43ed-a8d6-fc5836df98a7"
     }
 ]


### PR DESCRIPTION
GRCz11 option added to `genome_assembly` enums in the following schemas:
- file_reference.json
- file_processed.json
- file_vistrack.json
- genomic_region.json
- higlass_view_config.json
- organism.json

In addition:
- zebrafish insert in organism master-inserts edited to use GRCz11
- references to GRCz10 removed