### PR TITLE
Unauthenticated File Download Warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3710,8 +3710,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#75b0a789eaeb7befa3f0e87554d9b2e59058938a",
-      "from": "github:4dn-dcic/shared-portal-components#0.0.2.79",
+      "version": "github:4dn-dcic/shared-portal-components#6e8802eb658d773fe57dc29d6ba1b1309178bc35",
+      "from": "github:4dn-dcic/shared-portal-components#0.0.2.80b1",
       "requires": {
         "auth0-lock": "^11.26.3",
         "aws-sdk": "^2.745.0",
@@ -5477,9 +5477,9 @@
       }
     },
     "auth0-lock": {
-      "version": "11.27.0",
-      "resolved": "https://registry.npmjs.org/auth0-lock/-/auth0-lock-11.27.0.tgz",
-      "integrity": "sha512-vUsjbGZ719hE/XPro5xCW0nDEBO71NtnHccgvJx/U3b34LKDttB1dkmC9NoHBPKMECoBEtHUFNKsTub7YSZBgQ==",
+      "version": "11.27.1",
+      "resolved": "https://registry.npmjs.org/auth0-lock/-/auth0-lock-11.27.1.tgz",
+      "integrity": "sha512-qUa6f+rQJgTI3vCw8jDQA6m91TXiTYCQM9FLINyMRFKYvcJ/gIE1E5jMEll84miaAkXVWU8X+1vC7UHiRx8epA==",
       "requires": {
         "auth0-js": "^9.13.3",
         "auth0-password-policies": "^1.0.2",
@@ -5561,9 +5561,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.774.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.774.0.tgz",
-      "integrity": "sha512-3a/fM1E3nCPwT4AVbysOWCMmsu/TOdJDD3urjywWE/qO1JShxRwLSdRLD1xRkacR9JcnydfkmdU0qk+VsM3nqg==",
+      "version": "2.780.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.780.0.tgz",
+      "integrity": "sha512-pz/3dJdrkqgJn2YPwu6/VaGBSvYm33wjb6Ic7zSuFPOduqo42Se70BQASNmUg1E8EBqSwsrYEW04f5XGOJ0mMA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "4dn-microscopy-metadata-tool": "github:WU-BIMAC/4DNMicroscopyMetadataToolReact#0.0.0.19b3",
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.79",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.0.2.80b1",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",
     "detect-browser": "^3.0.1",

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -550,7 +550,7 @@ def metadata_tsv(context, request):
             ['###',   '',         ''],
             ['###',   'Files Selected for Download:', '', '',            str(summary['counts']['Files Selected for Download'] or 'All'), ''],
             ['###',   'Total File Rows:', '', '',            str(summary['counts']['Total Files']), ''],
-            ['###',   'Unique Downloadable Files:', '', '', str(summary['counts']['Total Unique Files to Download']), ''],
+            ['###',   'Unique Downloadable Files:', '', '', str(summary['counts']['Total Unique Files to Download']), '']
         ]
         
         def gen_mini_table(file_tuples):

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -552,7 +552,7 @@ def metadata_tsv(context, request):
             ['###',   'Total File Rows:', '', '',            str(summary['counts']['Total Files']), ''],
             ['###',   'Unique Downloadable Files:', '', '', str(summary['counts']['Total Unique Files to Download']), '']
         ]
-        
+
         def gen_mini_table(file_tuples):
             for idx, file_tuple in enumerate(file_tuples[0:5]):
                 ret_rows.append(['###', '    - Details:' if idx == 0 else '', file_tuple[1]['File Accession'] + '.' + file_tuple[1]['File Format'], file_tuple[0] ])
@@ -569,7 +569,7 @@ def metadata_tsv(context, request):
             ret_rows.append(['###', '- Commented out {} file{} which are currently not available (i.e. file restricted, or not yet finished uploading):'.format(str(len(summary['lists']['Not Available'])), 's' if len(summary['lists']['Not Available']) > 1 else ''), '', '', '', ''])
             gen_mini_table(summary['lists']['Not Available'])
 
-        # if not request._auth0_authenticated:
+        # add unauthenticated download is not permitted warning
         ret_rows.append(['###', '', '', '', '', '', ''])
         ret_rows.append(['###', 'IMPORTANT: As of December 1, 2020, you must include an access key in your cURL command for bulk downloads. You can configure the access key in your profile. If you don’t already have an account, you can log in with your Google or GitHub credentials.', '', '', '', ''])
 

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -550,9 +550,9 @@ def metadata_tsv(context, request):
             ['###',   '',         ''],
             ['###',   'Files Selected for Download:', '', '',            str(summary['counts']['Files Selected for Download'] or 'All'), ''],
             ['###',   'Total File Rows:', '', '',            str(summary['counts']['Total Files']), ''],
-            ['###',   'Unique Downloadable Files:', '', '', str(summary['counts']['Total Unique Files to Download']), '']
+            ['###',   'Unique Downloadable Files:', '', '', str(summary['counts']['Total Unique Files to Download']), ''],
         ]
-
+        
         def gen_mini_table(file_tuples):
             for idx, file_tuple in enumerate(file_tuples[0:5]):
                 ret_rows.append(['###', '    - Details:' if idx == 0 else '', file_tuple[1]['File Accession'] + '.' + file_tuple[1]['File Format'], file_tuple[0] ])
@@ -568,6 +568,10 @@ def metadata_tsv(context, request):
         if len(summary['lists']['Not Available']) > 0:
             ret_rows.append(['###', '- Commented out {} file{} which are currently not available (i.e. file restricted, or not yet finished uploading):'.format(str(len(summary['lists']['Not Available'])), 's' if len(summary['lists']['Not Available']) > 1 else ''), '', '', '', ''])
             gen_mini_table(summary['lists']['Not Available'])
+
+        # if not request._auth0_authenticated:
+        ret_rows.append(['###', '', '', '', '', '', ''])
+        ret_rows.append(['###', 'IMPORTANT: As of December 1, 2020, you must include an access key in your cURL command for bulk downloads. You can configure the access key in your profile. If you don’t already have an account, you can log in with your Google or GitHub credentials.', '', '', '', ''])
 
         return ret_rows
 

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -426,7 +426,7 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
     }
 
     const aboveTableControlsProps = { // Some more generic props get passed in by SPC > ControlsAndResults.js
-        href, toggleFullScreen, isFullscreen,
+        href, session, toggleFullScreen, isFullscreen,
         selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount
     };
 

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -75,7 +75,7 @@ function FileTableWithSelectedFilesCheckboxes(props){
 
 
     const aboveTableControlsProps = { // Some more generic props get passed in by SPC > ControlsAndResults.js
-        href, toggleFullScreen, isFullscreen,
+        href, session, toggleFullScreen, isFullscreen,
         selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount
     };
 

--- a/src/encoded/static/components/browse/components/above-table-controls/AboveBrowseViewTableControls.js
+++ b/src/encoded/static/components/browse/components/above-table-controls/AboveBrowseViewTableControls.js
@@ -91,7 +91,7 @@ export class AboveBrowseViewTableControls extends React.PureComponent {
         if (selectedFiles){
             wrappedLeftSectionControls = (
                 <ChartDataController.Provider id="selected_files_section">
-                    <SelectedFilesControls {..._.extend(_.pick(this.props, 'href', 'includeFileSets', 'context'), SelectedFilesController.pick(this.props))}
+                    <SelectedFilesControls {..._.extend(_.pick(this.props, 'href', 'includeFileSets', 'context', 'session'), SelectedFilesController.pick(this.props))}
                         subSelectedFiles={filteredSelectedFiles} onFilterFilesByClick={this.handleOpenFileTypeFiltersPanel}
                         currentFileTypeFilters={fileTypeFilters} setFileTypeFilters={this.setFileTypeFilters} />
                 </ChartDataController.Provider>
@@ -99,7 +99,7 @@ export class AboveBrowseViewTableControls extends React.PureComponent {
         }
 
         const aboveTableControlsProps = {
-            ..._.pick(this.props, 'isFullscreen', 'windowWidth', 'toggleFullScreen'),
+            ..._.pick(this.props, 'isFullscreen', 'windowWidth', 'toggleFullScreen', 'session'),
             "panelMap" : {
                 "filterFilesBy" : {
                     "title" : (

--- a/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesControls.js
+++ b/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesControls.js
@@ -270,7 +270,7 @@ const SelectedFilesFilterByButton = React.memo(function SelectedFilesFilterByBut
 
 export const SelectedFilesControls = React.memo(function SelectedFilesControls(props){
     const {
-        href, context,
+        href, context, session,
         selectedFiles, subSelectedFiles,
         currentFileTypeFilters,
         setFileTypeFilters,
@@ -298,7 +298,7 @@ export const SelectedFilesControls = React.memo(function SelectedFilesControls(p
             <SelectAllFilesButton {...selectedFileProps} {...{ href, context }} totalFilesCount={totalUniqueFilesCount} />
             <div className="pull-left box selection-buttons">
                 <div className="btn-group">
-                    <BrowseViewSelectedFilesDownloadButton {...{ selectedFiles, subSelectedFiles, context }} totalFilesCount={totalUniqueFilesCount} />
+                    <BrowseViewSelectedFilesDownloadButton {...{ selectedFiles, subSelectedFiles, context, session }} totalFilesCount={totalUniqueFilesCount} />
                     <SelectedFilesFilterByButton totalFilesCount={totalUniqueFilesCount} onFilterFilesByClick={props.panelToggleFxns.filterFilesBy}
                         active={currentOpenPanel === "filterFilesBy"} // <- must be boolean
                         {...selectedFileProps} {...{ currentFileTypeFilters, setFileTypeFilters, currentOpenPanel }} />

--- a/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
+++ b/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
@@ -22,7 +22,7 @@ const { Item } = typedefs;
  * This may likely change in future.
  */
 export const BrowseViewSelectedFilesDownloadButton = React.memo(function BrowseViewSelectedFilesDownloadButton(props){
-    const { selectedFiles, subSelectedFiles, context } = props;
+    const { selectedFiles, subSelectedFiles, context, session } = props;
 
     const [ selectedFilesUniqueCount, selectedFilesCountIncludingDuplicates ] = useMemo(function(){
         return [ uniqueFileCount(selectedFiles), fileCountWithDuplicates(selectedFiles) ];
@@ -55,7 +55,7 @@ export const BrowseViewSelectedFilesDownloadButton = React.memo(function BrowseV
     const cls = "btn-primary"; //disabled ? 'btn-outline-primary' : 'btn-primary';
 
     return (
-        <SelectedFilesDownloadButton {...{ context, disabled }} selectedFiles={subSelectedFiles || selectedFiles} filenamePrefix="metadata_"
+        <SelectedFilesDownloadButton {...{ context, session, disabled }} selectedFiles={subSelectedFiles || selectedFiles} filenamePrefix="metadata_"
             id="browse-view-download-files-btn" data-tip={tooltip} className={cls}>
             <i className="icon icon-download fas icon-fw mr-07"/>
             <span className="d-none d-lg-inline">Download </span>
@@ -111,7 +111,7 @@ export class SelectedFilesDownloadButton extends React.PureComponent {
     render(){
         const {
             selectedFiles, filenamePrefix, children, disabled,
-            windowWidth, context, analyticsAddFilesToCart, action,
+            windowWidth, context, analyticsAddFilesToCart, action, session,
             ...btnProps
         } = this.props;
         const { modalOpen } = this.state;
@@ -128,7 +128,7 @@ export class SelectedFilesDownloadButton extends React.PureComponent {
                     { children }
                 </button>
                 { modalOpen ?
-                    <SelectedFilesDownloadModal {...{ selectedFiles, filenamePrefix, context, fileCountUnique, fileCountWithDupes, analyticsAddFilesToCart, action }}
+                    <SelectedFilesDownloadModal {...{ selectedFiles, filenamePrefix, context, fileCountUnique, fileCountWithDupes, analyticsAddFilesToCart, action, session }}
                         onHide={this.hideModal}/>
                     : null }
             </React.Fragment>
@@ -184,7 +184,7 @@ class SelectedFilesDownloadModal extends React.PureComponent {
     }
 
     render(){
-        const { onHide, filenamePrefix, selectedFiles, fileCountUnique, fileCountWithDupes, context } = this.props;
+        const { onHide, filenamePrefix, selectedFiles, fileCountUnique, fileCountWithDupes, context, session } = this.props;
         let { action } = this.props;
         const { disclaimerAccepted } = this.state;
 
@@ -207,7 +207,7 @@ class SelectedFilesDownloadModal extends React.PureComponent {
                 </Modal.Header>
 
                 <Modal.Body>
-
+                    {!session ? <p className="text-danger"><strong className="text-dark">IMPORTANT: </strong>You must be logged in for bulk downloads as of December 1, 2020. If you do not have an account, you can create a new one.</p> : null }
                     <p>Please press the &quot;Download&quot; button below to save the metadata TSV file which contains download URLs and other information for the selected files.</p>
                     <p>Once you have saved the metadata TSV, you may download the files on any machine or server with the following cURL command:</p>
                     <ModalCodeSnippet filename={suggestedFilename} isSignedIn={isSignedIn} />

--- a/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
+++ b/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
@@ -207,22 +207,33 @@ class SelectedFilesDownloadModal extends React.PureComponent {
                 </Modal.Header>
 
                 <Modal.Body>
-                    {!session ? <p className="text-danger"><strong className="text-dark">IMPORTANT: </strong>You must be logged in for bulk downloads as of December 1, 2020. If you do not have an account, you can create a new one.</p> : null }
+                    <div className="important-notes-section">
+                        <h4 className="mb-07 text-500">Important</h4>
+                        <ul className="mb-25">
+                            <li className="mb-05">
+                                <span className="text-danger"><b>As of December 1, 2020</b>, you must include an <b>access key</b> in your cURL command for bulk downloads.</span>
+                            </li>
+                            <li className="mb-05">You can configure the access key in {isSignedIn ? <a href={profileHref} target="_blank" rel="noopener noreferrer">your profile</a> : 'your profile'}, then use it in place of <em>{'<access_key_id>:<access_key_secret>'}</em>, below.</li>
+                            {!isSignedIn ?
+                                <li>If you don’t already have an account, you can log in with your Google or GitHub credentials.</li>
+                                : null}
+                        </ul>
+                    </div>
                     <p>Please press the &quot;Download&quot; button below to save the metadata TSV file which contains download URLs and other information for the selected files.</p>
                     <p>Once you have saved the metadata TSV, you may download the files on any machine or server with the following cURL command:</p>
-                    <ModalCodeSnippet filename={suggestedFilename} isSignedIn={isSignedIn} />
+                    <ModalCodeSnippet filename={suggestedFilename} isSignedIn />
 
                     { isSignedIn || foundUnpublishedFiles ?
                         <div className="extra-notes-section">
                             <h4 className="mt-2 mb-07 text-500">Notes</h4>
                             <ul className="mb-25">
-                                { isSignedIn ?
+                                {/* { isSignedIn ?
                                     <li className="mb-05">
                                         To download files which are not yet released, please include an <b>access key</b> in your cURL command which you can configure in <a href={profileHref} target="_blank" rel="noopener noreferrer">your profile</a>.
                                         <br/>
                                         Use this access key in place of <em>{'<access_key_id>:<access_key_secret>'}</em>, above.
                                     </li>
-                                    : null }
+                                    : null } */}
                                 {/* <li className="mb-05">
                                 {isSignedIn ? 'If you do not provide an access key, files' : 'Files'} which do not have a status of &quot;released&quot; cannot be downloaded via cURL and must be downloaded directly through the website.
                                 </li> */}

--- a/src/encoded/static/components/item-pages/FileView.js
+++ b/src/encoded/static/components/item-pages/FileView.js
@@ -85,7 +85,7 @@ export default class FileView extends WorkflowRunTracingView {
         return (
             <React.Fragment>
                 { super.itemMidSection() }
-                <FileOverviewHeading {..._.pick(this.props, 'context', 'schemas', 'windowWidth')} />
+                <FileOverviewHeading {..._.pick(this.props, 'context', 'schemas', 'windowWidth', 'session')} />
             </React.Fragment>
         );
     }
@@ -175,7 +175,7 @@ export class FileOverviewHeading extends React.PureComponent {
     }
 
     render(){
-        const { context, schemas, windowWidth } = this.props;
+        const { context, schemas, windowWidth, session } = this.props;
         const { mounted, isPropertiesOpen } = this.state;
         const gridState = layout.responsiveGridState(windowWidth);
         const isSmallerSize = mounted && (gridState === "xs" || gridState === "sm");
@@ -192,7 +192,7 @@ export class FileOverviewHeading extends React.PureComponent {
                     </OverviewHeadingContainer>
                 </div>
                 <div className="col-12 col-md-4 mt-1 mb-3">
-                    <FileViewDownloadButtonContainer file={context} size="lg" verticallyCentered={!isSmallerSize && isPropertiesOpen} />
+                    <FileViewDownloadButtonContainer file={context} size="lg" verticallyCentered={!isSmallerSize && isPropertiesOpen} session={session} />
                 </div>
 
             </div>
@@ -202,11 +202,11 @@ export class FileOverviewHeading extends React.PureComponent {
 
 
 export function FileViewDownloadButtonContainer(props){
-    const { className, size, file, context, result } = props;
+    const { className, size, file, context, result, session } = props;
     const fileToUse = file || context || result;
     return (
         <div className={"file-download-container" + (className ? " " + className : "")}>
-            <fileUtil.FileDownloadButtonAuto result={fileToUse} size={size} />
+            <fileUtil.FileDownloadButtonAuto result={fileToUse} size={size} session={session} />
         </div>
     );
 }

--- a/src/encoded/static/components/util/file.js
+++ b/src/encoded/static/components/util/file.js
@@ -66,13 +66,15 @@ export function extendFile(file, experiment, experimentSet){
 
 /** Uses different defaultProps.canDownloadStatuses, specific to project */
 export function FileDownloadButtonAuto(props){
-    const { result, context = null } = props;
+    const { result, context = null, session = false } = props;
     const onClick = useMemo(function(){
         return function(evt){
             return downloadFileButtonClick(result, context);
         };
     }, [result, context]);
-    return <FileDownloadButtonAutoOriginal {...props} onClick={onClick} />;
+    const disabled = !session;
+    const tooltip = disabled ? 'Log in or create an account to download this file' : null;
+    return <FileDownloadButtonAutoOriginal {...props} onClick={onClick} disabled={disabled} tooltip={tooltip} />;
 }
 FileDownloadButtonAuto.defaultProps = {
     'canDownloadStatuses' : [


### PR DESCRIPTION
Pls handle this PR w/ https://github.com/4dn-dcic/shared-portal-components/pull/47

**From Trello:** 

- For individual download, disable the download button and show a tooltip asking users to log in or create an account.
- For bulk download, make a very prominent warning that they need to create an account. Also update metadata.tsv to include the same information.
- The text for bulk download should say they'll be disabled December 1, 2020.

### Unauthenticated Bulk Download Popup
<img width="1257" alt="Screen Shot 2020-10-28 at 11 00 42" src="https://user-images.githubusercontent.com/49978017/97411119-e78ed200-1910-11eb-822b-4e8fe1ecfd56.png">

### Authenticated Bulk Download Popup
<img width="1257" alt="Screen Shot 2020-10-28 at 11 00 20" src="https://user-images.githubusercontent.com/49978017/97411134-eeb5e000-1910-11eb-9c07-653c933eb3e0.png">

### Metadata.tsv File Footer
<img width="1673" alt="Screen Shot 2020-10-28 at 11 04 03" src="https://user-images.githubusercontent.com/49978017/97411171-f83f4800-1910-11eb-9c9e-c5dc8dd21293.png">

### Download Button Disabled
<img width="1150" alt="Screen_Shot_2020-10-22_at_15 08 10" src="https://user-images.githubusercontent.com/49978017/97411518-6edc4580-1911-11eb-9897-6bcfbe7d7116.png">

### Login - Logout
![Login_-_Logout](https://user-images.githubusercontent.com/49978017/97412081-1eb1b300-1912-11eb-943d-1fa0a70cb34b.gif)


