### PR TITLE
File Download Column for Protocols Search Table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.3.1"
+version = "2.3.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/protocol.json
+++ b/src/encoded/schemas/protocol.json
@@ -112,6 +112,9 @@
         },
         "tags": {
             "title": "Certification"
+        },
+        "attachment": {
+            "title": "File"
         }
     }
 }

--- a/src/encoded/static/components/browse/columnExtensionMap.js
+++ b/src/encoded/static/components/browse/columnExtensionMap.js
@@ -117,6 +117,19 @@ export const columnExtensionMap = _.extend({}, basicColumnExtensionMap, {
             return <span className="value text-center">{ valToShow }</span>;
         }
     },
+    'attachment' : {
+        'widthMap' : { 'lg' : 120, 'md' : 120, 'sm' : 120 },
+        'render': function(result, props){
+            const { attachment = null } = result;
+            if (!attachment) return null;
+            const { href: attachHref = '' } = attachment;
+            return (
+                <a href={object.itemUtil.atId(result) + attachHref} className="btn btn-xs btn-primary" data-tip="Download attached file" disabled={attachHref.length === 0}>
+                    <i className="icon icon-fw icon-file-pdf far" />
+                </a>
+            );
+        }
+    },
     'workflow.title' : {
         'title' : "Workflow",
         'render' : function(result, props){


### PR DESCRIPTION
**Trello Ticket:** https://trello.com/c/9qULcpwx

**Solution:**
The new "attachment" column with "File" as title added to `Protocols` schema and custom rendering is added to `columnExtensionMap` to render the pdf icon download link.

<img width="1168" alt="Screen Shot 2020-11-06 at 00 56 39" src="https://user-images.githubusercontent.com/49978017/98300875-f89fa900-1fca-11eb-9b51-8134a77ae0c2.png">
