### PR TITLE
Added aggregation for slim_terms

### DIFF
--- a/src/encoded/schemas/experiment_set.json
+++ b/src/encoded/schemas/experiment_set.json
@@ -173,6 +173,9 @@
         "aggregated_items.tissue.item.preferred_name": {
             "title": "Tissue Source"
         },
+        "aggregated_items.slim_terms.item.preferred_name": {
+            "title": "Organ or System"
+        },
         "publications_of_set.display_title": {
             "title": "Publication"
         },

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -61,6 +61,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
         'cell_culture_details.morphology_image.attachment.height',
         'cell_culture_details.tissue.term_name',
         'cell_culture_details.tissue.preferred_name',
+        'cell_culture_details.tissue.slim_terms',
         'modifications.modification_type',
         'modifications.description',
         'treatments.treatment_type',

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -59,7 +59,8 @@ class ExperimentSet(Item):
             "badge.badge_icon",
             "badge.description"
         ],
-        "tissue": ["preferred_name"]
+        "tissue": ["preferred_name"],
+        "slim_terms": ["preferred_name"]
     }
     embedded_list = Item.embedded_list + lab_award_attribution_embed_list + [
         "badges.badge.title",
@@ -121,6 +122,7 @@ class ExperimentSet(Item):
         "experiments_in_set.biosample.biosource.cell_line_tier",
         "experiments_in_set.biosample.biosource.individual.organism.name",
         "experiments_in_set.biosample.cell_culture_details.tissue.preferred_name",
+        "experiments_in_set.biosample.cell_culture_details.tissue.slim_terms",
         "experiments_in_set.biosample.modifications.modification_type",
         "experiments_in_set.biosample.modifications.display_title",
         "experiments_in_set.biosample.treatments.treatment_type",
@@ -167,7 +169,7 @@ class ExperimentSet(Item):
         "experiments_in_set.files.quality_metric.Sequence length",
         "experiments_in_set.files.quality_metric.url",
         "experiments_in_set.files.quality_metric.overall_quality_status",
-        "experiments_in_set.files.quality_metric.quality_metric_summary.*", # This may not yet be enabled on raw files.
+        "experiments_in_set.files.quality_metric.quality_metric_summary.*",  # This may not yet be enabled on raw files.
         "experiments_in_set.files.badges.badge.title",
         "experiments_in_set.files.badges.badge.commendation",
         "experiments_in_set.files.badges.badge.warning",
@@ -287,7 +289,7 @@ class ExperimentSet(Item):
         "experiments_in_set.other_processed_files.files.last_modified.date_modified",
         "experiments_in_set.other_processed_files.files.quality_metric.url",
         "experiments_in_set.other_processed_files.files.quality_metric.overall_quality_status",
-        #"experiments_in_set.other_processed_files.files.quality_metric_summary.*", #tood - delete soon
+        # "experiments_in_set.other_processed_files.files.quality_metric_summary.*", #tood - delete soon
         "experiments_in_set.other_processed_files.files.quality_metric.quality_metric_summary.*",
         "experiments_in_set.other_processed_files.files.notes_to_tsv",
 


### PR DESCRIPTION
1. Aggregation for slim_terms on ExperimentSet.  This aggregates slim_terms that are embedded from 
* biosample.biosource.cell_line, 
* biosample.biosource.tissue 
* biosample.cell_culture_details.tissue
Slightly more than ideal but OK for now.

2. embedding to support the aggregation
3. facet to use that aggregation
4. minor formatting tweaks
