### PR TITLE
Update HiGlass schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.1.5"
+version = "2.1.6"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.1.7"
+version = "2.1.8"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/higlass_view_config.json
+++ b/src/encoded/schemas/higlass_view_config.json
@@ -48,10 +48,6 @@
             "lookup" : 7,
             "formInput" : "code",
             "properties": {
-                "editable" : {
-                    "type" : "boolean",
-                    "default": true
-                },
                 "exportViewUrl" : {
                     "type" : "string",
                     "default": "/api/v1/viewconfs"
@@ -134,48 +130,6 @@
                                     }
                                 }
                             },
-                            "initialXDomain" : {
-                                "type" : "array",
-                                "items" : {
-                                    "type" : "number"
-                                }
-                            },
-                            "initialYDomain" : {
-                                "type" : "array",
-                                "items" : {
-                                    "type" : "number"
-                                }
-                            },
-                            "layout" : {
-                                "type" : "object",
-                                "properties" : {
-                                    "h" : {
-                                        "type" : "integer",
-                                        "default" : 12
-                                    },
-                                    "w" : {
-                                        "type" : "integer",
-                                        "default" : 12
-                                    },
-                                    "x" : {
-                                        "type" : "integer",
-                                        "default" : 0
-                                    },
-                                    "y" : {
-                                        "type" : "integer",
-                                        "default" : 0
-                                    },
-                                    "moved" : {
-                                        "type" : "boolean",
-                                        "default" : true
-                                    },
-                                    "static" : {
-                                        "type" : "boolean",
-                                        "default" : true
-                                    }
-
-                                }
-                            },
                             "tracks" : {
                                 "type" : "object",
                                 "properties" : {
@@ -183,43 +137,14 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["server", "tilesetUid"],
+                                            "required" : ["tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
-                                                "name" : {
-                                                    "type" : "string"
-                                                },
                                                 "uid" : {
                                                     "type" : "string"
                                                 },
-                                                "header" : {
-                                                    "type" : "string"
-                                                },
-                                                "height" : {
-                                                    "type" : "integer"
-                                                },
-                                                "orientation" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out.",
-                                                    "default" : "1d-horizontal"
-                                                },
-                                                "position" : {
-                                                    "type" : "string",
-                                                    "enum": [
-                                                        "top"
-                                                    ],
-                                                    "default" : "top"
-                                                },
-                                                "server" : {
-                                                    "type" : "string",
-                                                    "default" : "https://higlass.4dnucleome.org/api/v1"
-                                                },
                                                 "tilesetUid" : {
                                                     "type" : "string"
-                                                },
-                                                "type" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out."
                                                 },
                                                 "options" : {
                                                     "additionalProperties" : true,
@@ -227,48 +152,7 @@
                                                     "properties": {
                                                         "name" : {
                                                             "type" : "string"
-                                                        },
-                                                        "labelColor" : {
-                                                            "type" :"string",
-                                                            "default": "#888"
-                                                        },
-                                                        "labelPosition" : {
-                                                            "type" : "string",
-                                                            "comment" : "Should probably be an ENUM.",
-                                                            "default" : "hidden"
-                                                        },
-                                                        "minusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "red"
-                                                        },
-                                                        "plusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "blue"
-                                                        },
-                                                        "trackBorderColor" : {
-                                                            "type" : "string",
-                                                            "default" : "black"
-                                                        },
-                                                        "trackBorderWidth" : {
-                                                            "type" : "integer",
-                                                            "default" : 0
-                                                        },
-                                                        "showMousePosition": {
-                                                            "type" : "boolean",
-                                                            "default": true,
-                                                            "description": "Applicable for BigWag and other 1D track files."
-                                                        },
-                                                        "mousePositionColor": {
-                                                            "type" : "string",
-                                                            "default" : "#999999",
-                                                            "description": "Applicable for BigWig and other 1D track files."
-                                                        },
-                                                            "showTooltip" : {
-                                                                "type" : "boolean",
-                                                                "default": false,
-                                                                "description": "Applicable for BigWig and other 1D track files."
-                                                                                                       }
-
+                                                        }
                                                     }
                                                 }
                                             }
@@ -278,46 +162,14 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["server", "tilesetUid"],
+                                            "required" : ["tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
-                                                "name" : {
-                                                    "type" : "string"
-                                                },
                                                 "uid" : {
                                                     "type" : "string"
                                                 },
-                                                "header" : {
-                                                    "type" : "string"
-                                                },
-                                                "width" : {
-                                                    "type" : "integer"
-                                                },
-                                                "minWidth" : {
-                                                    "type" : "integer"
-                                                },
-                                                "orientation" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out.",
-                                                    "default" : "1d-vertical"
-                                                },
-                                                "position" : {
-                                                    "type" : "string",
-                                                    "enum": [
-                                                        "left"
-                                                    ],
-                                                    "default" : "left"
-                                                },
-                                                "server" : {
-                                                    "type" : "string",
-                                                    "default" : "https://higlass.4dnucleome.org/api/v1"
-                                                },
                                                 "tilesetUid" : {
                                                     "type" : "string"
-                                                },
-                                                "type" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out."
                                                 },
                                                 "options" : {
                                                     "additionalProperties" : true,
@@ -325,46 +177,6 @@
                                                     "properties": {
                                                         "name" : {
                                                             "type" : "string"
-                                                        },
-                                                        "labelColor" : {
-                                                            "type" :"string",
-                                                            "default": "black"
-                                                        },
-                                                        "labelPosition" : {
-                                                            "type" : "string",
-                                                            "comment" : "Should probably be an ENUM.",
-                                                            "default" : "hidden"
-                                                        },
-                                                        "minusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "red"
-                                                        },
-                                                        "plusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "blue"
-                                                        },
-                                                        "trackBorderColor" : {
-                                                            "type" : "string",
-                                                            "default" : "black"
-                                                        },
-                                                        "trackBorderWidth" : {
-                                                            "type" : "integer",
-                                                            "default" : 0
-                                                        },
-                                                        "showMousePosition": {
-                                                            "type" : "boolean",
-                                                            "default": true,
-                                                            "description": "Applicable for BigWig and other 1D track files."
-                                                        },
-                                                        "mousePositionColor": {
-                                                            "type" : "string",
-                                                            "default" : "#999999",
-                                                            "description": "Applicable for BigWig and other 1D track files."
-                                                        },
-                                                        "showTooltip" : {
-                                                            "type" : "boolean",
-                                                            "default": false,
-                                                            "description": "Applicable for BigWig and other 1D track files."
                                                         }
                                                     }
                                                 }
@@ -375,43 +187,14 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["server", "tilesetUid"],
+                                            "required" : ["tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
-                                                "name" : {
-                                                    "type" : "string"
-                                                },
                                                 "uid" : {
                                                     "type" : "string"
                                                 },
-                                                "header" : {
-                                                    "type" : "string"
-                                                },
-                                                "height" : {
-                                                    "type" : "integer"
-                                                },
-                                                "orientation" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out.",
-                                                    "default" : "1d-horizontal"
-                                                },
-                                                "position" : {
-                                                    "type" : "string",
-                                                    "enum": [
-                                                        "bottom"
-                                                    ],
-                                                    "default" : "bottom"
-                                                },
-                                                "server" : {
-                                                    "type" : "string",
-                                                    "default" : "https://higlass.4dnucleome.org/api/v1"
-                                                },
                                                 "tilesetUid" : {
                                                     "type" : "string"
-                                                },
-                                                "type" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out."
                                                 },
                                                 "options" : {
                                                     "additionalProperties" : true,
@@ -419,46 +202,6 @@
                                                     "properties": {
                                                         "name" : {
                                                             "type" : "string"
-                                                        },
-                                                        "labelColor" : {
-                                                            "type" :"string",
-                                                            "default": "black"
-                                                        },
-                                                        "labelPosition" : {
-                                                            "type" : "string",
-                                                            "comment" : "Should probably be an ENUM.",
-                                                            "default" : "hidden"
-                                                        },
-                                                        "minusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "red"
-                                                        },
-                                                        "plusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "blue"
-                                                        },
-                                                        "trackBorderColor" : {
-                                                            "type" : "string",
-                                                            "default" : "black"
-                                                        },
-                                                        "trackBorderWidth" : {
-                                                            "type" : "integer",
-                                                            "default" : 0
-                                                        },
-                                                        "showMousePosition": {
-                                                            "type" : "boolean",
-                                                            "default": true,
-                                                            "description": "Applicable for BigWig and other 1D track files."
-                                                        },
-                                                        "mousePositionColor": {
-                                                            "type" : "string",
-                                                            "default" : "#999999",
-                                                            "description": "Applicable for BigWig and other 1D track files."
-                                                        },
-                                                        "showTooltip" : {
-                                                            "type" : "boolean",
-                                                            "default": false,
-                                                            "description": "Applicable for BigWig and other 1D track files."
                                                         }
                                                     }
                                                 }
@@ -469,46 +212,14 @@
                                         "type" : "array",
                                         "items" : {
                                             "type" : "object",
-                                            "required" : ["server", "tilesetUid"],
+                                            "required" : ["tilesetUid"],
                                             "additionalProperties" : true,
                                             "properties": {
-                                                "name" : {
-                                                    "type" : "string"
-                                                },
                                                 "uid" : {
                                                     "type" : "string"
                                                 },
-                                                "header" : {
-                                                    "type" : "string"
-                                                },
-                                                "width" : {
-                                                    "type" : "integer"
-                                                },
-                                                "minWidth" : {
-                                                    "type" : "integer"
-                                                },
-                                                "orientation" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out.",
-                                                    "default" : "1d-vertical"
-                                                },
-                                                "position" : {
-                                                    "type" : "string",
-                                                    "enum": [
-                                                        "right"
-                                                    ],
-                                                    "default" : "right"
-                                                },
-                                                "server" : {
-                                                    "type" : "string",
-                                                    "default" : "https://higlass.4dnucleome.org/api/v1"
-                                                },
                                                 "tilesetUid" : {
                                                     "type" : "string"
-                                                },
-                                                "type" : {
-                                                    "type" : "string",
-                                                    "comment" : "This might be an ENUM, need to figure out."
                                                 },
                                                 "options" : {
                                                     "additionalProperties" : true,
@@ -516,46 +227,6 @@
                                                     "properties": {
                                                         "name" : {
                                                             "type" : "string"
-                                                        },
-                                                        "labelColor" : {
-                                                            "type" :"string",
-                                                            "default": "black"
-                                                        },
-                                                        "labelPosition" : {
-                                                            "type" : "string",
-                                                            "comment" : "Should probably be an ENUM.",
-                                                            "default" : "hidden"
-                                                        },
-                                                        "minusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "red"
-                                                        },
-                                                        "plusStrandColor" : {
-                                                            "type" : "string",
-                                                            "default": "blue"
-                                                        },
-                                                        "trackBorderColor" : {
-                                                            "type" : "string",
-                                                            "default" : "black"
-                                                        },
-                                                        "trackBorderWidth" : {
-                                                            "type" : "integer",
-                                                            "default" : 0
-                                                        },
-                                                        "showMousePosition": {
-                                                            "type" : "boolean",
-                                                            "default": true,
-                                                            "description": "Applicable for BigWag and other 1D track files."
-                                                        },
-                                                        "mousePositionColor": {
-                                                            "type" : "string",
-                                                            "default" : "#999999",
-                                                            "description": "Applicable for BigWig and other 1D track files."
-                                                        },
-                                                        "showTooltip" : {
-                                                            "type" : "boolean",
-                                                            "default": false,
-                                                            "description": "Applicable for BigWig and other 1D track files."
                                                         }
                                                     }
                                                 }
@@ -571,50 +242,20 @@
                                                 "uid" : {
                                                     "type" : "string"
                                                 },
-                                                "height" : {
-                                                    "type" : "integer"
-                                                },
-                                                "position" : {
-                                                    "type" : "string",
-                                                    "enum": [
-                                                        "center"
-                                                    ],
-                                                    "default" : "center"
-                                                },
                                                 "type" : {
                                                     "type" : "string",
-                                                    "default" : "combined",
-                                                    "comment" : "This might be an ENUM, need to figure out."
+                                                    "default" : "combined"
                                                 },
                                                 "contents" : {
                                                     "type" : "array",
                                                     "items" : {
                                                         "type" : "object",
                                                         "properties": {
-                                                            "name" : {
-                                                                "type" : "string"
-                                                            },
                                                             "uid" : {
                                                                 "type" : "string"
                                                             },
-                                                            "server" : {
-                                                                "type" : "string",
-                                                                "default" : "https://higlass.4dnucleome.org/api/v1"
-                                                            },
                                                             "tilesetUid" : {
                                                                 "type" : "string"
-                                                            },
-                                                            "position" : {
-                                                                "type" : "string",
-                                                                "enum": [
-                                                                    "center"
-                                                                ],
-                                                                "default" : "center"
-                                                            },
-                                                            "type" : {
-                                                                "type" : "string",
-                                                                "default" : "heatmap",
-                                                                "comment" : "This might be an ENUM, need to figure out."
                                                             },
                                                             "options" : {
                                                                 "additionalProperties" : true,

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -366,27 +366,27 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
      * @param {Object} trackInfo track info object that holds detail view and track info
      */
     hasSimilarTilesets(updatedTilesetField, trackInfo) {
-      const hgc = this.getHiGlassComponent();
-      const currentViewConf = this.getHiGlassViewConfig(hgc);
+        const hgc = this.getHiGlassComponent();
+        const currentViewConf = this.getHiGlassViewConfig(hgc);
 
-      if (!currentViewConf) {
-        throw new Error("Could not get current view configuration.");
-      }
+        if (!currentViewConf) {
+            throw new Error("Could not get current view configuration.");
+        }
 
-      // Gets all tracks with the same orientaton (e.g. all top tracks)
-      const tracks = currentViewConf.views[trackInfo.vIndex].tracks[trackInfo.track];
-      const currentTrack = _.find(tracks, function (t) {
-        return t.uid === trackInfo.uid;
-      });
+        // Gets all tracks with the same orientaton (e.g. all top tracks)
+        const tracks = currentViewConf.views[trackInfo.vIndex].tracks[trackInfo.track];
+        const currentTrack = _.find(tracks, function (t) {
+            return t.uid === trackInfo.uid;
+        });
 
-      if (currentTrack) {
-        const similarTilesets = _.filter(
-          tracks,
-          (trackItem) => currentTrack.type === trackItem.type
-        );
-        return similarTilesets && similarTilesets.length > 1;
-      }
-      return false;
+        if (currentTrack) {
+            const similarTilesets = _.filter(
+                tracks,
+                (trackItem) => currentTrack.type === trackItem.type
+            );
+            return similarTilesets && similarTilesets.length > 1;
+        }
+        return false;
     }
     /**
      * Update the current higlass viewconfig for the user, based on the current data.

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -326,22 +326,24 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         if (!currentViewConf) {
             throw new Error('Could not get current view configuration.');
         }
-        const track = currentViewConf.views[trackInfo.vIndex].tracks[trackInfo.track];
-        const tileset = _.find(track, function (t) { return t.uid === trackInfo.uid; });
 
-        if (tileset) {
-            const { orientation, type } = tileset;
+        // tracks contains all track with the same orientation (e.g. top)
+        const tracks = currentViewConf.views[trackInfo.vIndex].tracks[trackInfo.track];
+        const currentTrack = _.find(tracks, function (t) { return t.uid === trackInfo.uid; });
+
+        if (currentTrack) {
+            const { type } = currentTrack;
             if (_.has(updatedTilesetField, 'height')) {
-                _.each(track, (tilesetItem, idx) => {
-                    if (orientation === tilesetItem.orientation && type === tilesetItem.type) {
-                        tilesetItem.height = updatedTilesetField.height;
+                _.each(tracks, (trackItem, idx) => {
+                    if (type === trackItem.type) {
+                        trackItem.height = updatedTilesetField.height;
                     }
                 });
             }
             else if (_.has(updatedTilesetField, 'width')) {
-                _.each(track, (tilesetItem, i) => {
-                    if (orientation === tilesetItem.orientation && type === tilesetItem.type) {
-                        tilesetItem.width = updatedTilesetField.width;
+                _.each(tracks, (trackItem, i) => {
+                    if (type === trackItem.type) {
+                        trackItem.width = updatedTilesetField.width;
                     }
                 });
             }
@@ -359,26 +361,32 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
         return true;
     }
     /**
-     * checks whether multiple similar (within the same view and track, having same orientation and type) tilesets exist
+     * checks whether multiple similar (within the same view and track, having same type) tracks exist
      * @param {Object} updatedTilesetField edited field object
      * @param {Object} trackInfo track info object that holds detail view and track info
      */
     hasSimilarTilesets(updatedTilesetField, trackInfo) {
-        const hgc = this.getHiGlassComponent();
-        const currentViewConf = this.getHiGlassViewConfig(hgc);
+      const hgc = this.getHiGlassComponent();
+      const currentViewConf = this.getHiGlassViewConfig(hgc);
 
-        if (!currentViewConf) {
-            throw new Error('Could not get current view configuration.');
-        }
-        const track = currentViewConf.views[trackInfo.vIndex].tracks[trackInfo.track];
-        const tileset = _.find(track, function (t) { return t.uid === trackInfo.uid; });
+      if (!currentViewConf) {
+        throw new Error("Could not get current view configuration.");
+      }
 
-        if (tileset) {
-            const { orientation, type } = tileset;
-            const similarTilesets = _.filter(track, (tilesetItem) => orientation === tilesetItem.orientation && type === tilesetItem.type);
-            return similarTilesets && similarTilesets.length > 1;
-        }
-        return false;
+      // Gets all tracks with the same orientaton (e.g. all top tracks)
+      const tracks = currentViewConf.views[trackInfo.vIndex].tracks[trackInfo.track];
+      const currentTrack = _.find(tracks, function (t) {
+        return t.uid === trackInfo.uid;
+      });
+
+      if (currentTrack) {
+        const similarTilesets = _.filter(
+          tracks,
+          (trackItem) => currentTrack.type === trackItem.type
+        );
+        return similarTilesets && similarTilesets.length > 1;
+      }
+      return false;
     }
     /**
      * Update the current higlass viewconfig for the user, based on the current data.

--- a/src/encoded/static/components/testdata/higlass_sample_viewconfigs.js
+++ b/src/encoded/static/components/testdata/higlass_sample_viewconfigs.js
@@ -105,10 +105,7 @@ export const HIGLASS_WEBSITE = {
                 "w":12,
                 "h":12,
                 "x":0,
-                "y":0,
-                "i":"aa",
-                "moved":false,
-                "static":false
+                "y":0
             }
         }
     ],
@@ -171,9 +168,7 @@ export const SERVER_4DN = {
                 "w": 12,
                 "h": 13,
                 "x": 0,
-                "y": 0,
-                "moved": false,
-                "static": false
+                "y": 0
             },
             "initialYDomain": [
                 235207586.8246398,

--- a/src/encoded/tests/data/inserts/higlass_view_config.json
+++ b/src/encoded/tests/data/inserts/higlass_view_config.json
@@ -62,7 +62,7 @@
                                     "labelPosition": "hidden",
                                     "trackBorderWidth": 0,
                                     "stroke": "#FFFFFF",
-                                    "showTooltip": false,                                    
+                                    "showTooltip": false,
                                     "showMousePosition": false,
                                     "trackBorderColor": "black"
                                 },

--- a/src/encoded/tests/data/inserts/higlass_view_config.json
+++ b/src/encoded/tests/data/inserts/higlass_view_config.json
@@ -19,10 +19,8 @@
                         3350629531.737105
                     ],
                     "layout": {
-                        "static": false,
                         "w": 12,
                         "x": 0,
-                        "moved": false,
                         "y": 0,
                         "h": 12
                     },
@@ -31,7 +29,6 @@
                             {
                                 "server": "https://higlass.4dnucleome.org/api/v1",
                                 "uid": "top-annotation-track",
-                                "orientation": "1d-horizontal",
                                 "options": {
                                     "geneAnnotationHeight": 10,
                                     "showTooltip": false,
@@ -49,20 +46,14 @@
                                     "trackBorderColor": "black"
                                 },
                                 "width": 1130,
-                                "name": "4DNFIWG6CQQA.beddb",
                                 "type": "horizontal-gene-annotations",
                                 "tilesetUid": "XGrAqZupQb2h5Pjiarf8PA",
-                                "header": "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14",
-                                "height": 55,
-                                "position": "top"
+                                "height": 55
                             },
                             {
                                 "server": "https://higlass.4dnucleome.org/api/v1",
                                 "uid": "top-chromosome-track",
-                                "thumbnail": null,
-                                "orientation": "1d-horizontal",
                                 "options": {
-                                    "plusStrandColor": "blue",
                                     "fontIsAligned": false,
                                     "color": "#777777",
                                     "labelColor": "#888",
@@ -70,18 +61,15 @@
                                     "fontSize": 12,
                                     "labelPosition": "hidden",
                                     "trackBorderWidth": 0,
-                                    "minusStrandColor": "red",
                                     "stroke": "#FFFFFF",
-                                    "showTooltip": false,                                    "showMousePosition": false,
+                                    "showTooltip": false,                                    
+                                    "showMousePosition": false,
                                     "trackBorderColor": "black"
                                 },
                                 "width": 1130,
-                                "name": "Chromosome Axis",
                                 "type": "horizontal-chromosome-labels",
                                 "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg",
-                                "height": 35,
-                                "local": true,
-                                "position": "top"
+                                "height": 35
                             }
                         ],
                         "whole": [],
@@ -186,10 +174,8 @@
                         3257874853.005984
                     ],
                     "layout": {
-                        "static": false,
                         "h": 12,
                         "x": 0,
-                        "moved": false,
                         "y": 0,
                         "w": 12
                     },
@@ -204,21 +190,6 @@
                                 "contents": [
                                     {
                                         "type": "heatmap",
-                                        "resolutions": [
-                                            1000,
-                                            2000,
-                                            5000,
-                                            10000,
-                                            25000,
-                                            50000,
-                                            100000,
-                                            250000,
-                                            500000,
-                                            1000000,
-                                            2500000,
-                                            5000000,
-                                            10000000
-                                        ],
                                         "tilesetUid": "OxZJjFLwRYq8PA_cRgipbQ",
                                         "server": "https://higlass.4dnucleome.org/api/v1",
                                         "options": {
@@ -249,24 +220,6 @@
                                             "showTooltip": false,
                                             "showMousePosition": false
                                         },
-                                        "transforms": [
-                                            {
-                                                "name": "ICE",
-                                                "value": "weight"
-                                            },
-                                            {
-                                                "name": "VC",
-                                                "value": "VC"
-                                            },
-                                            {
-                                                "name": "KR",
-                                                "value": "KR"
-                                            },
-                                            {
-                                                "name": "VC_SQRT",
-                                                "value": "VC_SQRT"
-                                            }
-                                        ],
                                         "width": 1110,
                                         "height": 513,
                                         "position": "center",

--- a/src/encoded/tests/data/master-inserts/higlass_view_config.json
+++ b/src/encoded/tests/data/master-inserts/higlass_view_config.json
@@ -70,7 +70,6 @@
                         "left": [
                             {
                                 "width": 55,
-                                "orientation": "1d-vertical",
                                 "uid": "left-annotation-track",
                                 "tilesetUid": "308f5404-694a-4c77-a8e8-3e6cc5f63079",
                                 "options": {
@@ -81,7 +80,6 @@
                                     "minusStrandColor": "black",
                                     "geneLabelPosition": "outside",
                                     "labelRightMargin": 0,
-                                    "name": "Gene Annotations (hg38)",
                                     "labelLeftMargin": 0,
                                     "fontSize": 10,
                                     "labelTopMargin": 0,
@@ -94,36 +92,23 @@
                                     "plusStrandColor": "black"
                                 },
                                 "type": "vertical-gene-annotations",
-                                "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Gene Annotations (hg38)",
-                                "header": "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14"
+                                "server": "https://higlass.4dnucleome.org/api/v1"
                             },
                             {
                                 "width": 35,
-                                "orientation": "1d-vertical",
                                 "uid": "left-chromosome-track",
                                 "options": {
-                                    "trackBorderColor": "black",
                                     "showMousePosition": false,
                                     "showTooltip": false,
-                                    "trackBorderWidth": 0,
                                     "color": "#777777",
                                     "stroke": "#FFFFFF",
-                                    "plusStrandColor": "blue",
-                                    "fontIsAligned": false,
                                     "mousePositionColor": "#999999",
-                                    "fontSize": 12,
-                                    "labelColor": "black",
-                                    "minusStrandColor": "red",
-                                    "labelPosition": "hidden"
+                                    "fontSize": 12
                                 },
-                                "minWidth": 20,
                                 "type": "vertical-chromosome-labels",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Chromosome Axis",
                                 "height": 158,
-                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg",
-                                "position": "left"
+                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg"
                             }
                         ],
                         "right": [],
@@ -138,24 +123,6 @@
                                     {
                                         "height": 158,
                                         "uid": "GjuZed1ySGW1IzZZqFB9BA",
-                                        "transforms": [
-                                            {
-                                                "name": "ICE",
-                                                "value": "weight"
-                                            },
-                                            {
-                                                "name": "VC_SQRT",
-                                                "value": "VC_SQRT"
-                                            },
-                                            {
-                                                "name": "KR",
-                                                "value": "KR"
-                                            },
-                                            {
-                                                "name": "VC",
-                                                "value": "VC"
-                                            }
-                                        ],
                                         "options": {
                                             "trackBorderColor": "black",
                                             "showMousePosition": false,
@@ -164,7 +131,6 @@
                                             "maxZoom": null,
                                             "scaleStartPercent": "0.00000",
                                             "labelRightMargin": 0,
-                                            "name": "H1-hESC Hi-C",
                                             "labelLeftMargin": 0,
                                             "labelBottomMargin": 0,
                                             "colorRange": [
@@ -181,24 +147,8 @@
                                             "backgroundColor": "#eeeeee",
                                             "trackBorderWidth": 0
                                         },
-                                        "resolutions": [
-                                            1000,
-                                            2000,
-                                            5000,
-                                            10000,
-                                            25000,
-                                            50000,
-                                            100000,
-                                            250000,
-                                            500000,
-                                            1000000,
-                                            2500000,
-                                            5000000,
-                                            10000000
-                                        ],
                                         "type": "heatmap",
                                         "server": "https://higlass.4dnucleome.org/api/v1",
-                                        "name": "4DNFI6HDY7WZ.mcool",
                                         "width": 465,
                                         "tilesetUid": "bJORvAOhSmCkED7QGB7FYA",
                                         "position": "center"
@@ -210,22 +160,14 @@
                         "top": [
                             {
                                 "height": 35,
-                                "thumbnail": null,
-                                "orientation": "1d-horizontal",
-                                "name": "Chromosome Axis",
                                 "options": {
-                                    "trackBorderColor": "black",
                                     "showMousePosition": false,
                                     "showTooltip": false,
-                                    "trackBorderWidth": 0,
+                                    "color": "#777777",
+                                    "stroke": "#FFFFFF",
                                     "mousePositionColor": "#999999",
-                                    "fontSize": 12,
-                                    "labelColor": "#888",
-                                    "minusStrandColor": "red",
-                                    "labelPosition": "hidden"
+                                    "fontSize": 12
                                 },
-                                "local": true,
-                                "position": "top",
                                 "width": 465,
                                 "uid": "top-chromosome-track",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
@@ -243,12 +185,10 @@
                         583408504.4418085
                     ],
                     "layout": {
-                        "moved": false,
                         "y": 0,
                         "w": 6,
                         "x": 0,
-                        "h": 6,
-                        "static": false
+                        "h": 6
                     }
                 },
                 {
@@ -268,7 +208,6 @@
                         "left": [
                             {
                                 "width": 55,
-                                "orientation": "1d-vertical",
                                 "uid": "left-annotation-track",
                                 "tilesetUid": "308f5404-694a-4c77-a8e8-3e6cc5f63079",
                                 "options": {
@@ -279,7 +218,6 @@
                                     "minusStrandColor": "black",
                                     "geneLabelPosition": "outside",
                                     "labelRightMargin": 0,
-                                    "name": "Gene Annotations (hg38)",
                                     "labelLeftMargin": 0,
                                     "fontSize": 10,
                                     "labelTopMargin": 0,
@@ -293,36 +231,23 @@
                                 },
                                 "type": "vertical-gene-annotations",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Gene Annotations (hg38)",
-                                "height": 158,
-                                "header": "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14",
-                                "position": "left"
+                                "height": 158
                             },
                             {
                                 "width": 35,
-                                "orientation": "1d-vertical",
                                 "uid": "left-chromosome-track",
                                 "options": {
-                                    "trackBorderColor": "black",
                                     "showMousePosition": false,
                                     "showTooltip": false,
-                                    "trackBorderWidth": 0,
                                     "color": "#777777",
                                     "stroke": "#FFFFFF",
-                                    "plusStrandColor": "blue",
                                     "mousePositionColor": "#999999",
-                                    "fontSize": 12,
-                                    "labelColor": "black",
-                                    "minusStrandColor": "red",
-                                    "labelPosition": "hidden"
+                                    "fontSize": 12
                                 },
-                                "minWidth": 20,
                                 "type": "vertical-chromosome-labels",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Chromosome Axis",
                                 "height": 158,
-                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg",
-                                "position": "left"
+                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg"
                             }
                         ],
                         "right": [],
@@ -337,24 +262,6 @@
                                     {
                                         "height": 158,
                                         "uid": "GjuZed1ySGW1IzZZqFB9BA",
-                                        "transforms": [
-                                            {
-                                                "name": "ICE",
-                                                "value": "weight"
-                                            },
-                                            {
-                                                "name": "VC_SQRT",
-                                                "value": "VC_SQRT"
-                                            },
-                                            {
-                                                "name": "KR",
-                                                "value": "KR"
-                                            },
-                                            {
-                                                "name": "VC",
-                                                "value": "VC"
-                                            }
-                                        ],
                                         "options": {
                                             "trackBorderColor": "black",
                                             "showMousePosition": false,
@@ -363,7 +270,6 @@
                                             "maxZoom": null,
                                             "scaleStartPercent": "0.00000",
                                             "labelRightMargin": 0,
-                                            "name": "HFFc6 Hi-C",
                                             "labelLeftMargin": 0,
                                             "labelBottomMargin": 0,
                                             "colorRange": [
@@ -380,24 +286,8 @@
                                             "backgroundColor": "#eeeeee",
                                             "trackBorderWidth": 0
                                         },
-                                        "resolutions": [
-                                            1000,
-                                            2000,
-                                            5000,
-                                            10000,
-                                            25000,
-                                            50000,
-                                            100000,
-                                            250000,
-                                            500000,
-                                            1000000,
-                                            2500000,
-                                            5000000,
-                                            10000000
-                                        ],
                                         "type": "heatmap",
                                         "server": "https://higlass.4dnucleome.org/api/v1",
-                                        "name": "4DNFIB59T7NN.mcool",
                                         "width": 465,
                                         "tilesetUid": "OxZJjFLwRYq8PA_cRgipbQ",
                                         "position": "center"
@@ -409,25 +299,14 @@
                         "top": [
                             {
                                 "height": 35,
-                                "thumbnail": null,
-                                "orientation": "1d-horizontal",
-                                "name": "Chromosome Axis",
                                 "options": {
-                                    "trackBorderColor": "black",
                                     "showMousePosition": false,
                                     "showTooltip": false,
-                                    "trackBorderWidth": 0,
                                     "color": "#777777",
                                     "stroke": "#FFFFFF",
-                                    "plusStrandColor": "blue",
                                     "mousePositionColor": "#999999",
-                                    "fontSize": 12,
-                                    "labelColor": "#888",
-                                    "minusStrandColor": "red",
-                                    "labelPosition": "hidden"
+                                    "fontSize": 12
                                 },
-                                "local": true,
-                                "position": "top",
                                 "width": 465,
                                 "uid": "top-chromosome-track",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
@@ -445,12 +324,10 @@
                         583408504.4418085
                     ],
                     "layout": {
-                        "moved": false,
                         "y": 0,
                         "w": 6,
                         "x": 6,
-                        "h": 6,
-                        "static": false
+                        "h": 6
                     }
                 },
                 {
@@ -470,18 +347,15 @@
                         "left": [
                             {
                                 "width": 55,
-                                "orientation": "1d-vertical",
                                 "uid": "left-annotation-track",
                                 "tilesetUid": "308f5404-694a-4c77-a8e8-3e6cc5f63079",
                                 "options": {
                                     "trackBorderColor": "black",
                                     "showMousePosition": false,
                                     "showTooltip": false,
-
                                     "minusStrandColor": "black",
                                     "geneLabelPosition": "outside",
                                     "labelRightMargin": 0,
-                                    "name": "Gene Annotations (hg38)",
                                     "labelLeftMargin": 0,
                                     "fontSize": 10,
                                     "labelTopMargin": 0,
@@ -495,36 +369,23 @@
                                 },
                                 "type": "vertical-gene-annotations",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Gene Annotations (hg38)",
-                                "height": 158,
-                                "header": "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14",
-                                "position": "left"
+                                "height": 158
                             },
                             {
                                 "width": 35,
-                                "orientation": "1d-vertical",
                                 "uid": "left-chromosome-track",
                                 "options": {
-                                    "trackBorderColor": "black",
                                     "showMousePosition": false,
                                     "showTooltip": false,
-                                    "trackBorderWidth": 0,
                                     "color": "#777777",
                                     "stroke": "#FFFFFF",
-                                    "plusStrandColor": "blue",
                                     "mousePositionColor": "#999999",
-                                    "fontSize": 12,
-                                    "labelColor": "black",
-                                    "minusStrandColor": "red",
-                                    "labelPosition": "hidden"
+                                    "fontSize": 12
                                 },
-                                "minWidth": 20,
                                 "type": "vertical-chromosome-labels",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Chromosome Axis",
                                 "height": 158,
-                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg",
-                                "position": "left"
+                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg"
                             }
                         ],
                         "right": [],
@@ -539,24 +400,6 @@
                                     {
                                         "height": 158,
                                         "uid": "NAR1jmYWQSGoHaH6z0EouQ",
-                                        "transforms": [
-                                            {
-                                                "name": "ICE",
-                                                "value": "weight"
-                                            },
-                                            {
-                                                "name": "VC_SQRT",
-                                                "value": "VC_SQRT"
-                                            },
-                                            {
-                                                "name": "KR",
-                                                "value": "KR"
-                                            },
-                                            {
-                                                "name": "VC",
-                                                "value": "VC"
-                                            }
-                                        ],
                                         "options": {
                                             "trackBorderColor": "black",
                                             "showMousePosition": false,
@@ -565,7 +408,6 @@
                                             "maxZoom": null,
                                             "scaleStartPercent": "0.00000",
                                             "labelRightMargin": 0,
-                                            "name": "H1-hESC Micro-C",
                                             "labelLeftMargin": 0,
                                             "labelBottomMargin": 0,
                                             "colorRange": [
@@ -582,24 +424,8 @@
                                             "backgroundColor": "#eeeeee",
                                             "trackBorderWidth": 0
                                         },
-                                        "resolutions": [
-                                            1000,
-                                            2000,
-                                            5000,
-                                            10000,
-                                            25000,
-                                            50000,
-                                            100000,
-                                            250000,
-                                            500000,
-                                            1000000,
-                                            2500000,
-                                            5000000,
-                                            10000000
-                                        ],
                                         "type": "heatmap",
                                         "server": "https://higlass.4dnucleome.org/api/v1",
-                                        "name": "4DNFI9GMP2J8.mcool",
                                         "width": 465,
                                         "tilesetUid": "JfVtzAhFSCS-j6tNALioCQ",
                                         "position": "center"
@@ -611,8 +437,6 @@
                         "top": [
                             {
                                 "height": 55,
-                                "orientation": "1d-horizontal",
-                                "name": "Gene Annotations (hg38)",
                                 "options": {
                                     "trackBorderColor": "black",
                                     "showMousePosition": false,
@@ -621,7 +445,6 @@
                                     "geneAnnotationHeight": 12,
                                     "geneLabelPosition": "outside",
                                     "labelRightMargin": 0,
-                                    "name": "Gene Annotations (hg38)",
                                     "labelLeftMargin": 0,
                                     "fontSize": 10,
                                     "labelTopMargin": 0,
@@ -633,8 +456,6 @@
                                     "labelColor": "black",
                                     "plusStrandColor": "black"
                                 },
-                                "header": "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14",
-                                "position": "top",
                                 "width": 465,
                                 "uid": "top-annotation-track",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
@@ -652,12 +473,10 @@
                         570339928.1121173
                     ],
                     "layout": {
-                        "moved": false,
                         "y": 6,
                         "w": 6,
                         "x": 0,
-                        "h": 6,
-                        "static": false
+                        "h": 6
 
                     }
                 },
@@ -678,7 +497,6 @@
                         "left": [
                             {
                                 "width": 55,
-                                "orientation": "1d-vertical",
                                 "uid": "left-annotation-track",
                                 "tilesetUid": "308f5404-694a-4c77-a8e8-3e6cc5f63079",
                                 "options": {
@@ -689,7 +507,6 @@
                                     "minusStrandColor": "black",
                                     "geneLabelPosition": "outside",
                                     "labelRightMargin": 0,
-                                    "name": "Gene Annotations (hg38)",
                                     "labelLeftMargin": 0,
                                     "fontSize": 10,
                                     "labelTopMargin": 0,
@@ -703,36 +520,23 @@
                                 },
                                 "type": "vertical-gene-annotations",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Gene Annotations (hg38)",
-                                "height": 158,
-                                "header": "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14",
-                                "position": "left"
+                                "height": 158
                             },
                             {
                                 "width": 35,
-                                "orientation": "1d-vertical",
                                 "uid": "left-chromosome-track",
                                 "options": {
-                                    "trackBorderColor": "black",
                                     "showMousePosition": false,
                                     "showTooltip": false,
-                                    "trackBorderWidth": 0,
                                     "color": "#777777",
                                     "stroke": "#FFFFFF",
-                                    "plusStrandColor": "blue",
                                     "mousePositionColor": "#999999",
-                                    "fontSize": 12,
-                                    "labelColor": "black",
-                                    "minusStrandColor": "red",
-                                    "labelPosition": "hidden"
+                                    "fontSize": 12
                                 },
-                                "minWidth": 20,
                                 "type": "vertical-chromosome-labels",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
-                                "name": "Chromosome Axis",
                                 "height": 158,
-                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg",
-                                "position": "left"
+                                "tilesetUid": "OqB3CMF7RMyQ0a1w3RaFqg"
                             }
                         ],
                         "right": [],
@@ -747,24 +551,6 @@
                                     {
                                         "height": 158,
                                         "uid": "ZBgcj7jkTHSA9_jUbwQhIA",
-                                        "transforms": [
-                                            {
-                                                "name": "ICE",
-                                                "value": "weight"
-                                            },
-                                            {
-                                                "name": "VC_SQRT",
-                                                "value": "VC_SQRT"
-                                            },
-                                            {
-                                                "name": "KR",
-                                                "value": "KR"
-                                            },
-                                            {
-                                                "name": "VC",
-                                                "value": "VC"
-                                            }
-                                        ],
                                         "options": {
                                             "trackBorderColor": "black",
                                             "showMousePosition": false,
@@ -772,7 +558,6 @@
                                             "heatmapValueScaling": "log",
                                             "scaleStartPercent": "0.00000",
                                             "labelRightMargin": 0,
-                                            "name": "HFFc6 Micro-C",
                                             "labelLeftMargin": 0,
                                             "labelBottomMargin": 0,
                                             "colorRange": [
@@ -789,24 +574,8 @@
                                             "backgroundColor": "#eeeeee",
                                             "trackBorderWidth": 0
                                         },
-                                        "resolutions": [
-                                            1000,
-                                            2000,
-                                            5000,
-                                            10000,
-                                            25000,
-                                            50000,
-                                            100000,
-                                            250000,
-                                            500000,
-                                            1000000,
-                                            2500000,
-                                            5000000,
-                                            10000000
-                                        ],
                                         "type": "heatmap",
                                         "server": "https://higlass.4dnucleome.org/api/v1",
-                                        "name": "4DNFI643OYP9.mcool",
                                         "width": 465,
                                         "tilesetUid": "VIZiSC6uQ8actkvgIgzl-g",
                                         "position": "center"
@@ -818,8 +587,6 @@
                         "top": [
                             {
                                 "height": 55,
-                                "orientation": "1d-horizontal",
-                                "name": "Gene Annotations (hg38)",
                                 "options": {
                                     "trackBorderColor": "black",
                                     "showMousePosition": false,
@@ -828,7 +595,6 @@
                                     "geneAnnotationHeight": 12,
                                     "geneLabelPosition": "outside",
                                     "labelRightMargin": 0,
-                                    "name": "Gene Annotations (hg38)",
                                     "labelLeftMargin": 0,
                                     "fontSize": 10,
                                     "labelTopMargin": 0,
@@ -840,8 +606,6 @@
                                     "labelColor": "black",
                                     "plusStrandColor": "black"
                                 },
-                                "header": "1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t13\t14",
-                                "position": "top",
                                 "width": 465,
                                 "uid": "top-annotation-track",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
@@ -859,12 +623,10 @@
                         570339928.1121173
                     ],
                     "layout": {
-                        "moved": false,
                         "y": 6,
                         "w": 6,
                         "x": 6,
-                        "h": 6,
-                        "static": false
+                        "h": 6
                     }
                 }
             ],
@@ -931,41 +693,7 @@
                                 "contents": [
                                     {
                                         "uid": "GjuZed1ySGW1IzZZqFB9BA",
-                                        "transforms": [
-                                            {
-                                                "name": "KR",
-                                                "value": "KR"
-                                            },
-                                            {
-                                                "name": "ICE",
-                                                "value": "weight"
-                                            },
-                                            {
-                                                "name": "VC",
-                                                "value": "VC"
-                                            },
-                                            {
-                                                "name": "VC_SQRT",
-                                                "value": "VC_SQRT"
-                                            }
-                                        ],
                                         "position": "center",
-                                        "name": "4DNFI1TBYKV3.mcool",
-                                        "resolutions": [
-                                            1000,
-                                            2000,
-                                            5000,
-                                            10000,
-                                            25000,
-                                            50000,
-                                            100000,
-                                            250000,
-                                            500000,
-                                            1000000,
-                                            2500000,
-                                            5000000,
-                                            10000000
-                                        ],
                                         "server": "https://higlass.4dnucleome.org/api/v1",
                                         "tilesetUid": "LTiacew8TjCOaP9gpDZwZw",
                                         "type": "heatmap",
@@ -1003,9 +731,6 @@
                                 "uid": "left-annotation-track",
                                 "width": 55,
                                 "tilesetUid": "350f6449-5dbf-4754-a9eb-86040fe28354",
-                                "name": "Gene Annotations (GRCm38)",
-                                "orientation": "1d-vertical",
-                                "position": "left",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
                                 "type": "vertical-gene-annotations",
                                 "options": {
@@ -1019,27 +744,16 @@
                                     "showMousePosition": false,
                                     "trackBorderWidth": 0,
                                     "labelPosition": "hidden"
-                                },
-                                "header": ""
+                                }
                             },
                             {
                                 "uid": "left-chromosome-track",
                                 "width": 20,
-                                "minWidth": 20,
-                                "name": "Chromosome Axis",
-                                "orientation": "1d-vertical",
-                                "position": "left",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
                                 "type": "vertical-chromosome-labels",
                                 "options": {
-                                    "labelColor": "black",
-                                    "trackBorderColor": "black",
-                                    "minusStrandColor": "red",
                                     "showMousePosition": false,
-                                    "trackBorderWidth": 0,
                                     "showTooltip": false,
-                                    "labelPosition": "hidden",
-                                    "plusStrandColor": "blue",
                                     "mousePositionColor": "#999999"
                                 },
                                 "tilesetUid": "EMo5uFThS5S263tNLbzeVw"
@@ -1050,10 +764,7 @@
                             {
                                 "uid": "top-annotation-track",
                                 "tilesetUid": "350f6449-5dbf-4754-a9eb-86040fe28354",
-                                "name": "Gene Annotations (GRCm38)",
-                                "orientation": "1d-horizontal",
                                 "height": 55,
-                                "position": "top",
                                 "server": "https://higlass.4dnucleome.org/api/v1",
                                 "type": "horizontal-gene-annotations",
                                 "options": {
@@ -1067,29 +778,21 @@
                                     "showMousePosition": false,
                                     "trackBorderWidth": 0,
                                     "labelPosition": "hidden"
-                                },
-                                "header": ""
+                                }
                             },
                             {
-                                "orientation": "1d-horizontal",
                                 "height": 30,
-                                "position": "top",
                                 "type": "horizontal-chromosome-labels",
                                 "uid": "top-chromosome-track",
-                                "local": true,
-                                "name": "Chromosome Axis",
-                                "thumbnail": null,
                                 "server": "https://higlass.4dnucleome.org/api/v1",
                                 "tilesetUid": "EMo5uFThS5S263tNLbzeVw",
                                 "options": {
                                     "labelColor": "#888",
                                     "trackBorderColor": "black",
-                                    "minusStrandColor": "red",
                                     "showMousePosition": false,
                                     "trackBorderWidth": 0,
                                     "showTooltip": false,
                                     "labelPosition": "hidden",
-                                    "plusStrandColor": "blue",
                                     "mousePositionColor": "#999999"
                                 }
                             }
@@ -1106,12 +809,9 @@
                         "autocompleteId": "IUcqX4GzTNWJIzE2-b_sZg"
                     },
                     "layout": {
-                        "moved": false,
                         "h": 12,
-                        "static": true,
                         "x": 0,
                         "y": 0,
-                        "i": "view-4dn-mcool-0",
                         "w": 12
                     }
                 }
@@ -1163,11 +863,9 @@
                     "uid": "aa",
                     "autocompleteSource": "",
                     "layout": {
-                        "static": false,
                         "w": 12,
                         "x": 0,
                         "h": 12,
-                        "moved": false,
                         "y": 0
                     },
                     "initialYDomain": [

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -23,21 +23,14 @@ def higlass_mcool_viewconf(testapp, award, lab):
         'lab': lab['@id'],
         "title":
         "Test MCOOL Display",
-        "description":
-        "An MCOOL file track plus annotations for gene GRCm38 (tileset 'IUcqX4GzTNWJIzE2-b_sZg') and chromosome 'JXbq7f-GTeq3FJy_ilIomQ'.",
-        "uuid":
-        "00000000-1111-0000-1111-000000000002",
-        "name":
-        "higlass-mcool-test-view",
-        "genome_assembly":
-        "GRCm38",
+        "description": "An MCOOL file track plus annotations for gene GRCm38 (tileset 'IUcqX4GzTNWJIzE2-b_sZg') and chromosome 'JXbq7f-GTeq3FJy_ilIomQ'.",
+        "uuid": "00000000-1111-0000-1111-000000000002",
+        "name": "higlass-mcool-test-view",
+        "genome_assembly": "GRCm38",
         "viewconfig": {
-            "editable":
-            True,
-            "zoomFixed":
-            False,
-            "exportViewUrl":
-            "/api/v1/viewconfs",
+            "editable": True,
+            "zoomFixed": False,
+            "exportViewUrl": "/api/v1/viewconfs",
             "zoomLocks": {
                 "locksByViewUid": {},
                 "locksDict": {}
@@ -48,20 +41,16 @@ def higlass_mcool_viewconf(testapp, award, lab):
             },
             "trackSourceServers": ["https://higlass.4dnucleome.org/api/v1"],
             "views": [{
-                "uid":
-                "view-4dn-mcool-0",
+                "uid": "view-4dn-mcool-0",
                 "layout": {
                     "w": 12,
                     "h": 12,
                     "x": 0,
-                    "y": 0,
-                    "moved": False,
-                    "static": True
+                    "y": 0
                 },
                 "initialXDomain": [102391829.2052902, 2938891536.27695],
                 "initialYDomain": [129711724.73566854, 1810982460.1999617],
-                "autocompleteSource":
-                "/api/v1/suggest/?d=IUcqX4GzTNWJIzE2-b_sZg&",
+                "autocompleteSource": "/api/v1/suggest/?d=IUcqX4GzTNWJIzE2-b_sZg&",
                 "genomePositionSearchBox": {
                     "autocompleteServer":
                     "https://higlass.4dnucleome.org/api/v1",
@@ -72,7 +61,6 @@ def higlass_mcool_viewconf(testapp, award, lab):
                 },
                 "tracks": {
                     "top": [{
-                        "name": "Gene Annotations (GRCm38)",
                         "server": "https://higlass.4dnucleome.org/api/v1",
                         "tilesetUid": "IUcqX4GzTNWJIzE2-b_sZg",
                         "type": "horizontal-gene-annotations",
@@ -88,17 +76,11 @@ def higlass_mcool_viewconf(testapp, award, lab):
                             "mousePositionColor": "#999999"
                         },
                         "height": 55,
-                        "header": "",
-                        "position": "top",
-                        "orientation": "1d-horizontal",
                         "uid": "top-annotation-track"
                     }, {
-                        "name": "Chromosome Axis",
                         "server": "https://higlass.4dnucleome.org/api/v1",
                         "tilesetUid": "JXbq7f-GTeq3FJy_ilIomQ",
                         "type": "horizontal-chromosome-labels",
-                        "local": True,
-                        "thumbnail": None,
                         "options": {
                             "showMousePosition": False,
                             "mousePositionColor": "#999999"
@@ -109,16 +91,10 @@ def higlass_mcool_viewconf(testapp, award, lab):
                         "uid": "top-chromosome-track"
                     }],
                     "left": [{
-                        "name":
-                        "Gene Annotations (GRCm38)",
-                        "server":
-                        "https://higlass.4dnucleome.org/api/v1",
-                        "tilesetUid":
-                        "IUcqX4GzTNWJIzE2-b_sZg",
-                        "uid":
-                        "left-annotation-track",
-                        "type":
-                        "vertical-gene-annotations",
+                        "server": "https://higlass.4dnucleome.org/api/v1",
+                        "tilesetUid": "IUcqX4GzTNWJIzE2-b_sZg",
+                        "uid": "left-annotation-track",
+                        "type": "vertical-gene-annotations",
                         "options": {
                             "labelColor": "black",
                             "labelPosition": "hidden",
@@ -130,109 +106,47 @@ def higlass_mcool_viewconf(testapp, award, lab):
                             "showMousePosition": False,
                             "mousePositionColor": "#999999"
                         },
-                        "width":
-                        55,
-                        "header":
-                        "",
-                        "orientation":
-                        "1d-vertical",
-                        "position":
-                        "left"
+                        "width": 55
                     }, {
-                        "name":
-                        "Chromosome Axis",
-                        "server":
-                        "https://higlass.4dnucleome.org/api/v1",
-                        "tilesetUid":
-                        "JXbq7f-GTeq3FJy_ilIomQ",
-                        "uid":
-                        "left-chromosome-track",
-                        "type":
-                        "vertical-chromosome-labels",
+                        "server": "https://higlass.4dnucleome.org/api/v1",
+                        "tilesetUid": "JXbq7f-GTeq3FJy_ilIomQ",
+                        "uid": "left-chromosome-track",
+                        "type": "vertical-chromosome-labels",
                         "options": {
                             "showMousePosition": False,
                             "mousePositionColor": "#999999"
                         },
-                        "width":
-                        20,
-                        "minWidth":
-                        20,
-                        "orientation":
-                        "1d-vertical",
-                        "position":
-                        "left"
+                        "width": 20
                     }],
                     "center": [{
-                        "uid":
-                        "center-mcool-track",
-                        "type":
-                        "combined",
-                        "height":
-                        250,
+                        "uid": "center-mcool-track",
+                        "type": "combined",
+                        "height": 250,
                         "contents": [{
-                            "server":
-                            "https://higlass.4dnucleome.org/api/v1",
-                            "tilesetUid":
-                            "LTiacew8TjCOaP9gpDZwZw",
-                            "type":
-                            "heatmap",
-                            "position":
-                            "center",
-                            "uid":
-                            "GjuZed1ySGW1IzZZqFB9BA",
-                            "name":
-                            "4DNFI1TBYKV3.mcool",
+                            "server": "https://higlass.4dnucleome.org/api/v1",
+                            "tilesetUid": "LTiacew8TjCOaP9gpDZwZw",
+                            "type": "heatmap",
+                            "position": "center",
+                            "uid": "GjuZed1ySGW1IzZZqFB9BA",
                             "options": {
-                                "backgroundColor":
-                                "#eeeeee",
-                                "labelPosition":
-                                "topLeft",
-
+                                "backgroundColor": "#eeeeee",
+                                "labelPosition": "topLeft",
                                 "colorRange": [
                                     "white", "rgba(245,166,35,1.0)",
                                     "rgba(208,2,27,1.0)", "black"
                                 ],
-                                "maxZoom":
-                                None,
-                                "colorbarPosition":
-                                "topRight",
-                                "trackBorderWidth":
-                                0,
-                                "trackBorderColor":
-                                "black",
-                                "heatmapValueScaling":
-                                "log",
-                                "showMousePosition":
-                                False,
-                                "mousePositionColor":
-                                "#999999",
-                                "showTooltip":
-                                False,
-                                "name":
-                                "4DNFI1TBYKV3.mcool",
-                                "scaleStartPercent":
-                                "0.00000",
-                                "scaleEndPercent":
-                                "1.00000"
-                            },
-                            "transforms": [{
-                                "name": "KR",
-                                "value": "KR"
-                            }, {
-                                "name": "ICE",
-                                "value": "weight"
-                            }, {
-                                "name": "VC",
-                                "value": "VC"
-                            }, {
-                                "name": "VC_SQRT",
-                                "value": "VC_SQRT"
-                            }],
-                            "resolutions": [
-                                1000, 2000, 5000, 10000, 25000, 50000, 100000,
-                                250000, 500000, 1000000, 2500000, 5000000,
-                                10000000
-                            ]
+                                "maxZoom": None,
+                                "colorbarPosition": "topRight",
+                                "trackBorderWidth": 0,
+                                "trackBorderColor": "black",
+                                "heatmapValueScaling": "log",
+                                "showMousePosition": False,
+                                "mousePositionColor": "#999999",
+                                "showTooltip": False,
+                                "name": "4DNFI1TBYKV3.mcool",
+                                "scaleStartPercent": "0.00000",
+                                "scaleEndPercent": "1.00000"
+                            }
                         }],
                         "position":
                         "center",
@@ -300,9 +214,7 @@ def higlass_blank_viewconf(testapp, lab, award):
                     "w": 12,
                     "h": 12,
                     "x": 0,
-                    "y": 0,
-                    "moved": False,
-                    "static": False
+                    "y": 0
                 },
                 "initialYDomain": [549528857.4793874, 2550471142.5206127]
             }],

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -419,7 +419,7 @@ def test_add_bedGraph_higlass(testapp, higlass_mcool_viewconf,
 
     # Assert_true(there is still 1 central view)
     assert_true(len(tracks["center"][0]["contents"]) == 1)
-    assert_true("mcool" in tracks["center"][0]["contents"][0]["name"])
+    assert_true(tracks["center"][0]["contents"][0]["type"] == "heatmap")
 
     # Only one new top track should have appeared.
     assert_true(len(tracks["left"]) == len(old_tracks["left"]))
@@ -1254,7 +1254,7 @@ def test_add_files_by_accession(testapp, mcool_file_json,
 
     # 1 central track should be in the new view.
     assert_true(len(tracks["center"][0]["contents"]) == 1)
-    assert_true("mcool" in tracks["center"][0]["contents"][0]["name"])
+    assert_true(tracks["center"][0]["contents"][0]["type"] == "heatmap")
 
     # 1 more track should be on top.
     assert_true(len(tracks["top"]) == len(old_tracks["top"]) + 1)
@@ -1378,7 +1378,7 @@ def test_add_bigwig_higlass(testapp, higlass_mcool_viewconf, bigwig_file_json):
 
     # Assert_true(there is still 1 central view)
     assert_true(len(tracks["center"][0]["contents"]) == 1)
-    assert_true("mcool" in tracks["center"][0]["contents"][0]["name"])
+    assert_true(tracks["center"][0]["contents"][0]["type"] == "heatmap")
 
     # Only one new top track should have appeared.
     assert_true(len(tracks["left"]) == len(old_tracks["left"]))
@@ -1433,7 +1433,7 @@ def test_add_bigbed_higlass(testapp, higlass_mcool_viewconf, bigbed_file_json):
 
     # Assert_true(there is still 1 central view)
     assert_true(len(tracks["center"][0]["contents"]) == 1)
-    assert_true("mcool" in tracks["center"][0]["contents"][0]["name"])
+    assert_true(tracks["center"][0]["contents"][0]["type"] == "heatmap")
 
     # Make sure the view has an initialXDomain and initialYDomain.
     assert_true(len(new_higlass_json["views"][0]["initialXDomain"]) == 2)
@@ -1535,7 +1535,7 @@ def test_add_bed_with_beddb(testapp, higlass_mcool_viewconf,
 
     # Central track is unchanged
     assert_true(len(tracks["center"][0]["contents"]) == 1)
-    assert_true("mcool" in tracks["center"][0]["contents"][0]["name"])
+    assert_true(tracks["center"][0]["contents"][0]["type"] == "heatmap")
 
     # The top track should be a bed-like track
     found_data_track = False

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -1958,7 +1958,6 @@ def test_remove_1d(testapp, higlass_mcool_viewconf, chromsizes_file_json,
         if track["type"] in types_to_find:
             types_to_find[track["type"]] += 1
             
-
     assert_true(types_to_find["vertical-gene-annotations"] > 0)
     assert_true(types_to_find["vertical-chromosome-labels"] > 0)
     assert_true(vertical_tracks_found > 0)

--- a/src/encoded/tests/test_higlass.py
+++ b/src/encoded/tests/test_higlass.py
@@ -86,8 +86,6 @@ def higlass_mcool_viewconf(testapp, award, lab):
                             "mousePositionColor": "#999999"
                         },
                         "height": 30,
-                        "position": "top",
-                        "orientation": "1d-horizontal",
                         "uid": "top-chromosome-track"
                     }],
                     "left": [{
@@ -148,8 +146,7 @@ def higlass_mcool_viewconf(testapp, award, lab):
                                 "scaleEndPercent": "1.00000"
                             }
                         }],
-                        "position":
-                        "center",
+                        "position": "center",
                         "options": {}
                     }],
                     "right": [],
@@ -1883,7 +1880,6 @@ def test_remove_1d(testapp, higlass_mcool_viewconf, chromsizes_file_json,
     for t in full_higlass_json["views"][0]["tracks"]["top"]:
         if t["type"] == "horizontal-chromosome-labels":
             t['height'] = 50
-            t["orientation"] = "1d-horizontal"
 
     # Remove the mcool from the central contents.
     full_higlass_json["views"][0]["tracks"]["center"] = []
@@ -1953,6 +1949,7 @@ def test_remove_1d(testapp, higlass_mcool_viewconf, chromsizes_file_json,
 
     vertical_tracks_found = 0
     for track in restored_2d_track_higlass_json["views"][0]["tracks"]["left"]:
+        vertical_tracks_found += 1
         if "uid" in track:
             assert_true(
                 track["uid"] not in top_track_uids,
@@ -1960,8 +1957,7 @@ def test_remove_1d(testapp, higlass_mcool_viewconf, chromsizes_file_json,
                     uid=track["uid"]))
         if track["type"] in types_to_find:
             types_to_find[track["type"]] += 1
-        if track["orientation"] == "1d-vertical":
-            vertical_tracks_found += 1
+            
 
     assert_true(types_to_find["vertical-gene-annotations"] > 0)
     assert_true(types_to_find["vertical-chromosome-labels"] > 0)

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -848,13 +848,14 @@ def add_bg_bw_multivec_bed_file(views, file, genome_assembly, viewconfig_info, m
     new_track_base = {
         "server": "https://higlass.4dnucleome.org/api/v1",
         "tilesetUid": file["higlass_uid"],
-        "name": file["display_title"],
         "options": {
             "name": get_title(file),
             "labelPosition": "topLeft",
+            "showMousePosition": True,
+            "mousePositionColor": "#999999",
+            "labelTextOpacity": 0.6
         },
         "type": "horizontal-divergent-bar",
-        "orientation": "1d-horizontal",
         "uid": uuid.uuid4(),
     }
 
@@ -906,7 +907,6 @@ def add_bigbed_file(views, file, genome_assembly, viewconfig_info, maximum_heigh
     new_track_base = {
         "server": "https://higlass.4dnucleome.org/api/v1",
         "tilesetUid": file["higlass_uid"],
-        "name": file["display_title"],
         "options": {
             "name": get_title(file),
             "colorRange": [],
@@ -915,7 +915,6 @@ def add_bigbed_file(views, file, genome_assembly, viewconfig_info, maximum_heigh
         },
         "height": 18,
         "type": "horizontal-vector-heatmap",
-        "orientation": "1d-horizontal",
         "uid": uuid.uuid4(),
     }
 
@@ -1121,9 +1120,11 @@ def add_beddb_file(views, file, genome_assembly, viewconfig_info, maximum_height
     new_track_base = {
         "server": "https://higlass.4dnucleome.org/api/v1",
         "tilesetUid": file["higlass_uid"],
-        "name": file["display_title"],
         "options": {
             "name": get_title(file),
+            "labelPosition": "hidden",
+            "showMousePosition": True,
+            "mousePositionColor": "#999999",
             "fontSize": 10, # has to be set explicitly since Higlass has a different default value
             "geneAnnotationHeight": 12 # has to be set explicitly since Higlass has a different default value
         }
@@ -1138,12 +1139,10 @@ def add_beddb_file(views, file, genome_assembly, viewconfig_info, maximum_height
     }
 
     new_tracks_by_side["top"]["type"] = "horizontal-gene-annotations"
-    new_tracks_by_side["top"]["orientation"] = "1d-horizontal"
     new_tracks_by_side["top"]["height"] = 55 # has to be set explicitly since Higlass has a different default value
     new_tracks_by_side["top"]["uid"] = uuid.uuid4()
 
     new_tracks_by_side["left"]["type"] = "vertical-gene-annotations"
-    new_tracks_by_side["left"]["orientation"] = "1d-vertical"
     new_tracks_by_side["left"]["width"] = 55 # has to be set explicitly since Higlass has a different default value
     new_tracks_by_side["left"]["uid"] = uuid.uuid4()
 
@@ -1212,9 +1211,10 @@ def add_chromsizes_file(views, file, genome_assembly, viewconfig_info, maximum_h
     new_track_base_1d = {
         "server": "https://higlass.4dnucleome.org/api/v1",
         "tilesetUid": file["higlass_uid"],
-        "name": file["display_title"],
         "options": {
             "name": get_title(file),
+            "showMousePosition": True,
+            "mousePositionColor": "#999999",
         }
     }
 
@@ -1228,14 +1228,11 @@ def add_chromsizes_file(views, file, genome_assembly, viewconfig_info, maximum_h
     }
 
     new_tracks_by_side["top"]["type"] = "horizontal-chromosome-labels"
-    new_tracks_by_side["top"]["orientation"] = "1d-horizontal"
     new_tracks_by_side["top"]["uid"] = uuid.uuid4()
 
     new_tracks_by_side["left"]["type"] = "vertical-chromosome-labels"
-    new_tracks_by_side["left"]["orientation"] = "1d-vertical"
     new_tracks_by_side["left"]["uid"] = uuid.uuid4()
 
-    new_tracks_by_side["center"]["name"] = "Chromosome Grid"
     del new_tracks_by_side["center"]["options"]["name"]
    
 
@@ -1319,7 +1316,6 @@ def add_2d_file(views, new_content, viewconfig_info, maximum_height):
             chromsize_tracks = [ t for t in views[0]["tracks"]["top"] if "-chromosome-labels" in t["type"] ]
 
             contents = {
-                "name": "Chromosome Grid"
             }
             if len(chromsize_tracks) > 0:
                 chrom_source = chromsize_tracks[-1]
@@ -1382,7 +1378,6 @@ def create_2d_content(file, viewtype):
     contents = {}
 
     contents["tilesetUid"] = file["higlass_uid"]
-    contents["name"] = file["display_title"]
     contents["type"] = viewtype
     contents["server"] = "https://higlass.4dnucleome.org/api/v1"
 
@@ -1412,11 +1407,6 @@ def copy_top_reference_tracks_into_left(target_view, views):
     reference_file_type_mappings = {
         "horizontal-chromosome-labels": "vertical-chromosome-labels",
         "horizontal-gene-annotations": "vertical-gene-annotations",
-    }
-
-    orientation_mappings = {
-        "1d-horizontal": "1d-vertical",
-        "1d-vertical" : "1d-horizontal",
     }
 
     # Look through all of the top views for the chromsize and the gene annotation tracks.
@@ -1454,11 +1444,6 @@ def copy_top_reference_tracks_into_left(target_view, views):
             track["width"] = temp_width
             del track["height"]
         
-        # And the orientation
-        track_orientation = track.get("orientation", None)
-        if track_orientation in orientation_mappings:
-            track["orientation"] = orientation_mappings[track_orientation]
-
     # Add the copied tracks to the left side of this view if it doesn't have the track already.
     for track in reversed(new_tracks):
         if any([t for t in target_view["tracks"]["left"] if t["type"] == track["type"]] ) == False:


### PR DESCRIPTION
This PR updates the schema for Higlass viewconfigs. Many redundant or incorrect fields have been removed from the schema. Only fields that are globally present in every viewconf with the same default value (that are different from the Higlass defaults) and fields that are supposed to be indexed remain. 
I deleted most of the track options from the schema. Default values for track options are now taken care of in visualization.py. 
Track names (labels) and uuids remain in the schema, as we might want to search for those.