### PR TITLE
ExperimentSetsTableTabViewTitle Edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5561,9 +5561,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.772.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.772.0.tgz",
-      "integrity": "sha512-am1xrqaQhHbZsSbbZ8l0nRzl4dfCG+HGUAsgNGQp3RGwEZX8Eblge4dGPmg3A1ZyCHAzT1VIWxemOOCiyqJC/A==",
+      "version": "2.773.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.773.0.tgz",
+      "integrity": "sha512-bwqEm/x3HMUd/xfcUeTjCQFi904oSNcwl2ZNz3mwAdEIqt3sQ9aE3GYoZQxKXw/XHQlF7hPiKO07GDGmS6x4AQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.1.1"
+version = "2.1.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/ExperimentTypeView.js
+++ b/src/encoded/static/components/item-pages/ExperimentTypeView.js
@@ -25,7 +25,7 @@ export default class ExperimentTypeView extends DefaultItemView {
                 "experiments_in_set.experiment_type.display_title=" + encodeURIComponent(context.display_title)
             ),
             'facets' : null,
-            // Gets passed down to `ExperimentSetsTableTabView` which passes it down to `ExperimentSetsTableTabViewTitle`
+            // Gets passed down to `ExperimentSetsTableTabView` which passes it down to `SearchTableTitle`
             'externalSearchLinkVisible' : true
         };
 

--- a/src/encoded/static/components/item-pages/FileMicroscopyView.js
+++ b/src/encoded/static/components/item-pages/FileMicroscopyView.js
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { isServerSide, console, object } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { expFxn } from './../util';
-import { EmbeddedExperimentSetSearchTable, ExperimentSetsTableTabViewTitle } from './components/tables/ExperimentSetTables';
+import { SearchTableTitle } from './components/tables/ItemPageTable';
+import { EmbeddedExperimentSetSearchTable } from './components/tables/ExperimentSetTables';
 import { OverViewBodyItem } from './DefaultItemView';
 import FileView, { RelatedFilesOverViewBlock } from './FileView';
 import { QualityControlResults } from './QualityMetricView';
@@ -66,7 +67,7 @@ class FileMicroscopyViewOverview extends React.Component {
             searchHref,
             facets: null,
             defaultOpenIndices: [0],
-            title: <ExperimentSetsTableTabViewTitle externalSearchLinkVisible />
+            title: <SearchTableTitle title="Experiment Set" externalSearchLinkVisible />
         };
 
         return (

--- a/src/encoded/static/components/item-pages/FileView.js
+++ b/src/encoded/static/components/item-pages/FileView.js
@@ -11,7 +11,8 @@ import { getItemType } from '@hms-dbmi-bgm/shared-portal-components/es/component
 import { expFxn, Schemas, fileUtil } from './../util';
 import { store } from './../../store';
 
-import { ExperimentSetsTableTabView, EmbeddedExperimentSetSearchTable, ExperimentSetsTableTabViewTitle } from './components/tables/ExperimentSetTables';
+import { SearchTableTitle } from './components/tables/ItemPageTable';
+import { ExperimentSetsTableTabView, EmbeddedExperimentSetSearchTable } from './components/tables/ExperimentSetTables';
 import { OverviewHeadingContainer } from './components/OverviewHeadingContainer';
 import { OverViewBodyItem, WrapInColumn } from './DefaultItemView';
 import WorkflowRunTracingView, { FileViewGraphSection } from './WorkflowRunTracingView';
@@ -104,7 +105,7 @@ function FileViewOverview (props) {
         searchHref,
         facets: null,
         defaultOpenIndices: [0],
-        title: <ExperimentSetsTableTabViewTitle externalSearchLinkVisible={false} />
+        title: <SearchTableTitle title="Experiment Set" externalSearchLinkVisible={false} />
     };
     return (
         <div>

--- a/src/encoded/static/components/item-pages/components/tables/ExperimentSetTables.js
+++ b/src/encoded/static/components/item-pages/components/tables/ExperimentSetTables.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import _ from 'underscore';
 import memoize from 'memoize-one';
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
-import { ItemPageTable, ItemPageTableIndividualUrlLoader, ViewMoreResultsBtn, EmbeddedItemSearchTable } from './ItemPageTable';
+import { ItemPageTable, ItemPageTableIndividualUrlLoader, ViewMoreResultsBtn, EmbeddedItemSearchTable, SearchTableTitle } from './ItemPageTable';
 import { ExperimentSetDetailPane } from './../../../browse/components/ExperimentSetDetailPane';
 import { columnExtensionMap as columnExtensionMap4DN } from './../../../browse/columnExtensionMap';
 
@@ -77,7 +77,7 @@ export function ExperimentSetsTableTabView(props){
     const tableProps = {
         searchHref, facets, columns, defaultOpenIndices, schemas, session,
         maxHeight, filterFacetFxn, filterColumnFxn, hideFacets, hideColumns,
-        title: typeof title === "undefined" ? <ExperimentSetsTableTabViewTitle {...{ externalSearchLinkVisible }} /> : title
+        title: typeof title === "undefined" ? <SearchTableTitle {...{ title: "Experiment Set", externalSearchLinkVisible }} /> : title
     };
     return <EmbeddedExperimentSetSearchTable {...tableProps}>{ children }</EmbeddedExperimentSetSearchTable>;
 }
@@ -89,35 +89,6 @@ ExperimentSetsTableTabView.getTabObject = function(props){
         'content' : <ExperimentSetsTableTabView {...props} />
     };
 };
-
-/**
- * @todo Eventually maybe add UI controls for selecting columns and other things into here.
- */
-export function ExperimentSetsTableTabViewTitle(props) {
-    const {
-        totalCount,
-        href: currentSearchHref,
-        externalSearchLinkVisible = true
-    } = props;
-    const linkText = currentSearchHref && typeof currentSearchHref === 'string' && currentSearchHref.indexOf('/browse/') > -1 ?
-        'Open In Browse View' : 'Open In Search View';
-    return (
-        <h3 className="tab-section-title">
-            <span>
-                {typeof totalCount === "number" ? <span className="text-500">{totalCount + " "}</span> : null}
-                {"Experiment Set" + (typeof totalCount === "number" && totalCount !== 1 ? "s" : "")}
-            </span>
-            { externalSearchLinkVisible && currentSearchHref ?
-                <a href={currentSearchHref} className="btn btn-primary pull-right" style={{ marginTop: '-10px' }} data-tip="Run embedded search query in Browse/Search View">
-                    <i className="icon icon-fw fas icon-external-link-alt mr-07 align-baseline"></i>
-                    { linkText }
-                </a>
-                : null }
-        </h3>
-    );
-}
-
-
 
 /** @deprecated - Waiting until can use EmbeddedExperimentSetSearchTable everywhere */
 export class ExperimentSetTables extends React.PureComponent {

--- a/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
+++ b/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
@@ -92,12 +92,35 @@ export class EmbeddedItemSearchTable extends React.PureComponent {
     }
 }
 
+/**
+ * @todo Eventually maybe add UI controls for selecting columns and other things into here.
+ */
+export function SearchTableTitle(props) {
+    const {
+        totalCount,
+        href: currentSearchHref,
+        externalSearchLinkVisible = true,
+        title: propTitle
+    } = props;
 
-
-
-
-
-
+    const title = (propTitle && typeof propTitle === 'string') ? propTitle : 'Item';
+    const linkText = currentSearchHref && typeof currentSearchHref === 'string' && currentSearchHref.indexOf('/browse/') > -1 ?
+        'Open In Browse View' : 'Open In Search View';
+    return (
+        <h3 className="tab-section-title">
+            <span>
+                {typeof totalCount === "number" ? <span className="text-500">{totalCount + " "}</span> : null}
+                {title + (typeof totalCount === "number" && totalCount !== 1 ? "s" : "")}
+            </span>
+            { externalSearchLinkVisible && currentSearchHref ?
+                <a href={currentSearchHref} className="btn btn-primary pull-right" style={{ marginTop: '-10px' }} data-tip="Run embedded search query in Browse/Search View">
+                    <i className="icon icon-fw fas icon-external-link-alt mr-07 align-baseline"></i>
+                    { linkText }
+                </a>
+                : null }
+        </h3>
+    );
+}
 
 /** @deprecated */
 
@@ -307,8 +330,6 @@ class ItemPageTableRow extends React.PureComponent {
     }
 }
 
-
-
 export class ItemPageTableIndividualUrlLoader extends React.PureComponent {
 
     static propTypes = {
@@ -395,7 +416,6 @@ export function ViewMoreResultsBtn(props){
         return (countTotalResults - visibleResultCount) + ' more ' + itemTypeTitle + 's';
     }
 }
-
 
 /**
  * TODO: Once/if /search/ accepts POST JSON requests, we can do one single request to get all Items by @id from /search/ instead of multiple AJAX requests.

--- a/src/encoded/static/components/item-pages/components/tables/index.js
+++ b/src/encoded/static/components/item-pages/components/tables/index.js
@@ -8,12 +8,11 @@
  * @module
  */
 
-export { ItemPageTable, ItemPageTableIndividualUrlLoader, ItemPageTableBatchLoader, EmbeddedItemSearchTable } from './ItemPageTable';
+export { ItemPageTable, SearchTableTitle, ItemPageTableIndividualUrlLoader, ItemPageTableBatchLoader, EmbeddedItemSearchTable } from './ItemPageTable';
 
 export {
     EmbeddedExperimentSetSearchTable,
     ExperimentSetsTableTabView,
-    ExperimentSetsTableTabViewTitle,
     /* Somewhat deprecated: */
     ExperimentSetTables,
     ExperimentSetTablesLoaded,

--- a/src/encoded/static/components/static-pages/placeholders/index.js
+++ b/src/encoded/static/components/static-pages/placeholders/index.js
@@ -9,7 +9,7 @@ import { SlideCarousel } from './SlideCarousel';
 import { BasicCarousel } from './BasicCarousel';
 import { JointAnalysisMatrix } from './JointAnalysisMatrix';
 import { ExperimentSetMatrix } from './ExperimentSetMatrix';
-import { EmbeddedItemSearchTable } from './../../item-pages/components/tables/ItemPageTable';
+import { EmbeddedItemSearchTable, SearchTableTitle } from './../../item-pages/components/tables/ItemPageTable';
 import { MdSortableTable } from './MdSortableTable';
 
 export { SlideCarousel, BasicCarousel, JointAnalysisMatrix, ExperimentSetMatrix, MdSortableTable };
@@ -19,7 +19,7 @@ export { SlideCarousel, BasicCarousel, JointAnalysisMatrix, ExperimentSetMatrix,
  * Any placeholder(s) used in a StaticSection _must_ get imported here
  * and be available here.
  */
-const placeholders = { SlideCarousel, BasicCarousel, JointAnalysisMatrix, ExperimentSetMatrix, EmbeddedItemSearchTable, MdSortableTable };
+const placeholders = { SlideCarousel, BasicCarousel, JointAnalysisMatrix, ExperimentSetMatrix, EmbeddedItemSearchTable, SearchTableTitle, MdSortableTable };
 
 export const replaceString = memoize(function(placeholderString, props){
 

--- a/src/encoded/static/data/embedded-search-table-demo.jsx
+++ b/src/encoded/static/data/embedded-search-table-demo.jsx
@@ -10,8 +10,9 @@
     <ul>
         <li key="0"><code>searchHref="/search/?type=Item..."</code> - This is the initial search URL, including URL query parameters, to search.</li>
         <li key="1"><code>{'schemas={schemas}'}</code> - This should always be <code>{'schemas={schemas}'}</code>, it means to use/pass-in in-code variable <code>schemas</code>, which contains definitions for facets, columns, property titles, and so forth by Item Type.</li>
-        <li key="1"><code>{'session={session}'}</code> - This should always be <code>{'session={session}'}</code>, it means to use/pass-in in-code variable <code>session</code>, which is a boolean informing whether end-user is logged in, change of which triggers results refresh.</li>
-        <li key="2"><code>{'key="anyRandomTextString"'}</code> - This should always be set to any random string value, it tells React to avoid completely initiating a new instance of this component on extraneous changes, e.g. browser window width. This may be excluded if your component is within a parent/root JSX element that has a <code>key</code> prop, such as this static section.</li>
+        <li key="2"><code>{'session={session}'}</code> - This should always be <code>{'session={session}'}</code>, it means to use/pass-in in-code variable <code>session</code>, which is a boolean informing whether end-user is logged in, change of which triggers results refresh.</li>
+        <li key="3"><code>{'key="anyRandomTextString"'}</code> - This should always be set to any random string value, it tells React to avoid completely initiating a new instance of this component on extraneous changes, e.g. browser window width. This may be excluded if your component is within a parent/root JSX element that has a <code>key</code> prop, such as this static section.</li>
+        <li key="4"><code>{'title="anyString or React component"'}</code> - Title is optional, you can completely exlude it by not defining <code>title</code> prop at all or you can supply a plain text or allowed React component. It is highly recommended to use the built-in <code>SearchTableTitle</code> component:  <pre className="border rounded px-3 py-2">{'<SearchTableTitle title="Experiment Set or File or ..etc" externalSearchLinkVisible />'}</pre></li>
     </ul>
 
     <hr className="mt-2"/>
@@ -119,6 +120,30 @@
         }
     }}
 />
+
+    <h3>Title Configuration</h3>
+
+    <h4 className="mt-2">No Title</h4>
+
+    <p>Set <code>{"title={null}"}</code> or do not define <code>title</code> at all.</p>
+
+    <h4 className="mt-2">Default Title</h4>
+
+    <p>
+        The built-in <code>SearchTableTitle</code> component renders the total count of type (you should also pass it as title prop into SearchTableTitle) and an optional Browse/Search button that redirects you to Browse or Search pages with respectively.
+    </p>
+
+    <pre className="border rounded px-3 py-2">{'<EmbeddedItemSearchTable\r\n        searchHref="\/search/?type=Biosource"\r\n        schemas={schemas}\r\n        session={session}\r\n        facets={null}\r\n        title={<SearchTableTitle title="Biosource" externalSearchLinkVisible={true} />}\r\n    />'}</pre>
+
+    <p>This generates the following table:</p>
+
+    <EmbeddedItemSearchTable
+        searchHref="/search/?type=Biosource"
+        schemas={schemas}
+        session={session}
+        facets={null}
+        title={<SearchTableTitle title="Biosource" externalSearchLinkVisible={true} />}
+    />
 
 </div>
 


### PR DESCRIPTION
`ExperimentSetsTableTabViewTitle` used to be a customized title for **Experiment Sets** embedded search tables but its scope is now expanding for `EmbeddedItemSearchTable`:

1. `ExperimentSetsTableTabViewTitle` is renamed as `SearchTableTitle`.
2. added into the placeholders that allows the jsx component to be embedded in static sections.
3. gets a `title` prop to customize search type text.

PS: `embedded-search-table-demo.jsx` is also updated.