### PR TITLE
Adjust WSGI Conf

### DIFF
--- a/.ebextensions/05_set_wsgi.config
+++ b/.ebextensions/05_set_wsgi.config
@@ -97,7 +97,7 @@ files:
       ### START originally in /etc/httpd/wsgi.conf.d/extra_config.conf
       Header always set Access-Control-Allow-Origin "*"
       Header always set Access-Control-Allow-Methods "GET, HEAD, OPTIONS"
-      Header always set Access-Control-Allow-Headers "Accept, Origin, Range, X-Requested-With"
+      Header always set Access-Control-Allow-Headers "Accept, Authorization, Origin, Range, X-Requested-With"
       Header always set Access-Control-Expose-Headers: "Content-Length, Content-Range, Content-Type"
       RewriteCond %{REQUEST_METHOD} OPTIONS
       RewriteRule ^ - [redirect=200,last]
@@ -135,7 +135,7 @@ files:
       # - "queue-timeout" should not occur since Apache servers match total WSGI threads. Set to value of Apache Timeout
       # - maybe use "restart-interval" than "maximum-requests", but handle long requests
 
-      WSGIDaemonProcess wsgi processes=5 threads=4 display-name='%{GROUP}' python-path=/opt/python/current/app:/opt/python/run/venv/lib64/python3.6/site-packages:/opt/python/run/venv/lib/python3.6/site-packages user=wsgi group=wsgi home=/opt/python/current/app graceful-timeout=30 deadlock-timeout=60 queue-timeout=62 maximum-requests=1000
+      WSGIDaemonProcess wsgi processes=6 threads=4 display-name='%{GROUP}' python-path=/opt/python/current/app:/opt/python/run/venv/lib64/python3.6/site-packages:/opt/python/run/venv/lib/python3.6/site-packages user=wsgi group=wsgi home=/opt/python/current/app graceful-timeout=30 deadlock-timeout=60 queue-timeout=62 maximum-requests=1000
       WSGIProcessGroup wsgi
       </VirtualHost>
       '''


### PR DESCRIPTION
- Up # of application wsgi processes by 1
- Allow Authorization header for Ajax requests with access keys
- NOTE: it is NOT safe to use BasicAuth this way without HTTPS - make sure Ajax requests that use access keys are disabled in non-production environments.