### PR TITLE
Disable another bot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.1.0"
+version = "2.1.1"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/robots.txt
+++ b/src/encoded/static/robots.txt
@@ -13,3 +13,5 @@ User-agent: SemrushBot
 Disallow: /
 User-agent: AhrefsBot
 Disallow: /
+User-agent: PetalBot
+Disallow: /


### PR DESCRIPTION
- While analyzing bad download traffic, the following bot seems to ignore our restricted routes directive (it requests downloads) so we are blocking it altogether