### PR TITLE
Refactoring SearchViews re: SPC/SearchView/ContralsAndResults allowing more flexibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3710,8 +3710,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#c2d4e5ca7052abde1cc517c338bcd0db522447a6",
-      "from": "github:4dn-dcic/shared-portal-components#0.0.2.78b",
+      "version": "github:4dn-dcic/shared-portal-components#97e1a1633aaaf924d20e1fbbb17d9d2a45873781",
+      "from": "github:4dn-dcic/shared-portal-components#0.0.2.78",
       "requires": {
         "auth0-lock": "^11.26.3",
         "aws-sdk": "^2.745.0",
@@ -5561,9 +5561,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.771.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.771.0.tgz",
-      "integrity": "sha512-fqNGusCwkdemx3yFqvQbU1+xq/PB2wGq7EQIrrTZx/zxfXUp+7+PnrHzXtViCRghN0tylLghBfWYD4VcVcqi7g==",
+      "version": "2.772.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.772.0.tgz",
+      "integrity": "sha512-am1xrqaQhHbZsSbbZ8l0nRzl4dfCG+HGUAsgNGQp3RGwEZX8Eblge4dGPmg3A1ZyCHAzT1VIWxemOOCiyqJC/A==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3710,8 +3710,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#567742c3b4fae85c50961763074632a29024e83a",
-      "from": "github:4dn-dcic/shared-portal-components#0.0.2.76b4",
+      "version": "github:4dn-dcic/shared-portal-components#c2d4e5ca7052abde1cc517c338bcd0db522447a6",
+      "from": "github:4dn-dcic/shared-portal-components#0.0.2.78b",
       "requires": {
         "auth0-lock": "^11.26.3",
         "aws-sdk": "^2.745.0",
@@ -5512,9 +5512,9 @@
           }
         },
         "react": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+          "version": "15.7.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.7.0.tgz",
+          "integrity": "sha512-5/MMRYmpmM0sMTHGLossnJCrmXQIiJilD6y3YN3TzAwGFj6zdnMtFv6xmi65PHKRV+pehIHpT7oy67Sr6s9AHA==",
           "requires": {
             "create-react-class": "^15.6.0",
             "fbjs": "^0.8.9",
@@ -5524,9 +5524,9 @@
           }
         },
         "react-dom": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+          "version": "15.7.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.7.0.tgz",
+          "integrity": "sha512-mpjXqC2t1FuYsILOLCj0kg6pbg460byZkVA/80VtDmKU/pYmoTdHOtaMcTRIDiyXLz4sIur0cQ04nOC6iGndJg==",
           "requires": {
             "fbjs": "^0.8.9",
             "loose-envify": "^1.1.0",
@@ -5561,9 +5561,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.764.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.764.0.tgz",
-      "integrity": "sha512-0asgRwAI3WxUyOjlx2fL7pPHEZajFbAVRerE2h0xX649123PwdhIiJ2HM7lWwn/f+mX7IagYjOCn9dIyvCHBVQ==",
+      "version": "2.771.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.771.0.tgz",
+      "integrity": "sha512-fqNGusCwkdemx3yFqvQbU1+xq/PB2wGq7EQIrrTZx/zxfXUp+7+PnrHzXtViCRghN0tylLghBfWYD4VcVcqi7g==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -19321,6 +19321,13 @@
           "requires": {
             "@babel/runtime": "^7.8.7",
             "csstype": "^2.6.7"
+          },
+          "dependencies": {
+            "csstype": {
+              "version": "2.6.13",
+              "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+              "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+            }
           }
         },
         "lodash-es": {
@@ -19393,6 +19400,11 @@
                 "@types/prop-types": "*",
                 "csstype": "^2.2.0"
               }
+            },
+            "csstype": {
+              "version": "2.6.13",
+              "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+              "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
             },
             "invariant": {
               "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "4dn-microscopy-metadata-tool": "github:WU-BIMAC/4DNMicroscopyMetadataToolReact#0.0.0.19b3",
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.76b4",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.78b",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",
     "detect-browser": "^3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.1.0"
+version = "2.1.1"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.1.1"
+version = "2.1.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -398,7 +398,7 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
         );
         const showClearFiltersButton = Object.keys(currExpSetFilters || {}).length > 0;
 
-        const projectFacet = _.findWhere(contextFacets, { 'field' : 'award.project' });
+        const projectFacet = _.findWhere(contextFacets, { 'field' : 'award.project' }) || {};
         const projectFacetTerms = _.uniq(projectFacet.terms || [], 'key');
         const countExternalSets = projectFacetTerms.reduce(function(sum, projectTermObj){
             if (projectTermObj.key === '4DN') return sum; // continue.

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -8,18 +8,12 @@ import memoize from 'memoize-one';
 
 import { IndeterminateCheckbox } from '@hms-dbmi-bgm/shared-portal-components/es/components/forms/components/IndeterminateCheckbox';
 import { searchFilters, object, memoizedUrlParse } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
-import { ColumnCombiner, DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
-import { CustomColumnController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/CustomColumnController';
-import { SearchResultTable } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SearchResultTable';
-import { FacetList } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/FacetList';
-import { SortController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SortController';
-import { WindowNavigationController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/WindowNavigationController';
-
+import { DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
 import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
 
 // We use own extended navigate fxn (not from shared repo) b.c. need the extra project-specific browse-related functions
 // We could probably also create different 'browseState' module for it, however.
-import { navigate as globalNavigate, typedefs, Schemas } from './../util';
+import { navigate as globalNavigate, typedefs } from './../util';
 import { PageTitleContainer, TitleAndSubtitleUnder, StaticPageBreadcrumbs, pageTitleViews } from './../PageTitle';
 
 import { store } from './../../store';

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -398,7 +398,8 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
         );
         const showClearFiltersButton = Object.keys(currExpSetFilters || {}).length > 0;
 
-        const projectFacetTerms = _.uniq(_.findWhere(contextFacets, { 'field' : 'award.project' }).terms, 'key');
+        const projectFacet = _.findWhere(contextFacets, { 'field' : 'award.project' });
+        const projectFacetTerms = _.uniq(projectFacet.terms || [], 'key');
         const countExternalSets = projectFacetTerms.reduce(function(sum, projectTermObj){
             if (projectTermObj.key === '4DN') return sum; // continue.
             return sum + projectTermObj.doc_count;

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -13,7 +13,7 @@ import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-comp
 
 // We use own extended navigate fxn (not from shared repo) b.c. need the extra project-specific browse-related functions
 // We could probably also create different 'browseState' module for it, however.
-import { navigate as globalNavigate, typedefs } from './../util';
+import { navigate as globalNavigate, typedefs, Schemas } from './../util';
 import { PageTitleContainer, TitleAndSubtitleUnder, StaticPageBreadcrumbs, pageTitleViews } from './../PageTitle';
 
 import { store } from './../../store';
@@ -447,7 +447,7 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
         totalExpected: total // todo: remove, deprecated
     };
 
-    return <CommonSearchView {...passProps} />;
+    return <CommonSearchView {...passProps} termTransformFxn={Schemas.Term.toName} />;
 }
 BrowseTableWithSelectedFilesCheckboxes.propTypes = {
     // Props' type validation based on contents of this.props during render.

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -15,9 +15,11 @@ import { FacetList } from '@hms-dbmi-bgm/shared-portal-components/es/components/
 import { SortController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SortController';
 import { WindowNavigationController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/WindowNavigationController';
 
+import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
+
 // We use own extended navigate fxn (not from shared repo) b.c. need the extra project-specific browse-related functions
 // We could probably also create different 'browseState' module for it, however.
-import { navigate, typedefs, Schemas } from './../util';
+import { navigate as globalNavigate, typedefs, Schemas } from './../util';
 import { PageTitleContainer, TitleAndSubtitleUnder, StaticPageBreadcrumbs, pageTitleViews } from './../PageTitle';
 
 import { store } from './../../store';
@@ -120,132 +122,6 @@ class ExperimentSetCheckBox extends React.PureComponent {
 
 
 
-
-
-
-class ControlsAndResults extends React.PureComponent {
-
-    /**
-     * Different than the functionality in search-portal-components / SearchView.
-     * Accounts for browseBaseState.
-     */
-    static isClearFiltersBtnVisible(context, browseBaseState){
-        const currExpSetFilters = searchFilters.contextFiltersToExpSetFilters(
-            context && context.filters,
-            navigate.getBrowseBaseParams(browseBaseState)
-        );
-        return _.keys(currExpSetFilters || {}).length > 0;
-    }
-
-    static defaultProps = {
-        'href' : '/browse/',
-    };
-
-    constructor(props){
-        super(props);
-        this.onClearFiltersClick = this.onClearFiltersClick.bind(this);
-        this.browseExpSetDetailPane = this.browseExpSetDetailPane.bind(this);
-        this.updateDetailPaneFileSectionStateCache = this.updateDetailPaneFileSectionStateCache.bind(this);
-
-        this.detailPaneFileSectionStateCache = {};
-
-        this.memoized = {
-            isClearFiltersBtnVisible: memoize(ControlsAndResults.isClearFiltersBtnVisible)
-        };
-    }
-
-    onClearFiltersClick(evt, callback = null){
-        const { onClearFilters } = this.props;
-        evt.preventDefault();
-        evt.stopPropagation();
-        onClearFilters(callback);
-    }
-
-    updateDetailPaneFileSectionStateCache(resultID, resultPaneState){
-        // Purposely avoid changing reference to avoid re-renders/updates (except when new components initialize)
-        if (resultPaneState === null){
-            delete this.detailPaneFileSectionStateCache[resultID];
-        } else {
-            this.detailPaneFileSectionStateCache[resultID] = resultPaneState;
-        }
-    }
-
-    browseExpSetDetailPane(result, rowNumber, containerWidth, propsFromTable){
-        return (
-            <ExperimentSetDetailPane
-                {..._.pick(this.props, 'selectedFiles', 'selectFile', 'unselectFile', 'windowWidth', 'href')}
-                {...{ ...propsFromTable, result, containerWidth }} paddingWidth={47}
-                initialStateCache={this.detailPaneFileSectionStateCache} updateFileSectionStateCache={this.updateDetailPaneFileSectionStateCache} />
-        );
-    }
-
-    render() {
-        const {
-
-            // From Redux store or App.js:
-            context, schemas, currentAction, windowWidth, windowHeight, registerWindowOnScrollHandler, session,
-
-            // 4DN-Specific from Redux Store or App.js:
-            browseBaseState, isFullscreen, toggleFullScreen,
-
-            // From BrowseView higher-order-component (extends facets, removes type facet, etc)
-            facets, topLeftChildren, countExternalSets,
-
-            // From WindowNavigationController (or similar) (possibly from Redux store re: href)
-            href, onFilter, getTermStatus,
-
-            // From CustomColumnController:
-            hiddenColumns, addHiddenColumn, removeHiddenColumn, visibleColumnDefinitions, columnWidths, setColumnWidths,
-            // From ColumnCombiner:
-            columnDefinitions,
-            // From SortController:
-            sortBy, sortColumn, sortReverse,
-
-            // From SelectedFilesController (NOT SelectedItemsController - which is for currentAction=selection|multiselect)
-            selectedFiles, selectedFilesUniqueCount, selectFile, unselectFile, resetSelectedFiles
-
-        } = this.props;
-        const { filters, '@graph': results } = context; // Initial results; cloned, saved to SearchResultTable state, and appended to upon load-as-scroll.
-
-        const showClearFiltersButton = this.memoized.isClearFiltersBtnVisible(context, browseBaseState);
-
-        const facetListProps = {
-            session, schemas, windowWidth, windowHeight, facets, showClearFiltersButton,
-            filters, getTermStatus, onFilter, href
-        };
-
-        const aboveTableControlsProps = {
-            context, href, currentAction, windowHeight, windowWidth, toggleFullScreen, isFullscreen,
-            columnDefinitions, hiddenColumns, addHiddenColumn, removeHiddenColumn,
-            selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount
-        };
-
-        const tableProps = {
-            results, href, context, schemas,
-            sortBy, sortColumn, sortReverse, windowWidth, columnDefinitions, visibleColumnDefinitions,
-            selectedFiles, registerWindowOnScrollHandler, hiddenColumns, setColumnWidths, columnWidths,
-        };
-
-        return (
-            <div className="row">
-                { facets && facets.length > 0 ?
-                    <div className={"col-md-5 col-lg-4 col-xl-" + (isFullscreen ? '2' : '3')}>
-                        <ExternaDataExpSetsCount {...{ countExternalSets, browseBaseState, href }} />
-                        <FacetList {...facetListProps} className="with-header-bg" itemTypeForSchemas="ExperimentSetReplicate"
-                            termTransformFxn={Schemas.Term.toName} onClearFilters={this.onClearFiltersClick} separateSingleTermFacets />
-                    </div>
-                    : null }
-                <div className={"expset-result-table-fix col-md-7 col-lg-8 col-xl-" + (isFullscreen ? '10' : '9')}>
-                    <AboveBrowseViewTableControls {...aboveTableControlsProps} showSelectedFileCount />
-                    <SearchResultTable {...tableProps} termTransformFxn={Schemas.Term.toName} renderDetailPane={this.browseExpSetDetailPane} />
-                </div>
-            </div>
-        );
-    }
-
-}
-
-
 class ExternaDataExpSetsCount extends React.PureComponent {
 
     constructor(props){
@@ -257,7 +133,7 @@ class ExternaDataExpSetsCount extends React.PureComponent {
         const { browseBaseState, href, context } = this.props;
         e.preventDefault();
         e.stopPropagation();
-        navigate.setBrowseBaseStateAndRefresh(browseBaseState === 'only_4dn' ? 'all' : 'only_4dn', href, context);
+        globalNavigate.setBrowseBaseStateAndRefresh(browseBaseState === 'only_4dn' ? 'all' : 'only_4dn', href, context);
     }
 
     render(){
@@ -289,56 +165,6 @@ class ExternaDataExpSetsCount extends React.PureComponent {
 export default class BrowseView extends React.PureComponent {
 
     /**
-     * Calculates how many experiment sets are 'External' and do not have award.project===4DN from browse JSON result.
-     *
-     * @param {SearchResponse} context - Browse search result with at least 'facets'.
-     * @returns {number} Count of external experiment sets.
-     */
-    static externalDataSetsCount = memoize(function(context){
-        var projectFacetTerms = (
-            Array.isArray(context.facets) ? _.uniq(_.flatten(_.pluck(_.filter(context.facets, { 'field' : 'award.project' }), 'terms')), 'key') : []
-        );
-        return _.reduce(projectFacetTerms, function(sum, projectTermObj){
-            if (projectTermObj.key === '4DN') return sum; // continue.
-            return sum + projectTermObj.doc_count;
-        }, 0);
-    });
-
-    /**
-     * Function which is passed into a `.filter()` call to
-     * filter context.facets down in response to frontend-state.
-     *
-     * Currently is meant to filter out Award and Project facets if
-     * we're _not_ showing any external data, as determined via the
-     * prop `browseBaseState` (string).
-     *
-     * @param {{ field: string }} facet - Object representing a facet.
-     * @returns {boolean} Whether to keep or discard facet.
-     */
-    static filterFacet(facet, browseBaseState, session){
-        if (facet.hide_from_view) return false;
-
-        // Exclude facets which are part of browse base state filters.
-        if (browseBaseState){
-            const browseBaseParams = navigate.getBrowseBaseParams(browseBaseState);
-            if (typeof browseBaseParams[facet.field] !== 'undefined') return false;
-        }
-
-        return true;
-    }
-
-    /** The static func is memoized since assumed to only be 1 BrowseView ever per page/view. */
-    static transformedFacets = memoize(function(context, browseBaseState, session){
-        return _.filter(
-            context.facets || [],
-            function(facet, index, all){
-                return BrowseView.filterFacet(facet, browseBaseState, session);
-            }
-        );
-    });
-
-
-    /**
      * If different count in Browse result total, refetch chart data.
      *
      * @private
@@ -348,11 +174,16 @@ export default class BrowseView extends React.PureComponent {
      */
     static checkResyncChartData(hrefParts, context){
         setTimeout(function(){
-            if (context && context.total && ChartDataController.isInitialized() && navigate.isBaseBrowseQuery(hrefParts.query)){
-                const cdcState = ChartDataController.getState();
-                const cdcExpSetCount = (cdcState.barplot_data_unfiltered && cdcState.barplot_data_unfiltered.total && cdcState.barplot_data_unfiltered.total.experiment_sets);
+            const { total: resultCount = 0 } = context || {};
+            const { query } = hrefParts;
+            if (resultCount && ChartDataController.isInitialized() && globalNavigate.isBaseBrowseQuery(query)){
+                const {
+                    barplot_data_unfiltered: {
+                        total: { experiment_sets: cdcExpSetCount = null } = {}
+                    } = {}
+                } = ChartDataController.getState();
 
-                if (cdcExpSetCount && cdcExpSetCount !== context.total){
+                if (cdcExpSetCount && cdcExpSetCount !== resultCount){
                     if (cdcState.isLoadingChartData){
                         console.info('Already loading chart data, canceling.');
                     } else {
@@ -414,7 +245,6 @@ export default class BrowseView extends React.PureComponent {
     componentDidUpdate(pastProps){
         const { context, href } = this.props;
         const hrefParts = memoizedUrlParse(href);
-
         BrowseView.checkResyncChartData(hrefParts, context);
     }
 
@@ -426,13 +256,11 @@ export default class BrowseView extends React.PureComponent {
      * @returns {JSX.Element} View for Browse page.
      */
     render() {
-        const { context, href, session, browseBaseState } = this.props;
-        const facets = BrowseView.transformedFacets(context, browseBaseState, session);
-
+        const { context, href } = this.props;
         return (
             <div className="browse-page-container search-page-container container" id="content">
                 <SelectedFilesController {...{ href, context }} analyticsAddFilesToCart>
-                    <BrowseTableWithSelectedFilesCheckboxes {...this.props} facets={facets} />
+                    <BrowseTableWithSelectedFilesCheckboxes {...this.props} />
                 </SelectedFilesController>
             </div>
         );
@@ -451,7 +279,7 @@ const NoResultsView = React.memo(function NoResultsView({ context, href, browseB
     const browseExternalData = (e)=>{
         e.preventDefault();
         e.stopPropagation();
-        navigate.setBrowseBaseStateAndRefresh('all', href, context);
+        globalNavigate.setBrowseBaseStateAndRefresh('all', href, context);
     };
 
     // If there are no External Sets found:
@@ -494,18 +322,13 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
         windowHeight, windowWidth, registerWindowOnScrollHandler,
         toggleFullScreen, isFullscreen, session,
 
-        // Props from BrowseView:
-        facets,
-
         // Props from SelectedFilesController (separate from SPC SearchView SelectedItemsController):
-        selectedFiles, selectFile, unselectFile, resetSelectedFiles,
+        selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount,
 
         // Default prop / hardcoded (may become customizable later)
         columnExtensionMap,
     } = props;
     const { total = 0, notification = null } = context;
-
-    const countExternalSets = BrowseView.externalDataSetsCount(context);
 
     /**
      * Extends or creates `columnExtensionMap.display_title` with a larger width as well as
@@ -514,13 +337,11 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
      * If no selected files data structure is being fed through props, this function returns `columnExtensionMap`.
      */
     const columnExtensionMapWithSelectedFilesCheckboxes = useMemo(function(){
-
         if (typeof selectedFiles === 'undefined'){
-            // We don't need to add checkbox(es) for file selection.
+            // We don't need to add checkbox(es) for file selection. (This case shouldn't occur).
             return columnExtensionMap;
         }
-
-        // Add Checkboxes
+        // Else, add Checkboxes
         return _.extend({}, columnExtensionMap, {
             // We extend the display_title of global constant colExtensionMap4DN, not the columnExtensionMap,
             // incase the prop version's render fxn is different than what we expect.
@@ -537,40 +358,101 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
                 }
             })
         });
-
     }, [ columnExtensionMap, selectedFiles, selectFile, unselectFile ]);
 
+    /**
+     * Plain object used for caching to helps to preserve open states of Processed & Raw files' sections to iron out jumping as that state is lost that would
+     * otherwise be encountered during scrolling due to dismounting/destruction of ResultRow components. `detailPaneFileSectionStateCache` is read in constructor
+     * or upon mount by these ResultRows.
+     *
+     * Runs/memoized only once on mount so that same instance of the `detailPaneFileSectionStateCache` object persists throughout lifeycle of
+     * `BrowseTableWithSelectedFilesCheckboxes` component.
+     */
+    const { detailPaneFileSectionStateCache, updateDetailPaneFileSectionStateCache } = useMemo(function(){
+        const detailPaneFileSectionStateCache = {};
+        function updateDetailPaneFileSectionStateCache(resultID, resultPaneState){
+            // Purposely avoid changing reference to avoid re-renders/updates (except when new components initialize)
+            if (resultPaneState === null){
+                delete detailPaneFileSectionStateCache[resultID];
+            } else {
+                detailPaneFileSectionStateCache[resultID] = resultPaneState;
+            }
+        }
+        return { detailPaneFileSectionStateCache, updateDetailPaneFileSectionStateCache };
+    }, []);
+
+    /**
+     * ExperimentSetDetailPane instance will receive props `result`, `containerWidth`, `propsFromTable`, & `rowNumber`
+     * via React.cloneElement in SPC > SearchResultTable.js > ResultRowColumBlock.
+     *
+     * SearchResultTable (& rest of SPC) will soon no longer handle nor pass down selectedFiles so it is passed in (and memoized upon)
+     * here instead.
+     */
+    const detailPane = useMemo(function(){
+        return (
+            <ExperimentSetDetailPane {...{ selectedFiles, selectFile, unselectFile, windowWidth, href, schemas }} paddingWidth={47}
+                initialStateCache={detailPaneFileSectionStateCache} updateFileSectionStateCache={updateDetailPaneFileSectionStateCache} />
+        );
+    }, [ selectedFiles, windowWidth, href, schemas ]);
+
+    /** Some data calculated/derived from search response / `context` for BrowseView UX specifically */
+    const { showClearFiltersButton, countExternalSets, facets } = useMemo(function(){
+        const { filters: contextFilters = null, facets: contextFacets = [] } = context;
+        const currExpSetFilters = searchFilters.contextFiltersToExpSetFilters(
+            contextFilters,
+            globalNavigate.getBrowseBaseParams(browseBaseState)
+        );
+        const showClearFiltersButton = Object.keys(currExpSetFilters || {}).length > 0;
+
+        const projectFacetTerms = _.uniq(_.findWhere(contextFacets, { 'field' : 'award.project' }).terms, 'key');
+        const countExternalSets = projectFacetTerms.reduce(function(sum, projectTermObj){
+            if (projectTermObj.key === '4DN') return sum; // continue.
+            return sum + projectTermObj.doc_count;
+        }, 0);
+
+        // Filtered to exclude type + fields in browse base state.
+        const facets = contextFacets.filter(function(facet, index, all){
+            if (facet.hide_from_view) return false;
+            if (browseBaseState){
+                const browseBaseParams = globalNavigate.getBrowseBaseParams(browseBaseState);
+                if (typeof browseBaseParams[facet.field] !== 'undefined') return false;
+            }
+            return true;
+        });
+
+        return { showClearFiltersButton, countExternalSets, facets };
+    }, [ context ]);
+
+
     if (total === 0 && notification) {
+        // We need to have order & presence of all hooks (such as `useMemo`) be consistent across each
+        // re-render so we can't pre-emptively return this early (prior to definitions of all hooks).
         return <NoResultsView {...{ context, href, browseBaseState, countExternalSets }} />;
     }
 
-    const bodyViewProps = {
-        browseBaseState, session, schemas, countExternalSets, facets,
-        windowHeight, windowWidth, registerWindowOnScrollHandler,
-        toggleFullScreen, isFullscreen,
-        selectedFiles, selectFile, unselectFile, resetSelectedFiles,
-        totalExpected: total
+    const aboveTableControlsProps = { // Some more generic props get passed in by SPC > ControlsAndResults.js
+        href, toggleFullScreen, isFullscreen,
+        selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount
     };
 
-    // All these controllers pass props down to their children.
-    // So we don't need to be repetitive here; i.e. may assume 'context' is available
-    // in each controller that's child of <WindowNavigationController {...{ context, href }}>.
-    // As well as in ControlsAndResults.
+    const aboveTableComponent = <AboveBrowseViewTableControls {...aboveTableControlsProps} showSelectedFileCount />;
+    const aboveFacetListComponent = <ExternaDataExpSetsCount {...{ countExternalSets, browseBaseState, href }} />;
 
-    // Props passed down from parent components usually overwrite child props' components.
-    // (Unless otherwise implemented)
+    const passProps = {
+        href, context, facets,
+        session, schemas,
+        windowHeight, windowWidth, registerWindowOnScrollHandler,
+        detailPane,
+        showClearFiltersButton,
+        aboveTableComponent, aboveFacetListComponent,
+        columnExtensionMap: columnExtensionMapWithSelectedFilesCheckboxes,
+        navigate: propNavigate,
+        toggleFullScreen, isFullscreen, // todo: remove maybe, pass only to AboveTableControls
+        // selectedFiles, selectFile, unselectFile, resetSelectedFiles, // todo: remove and pass only to AboveTableControls, detailPane, and colExtensionMap
+        totalExpected: total // todo: remove, deprecated
+    };
 
-    return (
-        <WindowNavigationController {...{ href, context }} navigate={propNavigate}>
-            <ColumnCombiner columnExtensionMap={columnExtensionMapWithSelectedFilesCheckboxes}>
-                <CustomColumnController {...{ windowWidth }}>
-                    <SortController>
-                        <ControlsAndResults {...bodyViewProps} />
-                    </SortController>
-                </CustomColumnController>
-            </ColumnCombiner>
-        </WindowNavigationController>
-    );
+    return <CommonSearchView {...passProps} />;
 }
 BrowseTableWithSelectedFilesCheckboxes.propTypes = {
     // Props' type validation based on contents of this.props during render.
@@ -591,7 +473,7 @@ BrowseTableWithSelectedFilesCheckboxes.propTypes = {
     'selectedFiles'             : PropTypes.objectOf(PropTypes.object),
 };
 BrowseTableWithSelectedFilesCheckboxes.defaultProps = {
-    'navigate'  : navigate,
+    'navigate'  : globalNavigate,
     'columnExtensionMap' : colExtensionMap4DN
 };
 

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -34,79 +34,6 @@ export default function FileSearchView (props){
 }
 
 
-function AboveFacetList({ context, currentAction }){
-    const { total = 0, actions = [] } = context;
-    let totalResults = null;
-    if (total > 0) {
-        totalResults = (
-            <div>
-                <span id="results-count" className="text-500">
-                    { total }
-                </span> Results
-            </div>
-        );
-    }
-
-    let addButton = null;
-    if (!currentAction) {
-        const addAction = _.findWhere(actions, { 'name': 'add' });
-        if (addAction && typeof addAction.href === 'string') {
-            addButton = (
-                <a className="btn btn-primary btn-xs ml-1" href={addAction.href} data-skiprequest="true">
-                    <i className="icon icon-fw icon-plus fas mr-03 fas" />Create New&nbsp;
-                </a>
-            );
-        }
-    }
-
-    return (
-        <div className="above-results-table-row text-truncate d-flex align-items-center justify-content-end">
-            { totalResults }
-            { addButton }
-        </div>
-    );
-}
-
-
-class FileSearchViewCheckBox extends React.PureComponent {
-
-    static filesToObjectKeyedByAccessionTriples(file, isSelected) {
-        const allFileAccessionTriples = fileToAccessionTriple(file, false, true);
-        if (isSelected) {
-            return (_.zip([allFileAccessionTriples], [file]));
-        }
-        else { return allFileAccessionTriples; }
-    }
-
-    constructor(props) {
-        super(props);
-        this.onChange = this.onChange.bind(this);
-        this.memoized = {
-            filesToObjectKeyedByAccessionTriples: memoize(FileSearchViewCheckBox.filesToObjectKeyedByAccessionTriples),
-        };
-    }
-
-    onChange(e) {
-        const { file, selectFile, unselectFile } = this.props;
-        const isChecked = e.target.checked;
-        if (isChecked) {
-            const allFilesKeyedByTriples = this.memoized.filesToObjectKeyedByAccessionTriples(file, true);
-            selectFile(allFilesKeyedByTriples);
-        }
-        else {
-            const unselectFilesKeyedByTriples = this.memoized.filesToObjectKeyedByAccessionTriples(file, false);
-            unselectFile(unselectFilesKeyedByTriples);
-        }
-    }
-
-    render() {
-        const { file, selectedFiles } = this.props;
-        const accessionTriple = ['NONE', 'NONE', file.accession].join('~');
-        return <Checkbox checked={!!(selectedFiles[accessionTriple])} onChange={this.onChange} className="expset-checkbox" />;
-    }
-}
-
-
 function FileTableWithSelectedFilesCheckboxes(props){
     const {
         // Common high-level props from Redux, or App.js, or App.js > BodyElement:
@@ -195,3 +122,75 @@ FileTableWithSelectedFilesCheckboxes.defaultProps = {
     'navigate'  : navigate,
     'columnExtensionMap' : colExtensionMap4DN
 };
+
+function AboveFacetList({ context, currentAction }){
+    const { total = 0, actions = [] } = context;
+    let totalResults = null;
+    if (total > 0) {
+        totalResults = (
+            <div>
+                <span id="results-count" className="text-500">
+                    { total }
+                </span> Results
+            </div>
+        );
+    }
+
+    let addButton = null;
+    if (!currentAction) {
+        const addAction = _.findWhere(actions, { 'name': 'add' });
+        if (addAction && typeof addAction.href === 'string') {
+            addButton = (
+                <a className="btn btn-primary btn-xs ml-1" href={addAction.href} data-skiprequest="true">
+                    <i className="icon icon-fw icon-plus fas mr-03 fas" />Create New&nbsp;
+                </a>
+            );
+        }
+    }
+
+    return (
+        <div className="above-results-table-row text-truncate d-flex align-items-center justify-content-end">
+            { totalResults }
+            { addButton }
+        </div>
+    );
+}
+
+
+class FileSearchViewCheckBox extends React.PureComponent {
+
+    static filesToObjectKeyedByAccessionTriples(file, isSelected) {
+        const allFileAccessionTriples = fileToAccessionTriple(file, false, true);
+        if (isSelected) {
+            return (_.zip([allFileAccessionTriples], [file]));
+        }
+        else { return allFileAccessionTriples; }
+    }
+
+    constructor(props) {
+        super(props);
+        this.onChange = this.onChange.bind(this);
+        this.memoized = {
+            filesToObjectKeyedByAccessionTriples: memoize(FileSearchViewCheckBox.filesToObjectKeyedByAccessionTriples),
+        };
+    }
+
+    onChange(e) {
+        const { file, selectFile, unselectFile } = this.props;
+        const isChecked = e.target.checked;
+        if (isChecked) {
+            const allFilesKeyedByTriples = this.memoized.filesToObjectKeyedByAccessionTriples(file, true);
+            selectFile(allFilesKeyedByTriples);
+        }
+        else {
+            const unselectFilesKeyedByTriples = this.memoized.filesToObjectKeyedByAccessionTriples(file, false);
+            unselectFile(unselectFilesKeyedByTriples);
+        }
+    }
+
+    render() {
+        const { file, selectedFiles } = this.props;
+        const accessionTriple = ['NONE', 'NONE', file.accession].join('~');
+        return <Checkbox checked={!!(selectedFiles[accessionTriple])} onChange={this.onChange} className="expset-checkbox" />;
+    }
+}

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -6,20 +6,14 @@ import memoize from 'memoize-one';
 import _ from 'underscore';
 import { Checkbox } from '@hms-dbmi-bgm/shared-portal-components/es/components/forms/components/Checkbox';
 import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
-import { ColumnCombiner, DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
-import { CustomColumnController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/CustomColumnController';
-import { SortController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SortController';
-import { SearchResultDetailPane } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SearchResultDetailPane';
+import { DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { SelectedFilesController } from './../browse/components/SelectedFilesController';
-import { navigate, Schemas } from './../util';
-import { FacetList } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/FacetList';
+import { navigate } from './../util';
 import { columnExtensionMap as colExtensionMap4DN } from './columnExtensionMap';
-import { WindowNavigationController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/WindowNavigationController';
 import { transformedFacets } from './SearchView';
 import { AboveBrowseViewTableControls } from './components/above-table-controls/AboveBrowseViewTableControls';
 import { fileToAccessionTriple } from './../util/experiments-transforms';
-import { SearchResultTable } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SearchResultTable';
 
 
 export default function FileSearchView (props){

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import memoize from 'memoize-one';
 import _ from 'underscore';
 import { Checkbox } from '@hms-dbmi-bgm/shared-portal-components/es/components/forms/components/Checkbox';
+import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
 import { ColumnCombiner, DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
 import { CustomColumnController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/CustomColumnController';
 import { SortController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SortController';
@@ -20,229 +21,52 @@ import { AboveBrowseViewTableControls } from './components/above-table-controls/
 import { fileToAccessionTriple } from './../util/experiments-transforms';
 import { SearchResultTable } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SearchResultTable';
 
-export default class FileSearchView extends React.PureComponent {
 
-    constructor(props) {
-        super(props);
-
-        this.memoized = {
-            transformedFacets: memoize(transformedFacets)
-        };
-
-        this.state = {
-            show: false,
-            confirmLoading: false
-        };
-    }
-
-    render() {
-        const { isFullscreen, href, context, currentAction, session, schemas } = this.props;
-        const facets = this.memoized.transformedFacets(href, context, currentAction, session, schemas);
-
-        return (
-            <div className="search-page-container container" id="content">
-                <SelectedFilesController {...{ href, context }}>
-                    <FileTableWithSelectedFilesCheckboxes {...this.props} facets={facets} />
-                </SelectedFilesController>
-            </div>
-        );
-    }
-}
-
-function FileTableWithSelectedFilesCheckboxes(props){
-    const {
-        // Common high-level props from Redux, or App.js, or App.js > BodyElement:
-        context, href, schemas, navigate: propNavigate,
-        windowHeight, windowWidth, registerWindowOnScrollHandler,
-        toggleFullScreen, isFullscreen, session,
-        facets,
-        selectedFiles, selectFile, unselectFile, resetSelectedFiles,
-        columnExtensionMap
-    } = props;
-    const { total = 0 } = context;
-
-    const columnExtensionMapWithSelectedFilesCheckboxes = useMemo(function(){
-
-        if (typeof selectedFiles === 'undefined'){
-            // We don't need to add checkbox(es) for file selection.
-            return columnExtensionMap;
-        }
-
-        // Add Checkboxes
-        return _.extend({}, columnExtensionMap, {
-            // We extend the display_title of global constant colExtensionMap4DN, not the columnExtensionMap,
-            // incase the prop version's render fxn is different than what we expect.
-            'display_title' : _.extend({}, colExtensionMap4DN.display_title, {
-                'widthMap' : { 'lg' : 210, 'md' : 210, 'sm' : 200 },
-                'render': (file, parentProps) => {
-                    const { rowNumber, detailOpen, toggleDetailOpen } = parentProps;
-                    return (
-                        <DisplayTitleColumnWrapper {...{ href, context, rowNumber, detailOpen, toggleDetailOpen }} result={file}>
-                            <FileSearchViewCheckBox key="checkbox" {...{ file, selectedFiles, selectFile, unselectFile }} />
-                            <DisplayTitleColumnDefault />
-                        </DisplayTitleColumnWrapper>
-                    );
-                }
-            })
-        });
-
-    }, [columnExtensionMap, selectedFiles, selectFile, unselectFile]);
-
-    const bodyViewProps = {
-        session, schemas, facets,
-        windowHeight, windowWidth, registerWindowOnScrollHandler,
-        toggleFullScreen, isFullscreen,
-        selectedFiles, selectFile, unselectFile, resetSelectedFiles,
-        totalExpected: total
-    };
+export default function FileSearchView (props){
+    const { href, context } = props;
     return (
-        <WindowNavigationController {...{ href, context }} navigate={propNavigate}>
-            <ColumnCombiner columnExtensionMap={columnExtensionMapWithSelectedFilesCheckboxes}>
-                <CustomColumnController {...{ windowWidth }}>
-                    <SortController>
-                        <ControlsAndResults {...bodyViewProps} />
-                    </SortController>
-                </CustomColumnController>
-            </ColumnCombiner>
-        </WindowNavigationController>
+        <div className="search-page-container container" id="content">
+            <SelectedFilesController {...{ href, context }}>
+                <FileTableWithSelectedFilesCheckboxes {...props} />
+            </SelectedFilesController>
+        </div>
     );
 }
-FileTableWithSelectedFilesCheckboxes.propTypes = {
-    // Props' type validation based on contents of this.props during render.
-    'href'                      : PropTypes.string.isRequired,
-    'columnExtensionMap'        : PropTypes.object.isRequired,
-    'context'                   : PropTypes.shape({
-        'columns'                   : PropTypes.objectOf(PropTypes.object).isRequired,
-        'total'                     : PropTypes.number.isRequired
-    }).isRequired,
-    'facets'                    : PropTypes.arrayOf(PropTypes.shape({
-        'title'                     : PropTypes.string.isRequired
-    })),
-    'schemas'                   : PropTypes.object,
-    'browseBaseState'           : PropTypes.string.isRequired,
-    'selectFile'                : PropTypes.func,
-    'unselectFile'              : PropTypes.func,
-    'selectedFiles'             : PropTypes.objectOf(PropTypes.object),
-};
-FileTableWithSelectedFilesCheckboxes.defaultProps = {
-    'navigate'  : navigate,
-    'columnExtensionMap' : colExtensionMap4DN
-};
 
-class ControlsAndResults extends React.PureComponent {
-    static defaultProps = {
-        'href' : '/search/',
-    };
 
-    constructor(props){
-        super(props);
-        this.onClearFiltersClick = this.onClearFiltersClick.bind(this);
-        this.renderSearchDetailPane = this.renderSearchDetailPane.bind(this);
-    }
-
-    onClearFiltersClick(evt, callback = null){
-        const { onClearFilters } = this.props;
-        evt.preventDefault();
-        evt.stopPropagation();
-        onClearFilters(callback);
-    }
-
-    renderSearchDetailPane(result, rowNumber, containerWidth, propsFromTable){
-        const { renderDetailPane, windowWidth, schemas } = this.props;
-        if (typeof renderDetailPane === "function") {
-            return renderDetailPane(result, rowNumber, containerWidth, { ...propsFromTable, schemas, windowWidth });
-        }
-        return <SearchResultDetailPane {...{ result, rowNumber, containerWidth, schemas, windowWidth }} />;
-    }
-
-    render() {
-        const {
-            // From Redux store or App.js:
-            context, schemas, currentAction, windowWidth, windowHeight, registerWindowOnScrollHandler, session,
-            // 4DN-Specific from Redux Store or App.js:
-            isFullscreen, toggleFullScreen,
-            // From FileSearchView higher-order-component (extends facets, removes type facet, etc)
-            facets, topLeftChildren,
-            // From WindowNavigationController (or similar) (possibly from Redux store re: href)
-            href, onFilter, getTermStatus,
-            // From CustomColumnController:
-            hiddenColumns, addHiddenColumn, removeHiddenColumn, visibleColumnDefinitions,
-            setColumnWidths, columnWidths,
-            // From ColumnCombiner:
-            columnDefinitions,
-            // From SortController:
-            sortBy, sortColumn, sortReverse,
-            // From SelectedFilesController (NOT SelectedItemsController - which is for currentAction=selection|multiselect)
-            selectedFiles, selectedFilesUniqueCount, selectFile, unselectFile, resetSelectedFiles
-        } = this.props;
-        const { filters, '@graph': results } = context; // Initial results; cloned, saved to SearchResultTable state, and appended to upon load-as-scroll.
-
-        const facetListProps = {
-            session, schemas, windowWidth, windowHeight, facets,
-            filters, getTermStatus, onFilter, href
-        };
-
-        const aboveTableControlsProps = {
-            context, href, currentAction, windowHeight, windowWidth, toggleFullScreen, isFullscreen,
-            columnDefinitions, hiddenColumns, addHiddenColumn, removeHiddenColumn,
-            selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount
-        };
-
-        const tableProps = {
-            results, href, context, schemas,
-            sortBy, sortColumn, sortReverse, windowWidth,
-            columnDefinitions, visibleColumnDefinitions,
-            selectedFiles, registerWindowOnScrollHandler,
-            hiddenColumns, columnWidths, setColumnWidths
-        };
-
-        let totalResults = null;
-        if (context && typeof context.total === 'number' && context.total > 0) {
-            totalResults = (
-                <div className="d-inline-block mt-08">
-                    <span id="results-count">
-                        { context.total }
-                    </span> Results
-                </div>
-            );
-        } else {
-            totalResults = <span className="d-inline-block mt-08">&nbsp;</span>;
-        }
-
-        let addButton = null;
-        if (context && Array.isArray(context.actions) && !currentAction) {
-            const addAction = _.findWhere(context.actions, { 'name': 'add' });
-            if (addAction && typeof addAction.href === 'string') {
-                addButton = (
-                    <a className={"btn btn-primary btn-xs ml-1"} href={addAction.href} data-skiprequest="true">
-                        <i className="icon icon-fw icon-plus fas mr-03 fas" />Create New&nbsp;
-                    </a>);
-            }
-        }
-
-        return (
-            <div className="row search-view-controls-and-results">
-                {facets && facets.length > 0 ?
-                    <React.Fragment>
-                        <div className={"col-md-5 col-lg-4 col-xl-" + (isFullscreen ? '2' : '3')}>
-                            <div className="above-results-table-row text-right text-truncate">
-                                {totalResults}
-                                {addButton}
-                            </div>
-                            <FacetList {...facetListProps} className="with-header-bg" itemTypeForSchemas="ExperimentSetReplicate"
-                                termTransformFxn={Schemas.Term.toName} onClearFilters={this.onClearFiltersClick} separateSingleTermFacets />
-                        </div>
-                    </React.Fragment>
-                    : null}
-                <div className={"expset-result-table-fix col-md-7 col-lg-8 col-xl-" + (isFullscreen ? '10' : '9')}>
-                    <AboveBrowseViewTableControls {...aboveTableControlsProps} showSelectedFileCount />
-                    <SearchResultTable {...tableProps} termTransformFxn={Schemas.Term.toName} renderDetailPane={this.renderSearchDetailPane} />
-                </div>
+function AboveFacetList({ context, currentAction }){
+    const { total = 0, actions = [] } = context;
+    let totalResults = null;
+    if (total > 0) {
+        totalResults = (
+            <div>
+                <span id="results-count" className="text-500">
+                    { total }
+                </span> Results
             </div>
         );
     }
 
+    let addButton = null;
+    if (!currentAction) {
+        const addAction = _.findWhere(actions, { 'name': 'add' });
+        if (addAction && typeof addAction.href === 'string') {
+            addButton = (
+                <a className="btn btn-primary btn-xs ml-1" href={addAction.href} data-skiprequest="true">
+                    <i className="icon icon-fw icon-plus fas mr-03 fas" />Create New&nbsp;
+                </a>
+            );
+        }
+    }
+
+    return (
+        <div className="above-results-table-row text-truncate d-flex align-items-center justify-content-end">
+            { totalResults }
+            { addButton }
+        </div>
+    );
 }
+
 
 class FileSearchViewCheckBox extends React.PureComponent {
 
@@ -281,3 +105,93 @@ class FileSearchViewCheckBox extends React.PureComponent {
         return <Checkbox checked={!!(selectedFiles[accessionTriple])} onChange={this.onChange} className="expset-checkbox" />;
     }
 }
+
+
+function FileTableWithSelectedFilesCheckboxes(props){
+    const {
+        // Common high-level props from Redux, or App.js, or App.js > BodyElement:
+        context, href, schemas, navigate: propNavigate,
+        windowHeight, windowWidth, registerWindowOnScrollHandler,
+        toggleFullScreen, isFullscreen, session,
+        selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount,
+        columnExtensionMap,
+        currentAction
+    } = props;
+    const { total = 0 } = context;
+
+    const columnExtensionMapWithSelectedFilesCheckboxes = useMemo(function(){
+
+        if (typeof selectedFiles === 'undefined'){
+            // We don't need to add checkbox(es) for file selection.
+            return columnExtensionMap;
+        }
+
+        // Add Checkboxes
+        return _.extend({}, columnExtensionMap, {
+            // We extend the display_title of global constant colExtensionMap4DN, not the columnExtensionMap,
+            // incase the prop version's render fxn is different than what we expect.
+            'display_title' : _.extend({}, colExtensionMap4DN.display_title, {
+                'widthMap' : { 'lg' : 210, 'md' : 210, 'sm' : 200 },
+                'render': (file, parentProps) => {
+                    const { rowNumber, detailOpen, toggleDetailOpen } = parentProps;
+                    return (
+                        <DisplayTitleColumnWrapper {...{ href, context, rowNumber, detailOpen, toggleDetailOpen }} result={file}>
+                            <FileSearchViewCheckBox key="checkbox" {...{ file, selectedFiles, selectFile, unselectFile }} />
+                            <DisplayTitleColumnDefault />
+                        </DisplayTitleColumnWrapper>
+                    );
+                }
+            })
+        });
+
+    }, [columnExtensionMap, selectedFiles, selectFile, unselectFile]);
+
+
+    const facets = useMemo(function(){
+        return transformedFacets(href, context, currentAction, session, schemas);
+    }, [ context, currentAction, session, schemas ]);
+
+
+    const aboveTableControlsProps = { // Some more generic props get passed in by SPC > ControlsAndResults.js
+        href, toggleFullScreen, isFullscreen,
+        selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount
+    };
+
+    const aboveTableComponent = <AboveBrowseViewTableControls {...aboveTableControlsProps} showSelectedFileCount />;
+    const aboveFacetListComponent = <AboveFacetList {...{ context, currentAction }} />;
+
+    const passProps = {
+        href, context, facets,
+        session, schemas,
+        windowHeight, windowWidth, registerWindowOnScrollHandler,
+        aboveTableComponent, aboveFacetListComponent,
+        columnExtensionMap: columnExtensionMapWithSelectedFilesCheckboxes,
+        navigate: propNavigate,
+        toggleFullScreen, isFullscreen, // todo: remove maybe, pass only to AboveTableControls
+        // selectedFiles, selectFile, unselectFile, resetSelectedFiles, // todo: remove and pass only to AboveTableControls, detailPane, and colExtensionMap
+        totalExpected: total // todo: remove, deprecated
+    };
+
+    return <CommonSearchView {...passProps} />;
+}
+FileTableWithSelectedFilesCheckboxes.propTypes = {
+    // Props' type validation based on contents of this.props during render.
+    'href'                      : PropTypes.string.isRequired,
+    'columnExtensionMap'        : PropTypes.object.isRequired,
+    'context'                   : PropTypes.shape({
+        'columns'                   : PropTypes.objectOf(PropTypes.object).isRequired,
+        'total'                     : PropTypes.number.isRequired
+    }).isRequired,
+    'facets'                    : PropTypes.arrayOf(PropTypes.shape({
+        'title'                     : PropTypes.string.isRequired
+    })),
+    'schemas'                   : PropTypes.object,
+    'browseBaseState'           : PropTypes.string.isRequired,
+    'selectFile'                : PropTypes.func,
+    'unselectFile'              : PropTypes.func,
+    'selectedFiles'             : PropTypes.objectOf(PropTypes.object),
+};
+FileTableWithSelectedFilesCheckboxes.defaultProps = {
+    'navigate'  : navigate,
+    'columnExtensionMap' : colExtensionMap4DN
+};

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -9,11 +9,12 @@ import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-comp
 import { DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { SelectedFilesController } from './../browse/components/SelectedFilesController';
-import { navigate } from './../util';
+import { navigate, Schemas } from './../util';
 import { columnExtensionMap as colExtensionMap4DN } from './columnExtensionMap';
 import { transformedFacets } from './SearchView';
 import { AboveBrowseViewTableControls } from './components/above-table-controls/AboveBrowseViewTableControls';
 import { fileToAccessionTriple } from './../util/experiments-transforms';
+
 
 
 export default function FileSearchView (props){
@@ -93,7 +94,7 @@ function FileTableWithSelectedFilesCheckboxes(props){
         totalExpected: total // todo: remove, deprecated
     };
 
-    return <CommonSearchView {...passProps} />;
+    return <CommonSearchView {...passProps} termTransformFxn={Schemas.Term.toName} />;
 }
 FileTableWithSelectedFilesCheckboxes.propTypes = {
     // Props' type validation based on contents of this.props during render.

--- a/src/encoded/static/components/browse/MicroscopySearchView.js
+++ b/src/encoded/static/components/browse/MicroscopySearchView.js
@@ -8,6 +8,7 @@ import DropdownButton from 'react-bootstrap/esm/DropdownButton';
 import Modal from 'react-bootstrap/esm/Modal';
 
 import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
+import { AboveSearchViewTableControls } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/above-table-controls/AboveSearchViewTableControls';
 import { console, ajax, navigate, object } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { Alerts } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts';
 
@@ -18,7 +19,8 @@ import { transformedFacets } from './SearchView';
 
 
 
-const microscopyColExtensionMap = _.extend({}, columnExtensionMap, {
+const microscopyColExtensionMap = {
+    ...columnExtensionMap,
     "microscope.Tier": {
         "widthMap": { "sm": 50, "md": 70, "lg": 80 }
     },
@@ -36,8 +38,8 @@ const microscopyColExtensionMap = _.extend({}, columnExtensionMap, {
     },
     "submitted_by.display_title": {
         "widthMap": { "sm": 100, "md": 100, "lg": 120 }
-    },
-});
+    }
+};
 
 export default class MicroscopySearchView extends React.PureComponent {
 
@@ -63,8 +65,24 @@ export default class MicroscopySearchView extends React.PureComponent {
         };
     }
 
+    /** @todo Possibly move into own component instead of method, especially if state can move along with it. */
     createNewMicroscopeConfiguration() {
+        const { context, currentAction } = this.props;
         const { show, tier/*, validationTier*/, microscopeName, confirmLoading } = this.state;
+
+        let createNewVisible = false;
+        // don't show during submission search "selecting existing"
+        if (context && Array.isArray(context.actions) && !currentAction) {
+            const addAction = _.findWhere(context.actions, { 'name': 'add' });
+            if (addAction && typeof addAction.href === 'string') {
+                createNewVisible = true;
+            }
+        }
+
+        if (!createNewVisible) {
+            return null;
+        }
+
         const buttonProps = {
             'handleChangeMicroscopeTier': this.handleChangeMicroscopeTier,
             'startTier': 1,
@@ -161,26 +179,25 @@ export default class MicroscopySearchView extends React.PureComponent {
     }
 
     render() {
-        const { isFullscreen, href, context, currentAction, session, schemas } = this.props;
+        const { isFullscreen, toggleFullScreen, href, context, currentAction, session, schemas } = this.props;
         const facets = this.memoized.transformedFacets(href, context, currentAction, session, schemas);
         const tableColumnClassName = "expset-result-table-fix col-12" + (facets.length > 0 ? " col-sm-7 col-lg-8 col-xl-" + (isFullscreen ? '10' : '9') : "");
         const facetColumnClassName = "col-12 col-sm-5 col-lg-4 col-xl-" + (isFullscreen ? '2' : '3');
-        let createNewVisible = false;
-        // don't show during submission search "selecting existing"
-        if (context && Array.isArray(context.actions) && !currentAction) {
-            const addAction = _.findWhere(context.actions, { 'name': 'add' });
-            if (addAction && typeof addAction.href === 'string') {
-                createNewVisible = true;
-            }
-        }
+        const aboveTableComponent = (
+            <AboveSearchViewTableControls {...{ isFullscreen, toggleFullScreen }}
+                topLeftChildren={this.createNewMicroscopeConfiguration()} />
+        );
+
         return (
+            // TODO (low-ish priority): Pass in props.aboveTableComponent =  instead of props.topLeftChildren
             <div className="container" id="content">
-                <CommonSearchView {...this.props} {...{ tableColumnClassName, facetColumnClassName, facets }}
-                    termTransformFxn={Schemas.Term.toName} separateSingleTermFacets columnExtensionMap={microscopyColExtensionMap} topLeftChildren={createNewVisible ? this.createNewMicroscopeConfiguration() : null} />
+                <CommonSearchView {...this.props} {...{ tableColumnClassName, facetColumnClassName, facets, aboveTableComponent }}
+                    termTransformFxn={Schemas.Term.toName} separateSingleTermFacets columnExtensionMap={microscopyColExtensionMap} />
             </div>
         );
     }
 }
+
 
 const CreateNewConfigurationDropDownButton = React.memo(function (props) {
     const { handleChangeMicroscopeTier, startTier, endTier } = props;

--- a/src/encoded/static/components/browse/PublicationSearchView.js
+++ b/src/encoded/static/components/browse/PublicationSearchView.js
@@ -9,7 +9,6 @@ import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-comp
 import { console, analytics, object, navigate as spcNavigate, valueTransforms } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { TableRowToggleOpenButton } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/table-commons';
 import { LocalizedTime } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/LocalizedTime';
-import { FlexibleDescriptionBox } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/FlexibleDescriptionBox';
 import { Detail } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/ItemDetailList';
 
 import { columnExtensionMap } from './columnExtensionMap';

--- a/src/encoded/static/components/browse/columnExtensionMap.js
+++ b/src/encoded/static/components/browse/columnExtensionMap.js
@@ -22,7 +22,7 @@ function labDisplayTitleRenderFxn(result, props){
         return <span className="value">{ labLink }</span>;
     }
     return (
-        <span>
+        <span className="text-truncate">
             <i className="icon icon-fw icon-user far user-icon" data-html data-tip={'<small>Submitted by</small> ' + result.submitted_by.display_title} />
             { labLink }
         </span>
@@ -65,8 +65,13 @@ export const columnExtensionMap = _.extend({}, basicColumnExtensionMap, {
     'date_published' : {
         'widthMap' : { 'lg' : 140, 'md' : 120, 'sm' : 120 },
         'render' : function(result, props){
-            if (!result.date_published) return null;
-            return formatPublicationDate(result.date_published);
+            const { date_published = null } = result;
+            if (!date_published) return null;
+            return (
+                <span className="value text-right">
+                    { formatPublicationDate(date_published) }
+                </span>
+            );
         },
         'order' : 504
     },
@@ -76,7 +81,7 @@ export const columnExtensionMap = _.extend({}, basicColumnExtensionMap, {
         'render' : function googleAnalyticsDate(result, props){
             if (!result.google_analytics || !result.google_analytics.for_date) return null;
             return (
-                <span className="value">
+                <span className="value text-right">
                     <LocalizedTime timestamp={result.google_analytics.for_date} formatType="date-sm" localize={false} />
                 </span>
             );
@@ -135,7 +140,7 @@ export const columnExtensionMap = _.extend({}, basicColumnExtensionMap, {
         'render' : function publicRelease(result, props){
             if (!result.public_release) return null;
             return (
-                <span className="value">
+                <span className="value text-right">
                     <LocalizedTime timestamp={result.public_release} formatType="date-sm" />
                 </span>
             );
@@ -153,7 +158,7 @@ export const columnExtensionMap = _.extend({}, basicColumnExtensionMap, {
             if (!number_of_experiments){
                 number_of_experiments = 0;
             }
-            return <span className="value">{ number_of_experiments }</span>;
+            return <span className="value text-center">{ number_of_experiments }</span>;
         }
     },
     'number_of_files' : {
@@ -168,7 +173,7 @@ export const columnExtensionMap = _.extend({}, basicColumnExtensionMap, {
             if (!number_of_files){
                 number_of_files = 0;
             }
-            return <span className="value">{ number_of_files }</span>;
+            return <span className="value text-center">{ number_of_files }</span>;
         }
 
     },

--- a/src/encoded/tests/data/inserts/experiment_set_replicate.json
+++ b/src/encoded/tests/data/inserts/experiment_set_replicate.json
@@ -23,7 +23,8 @@
             "release-updates.TEST1",
             "resources.analysis.file-formats.hic",
             "00000000-1111-0000-1111-000000000001"
-        ]
+        ],
+        "date_created" : "2011-03-25"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b261",
@@ -41,7 +42,8 @@
         ],
         "lab": "test-4dn-lab",
         "award": "1U01CA200059-01",
-        "status": "released"
+        "status": "released",
+        "date_created" : "2011-03-24"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b222",
@@ -68,7 +70,8 @@
                 "badge": "/badges/inconsistent-replicate-info/",
                 "messages": ["Lorem Ipsum Text"]
             }
-        ]
+        ],
+        "date_created" : "2011-02-01"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b292",
@@ -83,7 +86,8 @@
         ],
         "lab": "test-4dn-lab",
         "award": "1U01CA200059-01",
-        "status": "released"
+        "status": "released",
+        "date_created" : "2011-01-01"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b112",
@@ -98,7 +102,8 @@
         ],
         "lab": "test-4dn-lab",
         "award": "1U01CA200059-01",
-        "status": "released"
+        "status": "released",
+        "date_created" : "2012-01-01"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b113",
@@ -111,7 +116,8 @@
         ],
         "lab": "test-4dn-lab",
         "award": "1U01CA200059-02",
-        "status": "released"
+        "status": "released",
+        "date_created" : "2016-08-07"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b223",
@@ -124,7 +130,8 @@
         ],
         "lab": "test-4dn-lab",
         "award": "1U01CA200059-01",
-        "status": "released"
+        "status": "released",
+        "date_created" : "2014-05-07"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b114",
@@ -138,7 +145,8 @@
         ],
         "lab": "test-4dn-lab",
         "award": "1U01CA200059-02",
-        "status": "released"
+        "status": "released",
+        "date_created" : "2016-09-18"
     },
     {
         "uuid": "431106bc-8535-4448-903e-854af460b115",


### PR DESCRIPTION
These edits on SPC-side are a precursor to creating the FilterBlocks UI wherein support for a `props.aboveTableComponent` & `props.aboveFacetListComponent` will be required. Code should be mostly self-explanatory and be "cleanup".

Functionally, everything should work exactly as it did before, but code should be somewhat cleaner hopefully.

Please look at alongside https://github.com/4dn-dcic/shared-portal-components/pull/44