### PR TITLE
Bug: Missing OPF Description in ExpSet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.3.0"
+version = "2.3.1"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -928,7 +928,7 @@ class SupplementaryFilesTabView extends React.PureComponent {
         }, []);
 
         _.forEach(allCollectionsFromExperiments, function(collection){
-            const { title, files } = collection;
+            const { title, files, description } = collection;
             if (collectionsByTitle[title]){ // Same title exists already from ExpSet.other_processed_files or another Experiment.other_processed_files.
                 // Add in files unless is already present (== duplicate).
                 _.forEach(files, function(f){
@@ -942,6 +942,8 @@ class SupplementaryFilesTabView extends React.PureComponent {
                         collectionsByTitle[title].files.push(f);
                     }
                 });
+                //clone description from exp's OPF if expset's OPF collection's missing
+                collectionsByTitle[title].description = collectionsByTitle[title].description || description;
             } else {
                 collectionsByTitle[title] = collection;
             }


### PR DESCRIPTION
**From Trello:** (https://trello.com/c/LHaSNu9D)

When an opf collection belongs to an **Experiment** (e.g. [4DNEXSUMVBKJ](https://data.4dnucleome.org/experiments-hi-c/4DNEXSUMVBKJ/#details)), it is shown in the **ExperimentSet**, under the Supplementary Files tab ([4DNESRJ8KV4Q](https://data.4dnucleome.org/experiment-set-replicates/4DNESRJ8KV4Q/#supplementary-files)). However, the description is missing. For comparison, this is how it looks like when an opf collection belongs to an **ExperimentSet**: [4DNESYTUBW2E](https://data.4dnucleome.org/experiment-set-replicates/4DNESYTUBW2E/#supplementary-files)

**Minor fix:** Exp's OPF's description is cloned if ExpSet's OPF collection's description is missing.

**Old:**
<img width="1168" alt="Screen Shot 2020-10-30 at 00 33 31" src="https://user-images.githubusercontent.com/49978017/97635018-ba910b00-1a47-11eb-8016-5c9194e311fe.png">

**Updated:**
<img width="1168" alt="Screen Shot 2020-10-30 at 00 33 40" src="https://user-images.githubusercontent.com/49978017/97635139-ec09d680-1a47-11eb-83f3-16d976980dbe.png">

