### PR TITLE
added external_submission

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.3.3"
+version = "2.3.4"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.3.2"
+version = "2.3.4"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -22,6 +22,7 @@
         { "$ref": "mixins.json#/tags" },
         { "$ref": "mixins.json#/badges" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/static_embeds" }
     ],

--- a/src/encoded/schemas/experiment_atacseq.json
+++ b/src/encoded/schemas/experiment_atacseq.json
@@ -19,6 +19,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/sop_mapping"},
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/tags" },

--- a/src/encoded/schemas/experiment_capture_c.json
+++ b/src/encoded/schemas/experiment_capture_c.json
@@ -19,6 +19,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/library"},
         { "$ref": "mixins.json#/sop_mapping"},

--- a/src/encoded/schemas/experiment_chiapet.json
+++ b/src/encoded/schemas/experiment_chiapet.json
@@ -19,6 +19,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/library"},
         { "$ref": "mixins.json#/sop_mapping"},

--- a/src/encoded/schemas/experiment_damid.json
+++ b/src/encoded/schemas/experiment_damid.json
@@ -19,6 +19,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/sop_mapping"},
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/tags" },

--- a/src/encoded/schemas/experiment_hi_c.json
+++ b/src/encoded/schemas/experiment_hi_c.json
@@ -19,6 +19,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/library"},
         { "$ref": "mixins.json#/sop_mapping"},

--- a/src/encoded/schemas/experiment_repliseq.json
+++ b/src/encoded/schemas/experiment_repliseq.json
@@ -19,6 +19,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/library"},
         { "$ref": "mixins.json#/sop_mapping"},

--- a/src/encoded/schemas/experiment_seq.json
+++ b/src/encoded/schemas/experiment_seq.json
@@ -19,6 +19,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/references" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/documents" },
         { "$ref": "mixins.json#/library"},
         { "$ref": "mixins.json#/sop_mapping"},

--- a/src/encoded/schemas/experiment_set_replicate.json
+++ b/src/encoded/schemas/experiment_set_replicate.json
@@ -15,6 +15,7 @@
         { "$ref": "mixins.json#/attribution" },
         { "$ref": "mixins.json#/status" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/modified" },
         { "$ref": "mixins.json#/release_dates" },

--- a/src/encoded/schemas/file_fastq.json
+++ b/src/encoded/schemas/file_fastq.json
@@ -18,6 +18,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/accession" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/tags" },
         { "$ref": "mixins.json#/badges" },
         { "$ref": "mixins.json#/static_embeds" },

--- a/src/encoded/schemas/file_processed.json
+++ b/src/encoded/schemas/file_processed.json
@@ -18,6 +18,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/accession" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/tags" },
         { "$ref": "mixins.json#/static_embeds" },
         { "$ref": "mixins.json#/higlass_defaults" },

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -342,6 +342,35 @@
             }
         }
     },
+    "external_submission": {
+        "external_submission": {
+            "title": "External Submission",
+            "description": "The external resource where 4DN has deposited this item.",
+            "internal_comment": "Only admins are allowed to set or update these values.",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "object",
+            "lookup": 1000,
+            "additionalProperties": false,
+            "required": ["date_exported", "database"],
+            "properties": {
+                "date_exported": {
+                    "title": "Date Exported",
+                    "description": "The date when this item was exported for the most recent submission/update.",
+                    "type": "string",
+                    "anyOf": [
+                        {"format": "date-time"},
+                        {"format": "date"}
+                    ]
+                },
+                "database": {
+                    "title": "Database",
+                    "description": "The name of the external resource.",
+                    "type": "string",
+                    "enum": ["GEO"]
+                }
+        }
+    },
     "library": {
         "library_prep_kit": {
             "title": "Library Prep Kit",

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -369,6 +369,7 @@
                     "type": "string",
                     "enum": ["GEO"]
                 }
+            }
         }
     },
     "library": {

--- a/src/encoded/tests/data/workbook-inserts/experiment_hi_c.json
+++ b/src/encoded/tests/data/workbook-inserts/experiment_hi_c.json
@@ -21,6 +21,7 @@
         "crosslinking_temperature": 37,
         "award": "1U01CA200059-02",
         "dbxrefs": ["SRA:SRX764985", "GEO:GSM1551599"],
+        "external_submission": {"date_exported": "2020-11-23", "database": "GEO"},
         "crosslinking_method": "1% Formaldehyde",
         "uuid": "75041e2f-3e43-4388-8bbb-e861f209c444",
         "protocol": "131106bc-8535-4448-903e-854af460b244",


### PR DESCRIPTION
Created an `external_submission` mixin property and added that to ExpSet, Exp and Biosample.
When an item is submitted by 4DN DCIC to an external resource, the database name and date of export will be recorded here.