### PR TITLE
Add date_approved property to protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.0.10"
+version = "2.0.11"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/protocol.json
+++ b/src/encoded/schemas/protocol.json
@@ -80,6 +80,16 @@
             "description": "An external resource with additional information about the protocol.",
             "type": "string",
             "format": "uri"
+        },
+        "date_approved": {
+            "title": "Date of Approval",
+            "description": "The date on which the SOP was approved by the 4DN consortium steering committee",
+            "comment": "Should only be used in conjunction with 4DN Standard tag for protocols approved by the consortium",
+            "type": "string",
+            "anyOf": [
+                {"format": "date-time"},
+                {"format": "date"}
+            ]
         }
     },
     "facets": {

--- a/src/encoded/static/components/util/Schemas.js
+++ b/src/encoded/static/components/util/Schemas.js
@@ -53,6 +53,7 @@ export const Term = {
             case 'date_created':
             case 'public_release':
             case 'project_release':
+            case 'date_approved':
                 if (allowJSXOutput) name = <LocalizedTime timestamp={term} />;
                 else name = dateFormat(term);
                 break;

--- a/src/encoded/types/protocol.py
+++ b/src/encoded/types/protocol.py
@@ -18,7 +18,7 @@ class Protocol(Item, ItemWithAttachment):
 
     item_type = 'protocol'
     schema = load_schema('encoded:schemas/protocol.json')
-    embedded_list = Item.embedded_list + ["award.project", "lab.title"]
+    embedded_list = Item.embedded_list + ["award.project", "lab.title", "experiment_type.display_title"]
     rev = {
         'exp_type': ('ExperimentType', 'other_protocols'),
         'sop_exp': ('ExperimentType', 'sop')


### PR DESCRIPTION
In order to support and embedded search table in a static section for 4DN approved protocols:
- Add date_approved property to protocol
- embedded ExperimentType in Protocol
-  tweaked javascript to format date on this field appropriately