### PR TITLE
add dataset group properties to ExpSet schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.0.11"
+version = "2.0.12"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/experiment_set.json
+++ b/src/encoded/schemas/experiment_set.json
@@ -96,6 +96,29 @@
             "lookup": 20,
             "formInput": "textarea"
         },
+        "dataset_group": {
+            "title": "Dataset Group",
+            "description": "An optional property to group datasets in a single row in the datasets summary table",
+            "type": "string",
+            "lookup": 900
+        },
+        "study": {
+            "title": "Study",
+            "description": "Study title to be shown in the datasets summary table",
+            "type": "string",
+            "lookup": 901
+        },
+        "study_group": {
+            "title": "Study Group",
+            "description": "Static section in the summary table",
+            "type": "string",
+            "lookup": 902,
+            "enum": [
+                "Single Time Point and Condition",
+                "Time Course",
+                "Disrupted or Atypical Cells"
+            ]
+        },
         "processed_files": {
             "title": "Processed Files",
             "description": "Processed files that are derived from files in this experiment set.",

--- a/src/encoded/schemas/experiment_set.json
+++ b/src/encoded/schemas/experiment_set.json
@@ -100,18 +100,21 @@
             "title": "Dataset Group",
             "description": "An optional property to group datasets in a single row in the datasets summary table",
             "type": "string",
+            "exclude_from": ["submit4dn"],
             "lookup": 900
         },
         "study": {
             "title": "Study",
             "description": "Study title to be shown in the datasets summary table",
             "type": "string",
+            "exclude_from": ["submit4dn"],
             "lookup": 901
         },
         "study_group": {
             "title": "Study Group",
             "description": "Static section in the summary table",
             "type": "string",
+            "exclude_from": ["submit4dn"],
             "lookup": 902,
             "enum": [
                 "Single Time Point and Condition",


### PR DESCRIPTION
The Hi-C Summary table requires properties like study, study group, dataset group (optional). Adding them to the ExpSet schema allows to generate the Summary table automatically.