### PR TITLE
Fix warnings (C4-629, C4-631)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ clean-python:
 	pip freeze | xargs pip uninstall -y
 
 test:
-	make test-npm
 	make test-unit
+	make test-npm
 
 test-any:
 	bin/test -vv --timeout=200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.5.1"
+version = "2.5.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -1,20 +1,22 @@
-'''py.test fixtures for Pyramid.
+"""py.test fixtures for Pyramid.
 
 http://pyramid.readthedocs.org/en/latest/narr/testing.html
-'''
+"""
+
+import datetime as datetime_module
 import logging
+import os
+import pkg_resources
 import pytest
 import webtest
-import os
-import tempfile
-import subprocess
-import time
 
+from dcicutils.qa_utils import notice_pytest_fixtures
 from pyramid.request import apply_request_extensions
-from pyramid.testing import DummyRequest, setUp, tearDown
+from pyramid.testing import DummyRequest
 from pyramid.threadlocal import get_current_registry, manager as threadlocal_manager
 from snovault import DBSESSION, ROOT, UPGRADER
-from snovault.elasticsearch import ELASTIC_SEARCH
+from snovault.elasticsearch import ELASTIC_SEARCH, create_mapping
+from snovault.util import generate_indexer_namespace_for_testing
 from .. import main
 from .conftest_settings import make_app_settings_dictionary
 
@@ -60,36 +62,6 @@ def pytest_configure():
 
 
 @pytest.yield_fixture
-def config():
-    # From https://docs.pylonsproject.org/projects/pyramid/en/latest/api/testing.html#pyramid.testing.setUp
-    # setUp:
-    #   Set Pyramid registry and request thread locals for the duration of a single unit test.
-    #   Use this function in the setUp method of a unittest test case which directly or indirectly uses:
-    #     * any method of the pyramid.config.Configurator object returned by this function.
-    #     * the pyramid.threadlocal.get_current_registry() or pyramid.threadlocal.get_current_request() functions.
-    # tearDown:
-    #   Undo the effects of pyramid.testing.setUp(). Use this function in the tearDown method of a unit test
-    #   that uses pyramid.testing.setUp() in its setUp method.
-    #
-    # The recommended use with unittest can be found here:
-    # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/testing.html#test-set-up-and-tear-down
-    #   class MyTest(unittest.TestCase):
-    #     def setUp(self):
-    #       self.config = testing.setUp()
-    #     def tearDown(self):
-    #       testing.tearDown()
-    # This is the approximate equivalent in pyTest:
-
-    # TODO: Reonsider whether this setup/teardown is being done correctly
-    #  Then again, this fixture might not be used at all. I inserted this here and it didn't fail the tests:
-    #     raise Exception("fixture config used")
-    #  -kmp 28-Jun-2020
-    the_config = setUp()
-    yield the_config
-    tearDown()
-
-
-@pytest.yield_fixture
 def threadlocals(request, dummy_request, registry):
     threadlocal_manager.push({'request': dummy_request, 'registry': registry})
     yield dummy_request
@@ -127,8 +99,8 @@ def dummy_request(root, registry, app):
 
 @pytest.fixture(scope='session')
 def app(app_settings):
-    '''WSGI application level functional testing.
-    '''
+    """WSGI application level functional testing.
+    """
     return main({}, **app_settings)
 
 

--- a/src/encoded/tests/test_types_biosample.py
+++ b/src/encoded/tests/test_types_biosample.py
@@ -39,7 +39,6 @@ def biosample_w_treatment(testapp, biosample_1, rnai):
     return testapp.patch_json(biosample_1['@id'], {'treatments': [rnai['@id']]}).json['@graph'][0]
 
 
-@pytest.fixture
 def biosample_relation(derived_from):
     return {"biosample_relation": [{"relationship_type": "derived from",
             "biosample": derived_from['@id']}]}


### PR DESCRIPTION
This makes these changes:

* Fixes [C4-629](https://hms-dbmi.atlassian.net/browse/C4-629), rewriting `raise StopIteration` to simple `return` statements.
* Muffles [C4-630](https://hms-dbmi.atlassian.net/browse/C4-630) for now since we know about the problem. I assigned follow-up on this to @alexkb0009. Basically, I _think_ we should be using pyramid's static route capability. But meanwhile we don't need to be beaten up about this with warnings that make it harder to see other warnings we might care about.
* Fixes [C4-631](https://hms-dbmi.atlassian.net/browse/C4-631), removing an unwanted `pytest.fixture` declaration.

Incidental other changes:

* Removes the unused `config` fixture from `src/encoded/tests/conftest.py`. This was removed already in `cgap-portal` and should cause us no problems.
* Changes the order in which local machines run tests so that `unit` testing comes first (the long list of about a thousand non-`workbook` tests) and then `npm` tests second (the short list, about a hundred more tests related to `workbook`).