### PR TITLE
Kmp c4 627 update renderers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,16 @@ deploy2:  # spins up waittress to serve the application
 	pserve development.ini
 
 psql-dev:  # starts psql with the url after 'sqlalchemy.url =' in development.ini
-	@psql `grep 'sqlalchemy[.]url =' development.ini | sed -E 's/^.* = (.*)/\1/'`
+	@scripts/psql-start dev
 
-kibana-start:
+psql-test:  # starts psql with a url constructed from data in 'ps aux'.
+	@scripts/psql-start test
+
+kibana-start:  # starts a dev version of kibana (default port)
 	scripts/kibana-start
+
+kibana-start-test:  # starts a test version of kibana (port chosen for active tests)
+	scripts/kibana-start test
 
 kibana-stop:
 	scripts/kibana-stop
@@ -114,18 +120,26 @@ clean-python:
 	pip freeze | xargs pip uninstall -y
 
 test:
-	make test-unit
 	make test-npm
+	make test-unit
+
+retest:
+	bin/test  -vv --last-failed
 
 test-any:
 	bin/test -vv --timeout=200
-
 
 test-npm:
 	bin/test -vv --timeout=200 -m "working and not manual and not integratedx and not performance and not broken and not sloppy and workbook"
 
 test-unit:
 	bin/test -vv --timeout=200 -m "working and not manual and not integratedx and not performance and not broken and not sloppy and not workbook"
+
+test-performance:
+	bin/test -vv --timeout=200 -m "working and not manual and not integratedx and performance and not broken and not sloppy"
+
+test-integrated:
+	bin/test -vv --timeout=200 -m "working and not manual and (integrated or integratedx) and not performance and not broken and not sloppy"
 
 travis-test:  # Actually, we don't normally use this. Instead the GA workflow sets up two parallel tests.
 	make travis-test-npm
@@ -154,11 +168,14 @@ info:
 	   $(info - Use 'make configure' to install poetry. You should not have to do this directly.)
 	   $(info - Use 'make deploy1' to spin up postgres/elasticsearch and load inserts.)
 	   $(info - Use 'make deploy2' to spin up the application server.)
-	   $(info - Use 'make kibana-start' to start kibana, and 'make kibana-stop' to stop it.)
+	   $(info - Use 'make kibana-start' to start kibana on the default local ES port, and 'make kibana-stop' to stop it.)
+	   $(info - Use 'make kibana-start-test' to start kibana on the port being used for active testing, and 'make kibana-stop' to stop it.)
 	   $(info - Use 'make kill' to kill postgres and elasticsearch proccesses. Please use with care.)
 	   $(info - Use 'make moto-setup' to install moto, for less flaky tests. Implied by 'make build'.)
 	   $(info - Use 'make npm-setup' to build the front-end. Implied by 'make build'.)
 	   $(info - Use 'make psql-dev' to start psql on data associated with an active 'make deploy1'.)
+	   $(info - Use 'make psql-test' to start psql on data associated with an active test.)
+	   $(info - Use 'make retest' to run failing tests from the previous test run.)
 	   $(info - Use 'make test' to run tests with normal options similar to what we use on GitHub Actions.)
 	   $(info - Use 'make test-any' to run tests without marker constraints (i.e., with no '-m' option).)
 	   $(info - Use 'make update' to update dependencies (and the lock file).)

--- a/scripts/kibana-start
+++ b/scripts/kibana-start
@@ -1,5 +1,60 @@
 #!/bin/bash
 
+docker_kibana_image=docker.elastic.co/kibana/kibana-oss:6.8.9
+docker_kibana_port=5601
+local_kibana_port=${docker_kibana_port}
+default_es_port=9200
+local_es_port=${default_es_port}
+
+if [ "$1" = "test" ]; then
+
+    # This deletes all the output that doesn't match our pattern and includes only what does.
+    # Ref: https://stackoverflow.com/questions/6011661/regexp-sed-suppress-no-match-output
+    port=`ps aux | sed -E '/.*elasticsearch.*-Ehttp[.]port=([0-9]+)[^0-9].*/!d;s//\1/'`
+
+    if [ -z "${port}" ]; then
+        echo "Cannot find test port."
+        exit 1
+    elif [ `echo "${port}" | wc -l` -gt 1 ]; then
+        echo "Found multiple test ports:"
+        echo "${port}"
+        exit 1
+    fi
+
+    if [[ "${port}" =~ ^[0-9]+$ ]]; then
+        local_es_port="${port}"
+        echo "Using local_es_port=${local_es_port}."
+    else
+        echo "Port format is wrong: ${port}"
+        exit 1
+    fi
+
+elif [[ "$1" =~ ^[0-9]+$ ]]; then
+
+    local_es_port=$1
+    echo "Using local_es_port=${local_es_port}."
+
+elif [ $# -gt 0 -a "$1" != "dev" ]; then
+
+    echo "Syntax: $0 [ <es-port> | test | dev ]"
+    echo " Starts kibana. By default, or if 'dev' is given, uses the standard port ${default_es_port}."
+    echo " If es-port is an integer, that port is used."
+    echo " If es-port is the word 'test', a test port is found using 'ps aux'."
+    echo " Note that this will choose its own http port, which will be 5601 for es-port=9200,"
+    echo " or else a generated port number 10000+(<es-port> % 55536) otherwise."
+    exit 1
+
+fi
+
+if [ "${local_es_port}" != "${default_es_port}" ]; then
+    # 0-1023 are reserved ports
+    # 1024-65535 are available for custom use, but usualy 1024-9999 are assigned manually
+    # we'll generate a port in the range 10000-65535. that might sometimes collide, but probably VERY rarely.
+    local_kibana_port=$(( $local_es_port % 55536 + 10000 ))
+fi
+
+echo "Using local_kibana_port=${local_kibana_port}"
+
 docker --version
 
 if [ $? -ne 0 ]; then
@@ -11,25 +66,38 @@ fi
 existing_network=`docker network ls | grep localnet`
 
 if [ -z "${existing_network}" ]; then
+    echo "creating localnet --driver=bridge"
     docker network create localnet --driver=bridge
 else
     echo "docker localnet is already set up. From 'docker network':"
-    echo " ${existing_network}"
+    # echo " ${existing_network}"
 fi
 
-existing_kibana=`docker ps | egrep 'kibana:[0-9]*.[0-9]+.*[ ].*'`
+# This pattern is structured so that if we need to extract the container id (e.g., to kill it), it will be in \1.
+# But I figured out a way not to have to kill the old one, so that part of the pattern isn't used any more.
+# I retained the first group just for possible future use. At this point, this just detects whether we have a
+# handler for $local_kibana_port at all. This pattern also anticipates kibana images named 'kibana' or 'kibana-oss'.
+# I other image names come up, for example if aws creates its own naming convention, it will need adjusting.
+# -kmp 31-Jan-2021
+kibana_docker_pattern="([0-9a-f]+) .*kibana(-oss)?:[0-9]+[.][0-9]+[.].*0[.]0[.]0[.]0[:]${local_kibana_port}-[>]"
+
+existing_kibana=`docker ps | egrep "${kibana_docker_pattern}"`
 
 if [ -z "${existing_kibana}" ]; then
 
-    docker run -d --network localnet -p 5601:5601 -e ELASTICSEARCH_URL=http://host.docker.internal:9200 kibana:5.6.16
+    echo "Kibana is not already running for ES port ${local_es_port}"
+    docker_es_url="http://host.docker.internal:${local_es_port}"
+    docker run -d --network localnet -p ${local_kibana_port}:${docker_kibana_port} -e ELASTICSEARCH_URL=${docker_es_url} ${docker_kibana_image}
+
+    echo "Waiting for kibana to start..."
+    sleep 5
 
 else
-    echo "Kibana is already running. From 'docker ps':"
+    echo "Kibana is already listening on port ${local_kibana_port} for elasticsearch on port ${local_es_port}:"
     echo " ${existing_kibana}"
 fi
 
-local_kibana_url="http://localhost:5601/app/kibana#/dev_tools/console?_g=()"
+local_kibana_url="http://localhost:${local_kibana_port}/app/kibana#/dev_tools/console?_g=()"
 
 echo "Opening kibana in browser at '${local_kibana_url}'..."
 open "${local_kibana_url}" &
-

--- a/scripts/psql-start
+++ b/scripts/psql-start
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+port=$1
+
+dev_url_line=`grep 'sqlalchemy[.]url =' development.ini`
+
+dev_url=`echo "${dev_url_line}" | sed -E 's/^.* = (.*)$/\1/'`
+dev_port=`echo "${dev_url_line}" | sed -E 's|^.* = .*:([0-9]+)/postgres[?].*$|\1|'`
+
+
+# echo "dev_url=${dev_url}"
+# echo "dev_port=${dev_port}"
+
+
+# There seem be two processes, one for postgres and one for postgres-engine.
+# The relevant data can be obtained from either, but matching both 
+# the match for postgres[^-] excludes the matches on postgres-engine so we
+# can assume the match is unique.
+
+if [ "$port" = 'test' ]; then
+
+    test_process=`ps aux | grep '.*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-]'`
+
+    if [ -z "${test_process}" ]; then
+
+        echo "No test process found."
+	exit 1
+
+    else
+
+        test_url=`echo "$test_process" | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+        psql "${test_url}"
+
+        # psql `ps aux | grep '.*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-]' | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+
+    fi
+
+elif [ "$port" = 'dev' -o "$port" = "$dev_port" ]; then
+
+    dev_url=`grep 'sqlalchemy[.]url =' development.ini | sed -E 's/^.* = (.*)/\1/'`
+    psql "${dev_url}"
+
+elif [[ "${port}" =~ ^[0-9]+$ ]]; then
+
+    port_process=`ps aux | grep ".*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-].*-p[ ]+${port}.*"`
+
+    if [ -z "${port_process}" ]; then
+
+        echo "No postgres process found on port ${port}."
+	exit 1
+
+    else
+
+        port_url=`echo "$test_process" | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+        psql "${port_url}"
+
+        # psql `ps aux | grep '.*[p]ostgres -D.*/private[a-zA-Z0-9_/-]*/postgresql[^-]' | sed -E 's|^.*postgres[ ]+-D[ ]+([/a-zA-Z0-9_-]+)[ ]+.*-p[ ]+([0-9]+)([^0-9].*)?$|postgresql://postgres@localhost:\2/postgres?host=\1|'`
+
+    fi
+
+else
+
+    echo "Syntax: $0 [ <port> | test | dev ]"
+    echo ""
+    echo "Starts psql for debugging in a way that corresponds to the given port."
+    echo "The port can be an integer or one of the special tokens 'dev' or 'test'."
+    echo "If 'dev' is given, the port from development.ini (currently '${dev_port}') is used."
+    echo "If 'test' is given, the port will be found from data in 'ps aux'."
+
+fi

--- a/src/encoded/renderers.py
+++ b/src/encoded/renderers.py
@@ -4,35 +4,33 @@ import os
 import psutil
 import time
 
-from pkg_resources import resource_filename
-from urllib.parse import urlencode, urlparse
+from dcicutils.misc_utils import environ_bool, PRINT, ignored
 from functools import lru_cache
+from pkg_resources import resource_filename
 from pyramid.events import BeforeRender, subscriber
 from pyramid.httpexceptions import (
     HTTPMovedPermanently,
     HTTPPreconditionFailed,
     HTTPUnauthorized,
-    # HTTPForbidden,
     HTTPUnsupportedMediaType,
     HTTPNotAcceptable,
     HTTPServerError
 )
-# from pyramid.security import forget
+from pyramid.response import Response
 from pyramid.settings import asbool
 from pyramid.threadlocal import manager
-from pyramid.response import Response
 from pyramid.traversal import split_path_info, _join_path_tuple
-# from snovault.validation import CSRFTokenError
-# from subprocess_middleware.tween import SubprocessTween
 from subprocess_middleware.worker import TransformWorker
+from urllib.parse import urlencode, urlparse
 from webob.cookies import Cookie
+from .util import content_type_allowed
 
 
 log = logging.getLogger(__name__)
 
 
 def includeme(config):
-    '''
+    """
     Can get tween ordering by executing the following on command-line from root dir:
         `bin/ptween development.ini`
 
@@ -67,13 +65,15 @@ def includeme(config):
     This means that if handler(request) is called, then the downstream tweens are acted upon it,
     until response is returned. It's an ONION!
 
-    '''
+    """
 
     config.add_tween('.renderers.validate_request_tween_factory', under='snovault.stats.stats_tween_factory')
-    # DISABLED - .add_tween('.renderers.remove_expired_session_cookies_tween_factory', under='.renderers.validate_request_tween_factory')
+    # DISABLED - .add_tween('.renderers.remove_expired_session_cookies_tween_factory',
+    #                       under='.renderers.validate_request_tween_factory')
     config.add_tween('.renderers.render_page_html_tween_factory', under='.renderers.validate_request_tween_factory')
 
-    # The above tweens, when using response (= `handler(request)`) act on the _transformed_ response (containing HTML body).
+    # The above tweens, when using response (= `handler(request)`) act on the _transformed_ response
+    # (containing HTML body).
     # The below tweens run _before_ the JS rendering. Responses in these tweens have not been transformed to HTML yet.
     config.add_tween('.renderers.set_response_headers_tween_factory', under='.renderers.render_page_html_tween_factory')
 
@@ -93,6 +93,7 @@ def validate_request_tween_factory(handler, registry):
     Apache config:
         SetEnvIf Request_Method HEAD X_REQUEST_METHOD=HEAD
     """
+    ignored(registry)
 
     def validate_request_tween(request):
 
@@ -107,19 +108,18 @@ def validate_request_tween_factory(handler, registry):
             # Includes page text/html requests.
             return handler(request)
 
-        elif request.content_type != 'application/json':
-            if request.content_type == 'application/x-www-form-urlencoded' and request.path[0:10] == '/metadata/':
-                # Special case to allow us to POST to metadata TSV requests via form submission
-                return handler(request)
+        elif content_type_allowed(request):
+            return handler(request)
+
+        else:
             detail = "Request content type %s is not 'application/json'" % request.content_type
             raise HTTPUnsupportedMediaType(detail)
-
-        return handler(request)
 
     return validate_request_tween
 
 
 def security_tween_factory(handler, registry):
+    ignored(registry)
 
     def security_tween(request):
         """
@@ -132,7 +132,7 @@ def security_tween_factory(handler, registry):
         """
 
         expected_user = request.headers.get('X-If-Match-User')
-        if expected_user is not None: # Not sure when this is the case
+        if expected_user is not None:  # Not sure when this is the case
             if request.authenticated_userid != 'mailto.' + expected_user:
                 detail = 'X-If-Match-User does not match'
                 raise HTTPPreconditionFailed(detail)
@@ -147,15 +147,18 @@ def security_tween_factory(handler, registry):
                     raise HTTPUnauthorized(
                         title="No Access",
                         comment="Invalid Authorization header or Auth Challenge response.",
-                        headers={'WWW-Authenticate': "Bearer realm=\"{}\"; Basic realm=\"{}\"".format(request.domain, request.domain) }
+                        headers={
+                            'WWW-Authenticate': ("Bearer realm=\"{}\"; Basic realm=\"{}\""
+                                                 .format(request.domain, request.domain))
+                        }
                     )
-
 
         if hasattr(request, 'auth0_expired'):
             # Add some security-related headers on the up-swing
             response = handler(request)
             if request.auth0_expired:
-                #return response
+                # return response
+                #
                 # If have the attribute and it is true, then our session has expired.
                 # This is true for both AJAX requests (which have request.authorization) & browser page
                 # requests (which have cookie); both cases handled in authentication.py
@@ -176,7 +179,10 @@ def security_tween_factory(handler, registry):
                     path='/'
                 )  # = Same as response.delete_cookie(..)
                 response.status_code = 401
-                response.headers['WWW-Authenticate'] = "Bearer realm=\"{}\", title=\"Session Expired\"; Basic realm=\"{}\"".format(request.domain, request.domain)
+                response.headers['WWW-Authenticate'] = (
+                    "Bearer realm=\"{}\", title=\"Session Expired\"; Basic realm=\"{}\""
+                    .format(request.domain, request.domain)
+                )
             else:
                 # We have JWT and it's not expired. Add 'X-Request-JWT' & 'X-User-Info' header.
                 # For performance, only do it if should transform to HTML as is not needed on every request.
@@ -188,9 +194,10 @@ def security_tween_factory(handler, registry):
                             # This header is parsed in renderer.js, or, more accurately,
                             # by libs/react-middleware.js which is imported by server.js and compiled into
                             # renderer.js. Is used to get access to User Info on initial web page render.
-                            response.headers['X-Request-JWT'] = request.cookies.get('jwtToken','')
-                            user_info = request.user_info.copy() # Re-ified property set in authentication.py
-                            del user_info["id_token"] # Redundant - don't need this in SSR nor browser as get from X-Request-JWT.
+                            response.headers['X-Request-JWT'] = request.cookies.get('jwtToken', '')
+                            user_info = request.user_info.copy()  # Re-ified property set in authentication.py
+                            # Redundant - don't need this in SSR nor browser as get from X-Request-JWT.
+                            del user_info["id_token"]
                             response.headers['X-User-Info'] = json.dumps(user_info)
                         else:
                             response.headers['X-Request-JWT'] = "null"
@@ -203,20 +210,22 @@ def security_tween_factory(handler, registry):
         # requests from Authorization header which acts like a CSRF token.
         # See authentication.py - get_jwt()
 
-        #token = request.headers.get('X-CSRF-Token')
-        #if token is not None:
-        #    # Avoid dirtying the session and adding a Set-Cookie header
-        #    # XXX Should consider if this is a good idea or not and timeouts
-        #    if token == dict.get(request.session, '_csrft_', None):
-        #        return handler(request)
-        #    raise CSRFTokenError('Incorrect CSRF token')
+        # Alex notes that we do not use request.session so this is probably very old. -kmp 4-Mar-2021
+
+        # token = request.headers.get('X-CSRF-Token')
+        # if token is not None:
+        #     # Avoid dirtying the session and adding a Set-Cookie header
+        #     # XXX Should consider if this is a good idea or not and timeouts
+        #     if token == dict.get(request.session, '_csrft_', None):
+        #         return handler(request)
+        #     raise CSRFTokenError('Incorrect CSRF token')
         # raise CSRFTokenError('Missing CSRF token')
 
     return security_tween
 
 
 def remove_expired_session_cookies_tween_factory(handler, registry):
-    '''
+    """
     CURRENTLY DISABLED
     Original purpose of this was to remove expired (session?) cookies.
     See: https://github.com/ENCODE-DCC/encoded/commit/75854803c99e5044a6a33aedb3a79d750481b6cd#diff-bc19a9793a1b3b4870cff50e7c7c9bd1R135
@@ -224,7 +233,8 @@ def remove_expired_session_cookies_tween_factory(handler, registry):
     We disable it for now via removing from tween chain as are using JWT tokens and handling
     their removal in security_tween_factory & authentication.py as well as client-side
     (upon "Logout" action). If needed for some reason, can re-enable.
-    '''
+    """  # noQA - not going to break the long URL line above
+    ignored(registry)
 
     ignore = {
         '/favicon.ico',
@@ -235,8 +245,8 @@ def remove_expired_session_cookies_tween_factory(handler, registry):
             return handler(request)
 
         session = request.session
-        #if session or session._cookie_name not in request.cookies:
-        #    return handler(request)
+        # if session or session._cookie_name not in request.cookies:
+        #     return handler(request)
 
         response = handler(request)
         # Below seems to be empty always; though we do have some in request.cookies
@@ -260,7 +270,9 @@ def remove_expired_session_cookies_tween_factory(handler, registry):
 
 
 def set_response_headers_tween_factory(handler, registry):
-    '''Add additional response headers here'''
+    """Add additional response headers here"""
+    ignored(registry)
+
     def set_response_headers_tween(request):
         response = handler(request)
         response.headers['X-Request-URL'] = request.url
@@ -316,21 +328,93 @@ def canonical_redirect(event):
     raise HTTPMovedPermanently(location=location, detail="Redirected from " + str(request.path_info))
 
 
+# Web browsers send an Accept request header for initial (e.g. non-AJAX) page requests
+# which should contain 'text/html'
+MIME_TYPE_HTML = 'text/html'
+MIME_TYPE_JSON = 'application/json'
+MIME_TYPE_LD_JSON = 'application/ld+json'
+
+MIME_TYPES_SUPPORTED = [MIME_TYPE_JSON, MIME_TYPE_HTML, MIME_TYPE_LD_JSON]
+MIME_TYPE_DEFAULT = MIME_TYPES_SUPPORTED[0]
+MIME_TYPE_TRIAGE_MODE = 'modern'  # if this doesn't work, fall back to 'legacy'
+
+DEBUG_MIME_TYPES = environ_bool("DEBUG_MIME_TYPES", default=False)
+
+
+def best_mime_type(request, mode=MIME_TYPE_TRIAGE_MODE):
+    # TODO: I think this function does nothing but return MIME_TYPES_SUPPORTED[0] -kmp 3-Feb-2021
+    """
+    Given a request, tries to figure out the best kind of MIME type to use in response
+    based on what kinds of responses we support and what was requested.
+
+    In the case we can't comply, we just use application/json whether or not that's what was asked for.
+    """
+    if mode == 'legacy':
+        # See:
+        # https://tedboy.github.io/flask/generated/generated/werkzeug.Accept.best_match.html#werkzeug-accept-best-match
+        # Note that this is now deprecated, or will be. The message is oddly worded ("will be deprecated")
+        # that presumably means "will be removed". Deprecation IS the warning of actual action, not the action itself.
+        # "This is currently maintained for backward compatibility, and will be deprecated in the future.
+        #  AcceptValidHeader.best_match() uses its own algorithm (one not specified in RFC 7231) to determine
+        #  what is a best match. The algorithm has many issues, and does not conform to RFC 7231."
+        # Anyway, we were getting this warning during testing:
+        #   DeprecationWarning: The behavior of AcceptValidHeader.best_match is currently
+        #      being maintained for backward compatibility, but it will be deprecated in the future,
+        #      as it does not conform to the RFC.
+        # TODO: Once the modern replacement is shown to work, we should remove this conditional branch.
+        result = request.accept.best_match(MIME_TYPES_SUPPORTED, MIME_TYPE_DEFAULT)
+    else:
+        options = request.accept.acceptable_offers(MIME_TYPES_SUPPORTED)
+        if not options:
+            # TODO: Probably we should return a 406 response by raising HTTPNotAcceptable if
+            #       no acceptable types are available. (Certainly returning JSON in this case is
+            #       not some kind of friendly help toa naive user with an old browser.)
+            #       Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+            result = MIME_TYPE_DEFAULT
+        else:
+            mime_type, score = options[0]
+            result = mime_type
+    if DEBUG_MIME_TYPES:
+        PRINT("Using mime type", result, "for", request.method, request.url)
+        for k, v in request.headers.items():
+            PRINT("%s: %s" % (k, v))
+        PRINT("----------")
+    return result
+
+
 @lru_cache(maxsize=16)
 def should_transform(request, response):
-    '''
+    """
     Determines whether to transform the response from JSON->HTML/JS depending on type of response
-    and what the request is looking for to be returned via e.g. request Accept, Authorization header.
-    In case of no Accept header, attempts to guess.
+    and what the request is looking for to be returned via these criteria, which are tried in order
+    until one succeeds:
 
-    Memoized via `lru_cache`. Cache size is set to be 16 (> 1) in case sub-requests fired off during handling.
-    '''
+    * If the request method is other than GET or HEAD, returns False.
+    * If the response.content_type is other than 'application/json', returns False.
+    * If a 'frame=' query param is given and not 'page' (the default), returns False.
+    * If a 'format=json' query param is given explicitly,
+        * For 'format=html', returns True.
+        * For 'format=json', returns False.
+      This rule does not match if 'format=' is not given explicitly.
+      If 'format=' is given an explicit value of ther than 'html' or 'json', an HTTPNotAcceptable error will be raised.
+    * If the first element of MIME_TYPES_SUPPORTED[0] is 'text/html', returns True.
+    * Otherwise, in all remaining cases, returns False.
+
+    NOTE: Memoized via `lru_cache`. Cache size is set to be 16 (> 1) in case sub-requests fired off during handling.
+    """
     # We always return JSON in response to POST, PATCH, etc.
     if request.method not in ('GET', 'HEAD'):
         return False
 
     # Only JSON response/content can be plugged into HTML/JS template responses.
     if response.content_type != 'application/json':
+        return False
+
+    # This is weirdly redundant with the next clause starting at 'format =' below. -kmp 11-Mar-2021
+    # If we have a 'frame' that is not None or page, force JSON, since our UI doesn't handle all various
+    # forms of the data, just embedded/page.
+    request_frame = request.params.get("frame", "page")
+    if request_frame != "page":
         return False
 
     # The `format` URI param allows us to override request's 'Accept' header.
@@ -342,16 +426,18 @@ def should_transform(request, response):
         if format == 'html':
             return True
         else:
-            raise HTTPNotAcceptable("Improper format URI parameter", comment="The format URI parameter should be set to either html or json.")
+            raise HTTPNotAcceptable("Improper format URI parameter",
+                                    comment="The format URI parameter should be set to either html or json.")
 
     # Web browsers send an Accept request header for initial (e.g. non-AJAX) page requests
     # which should contain 'text/html'
     # See: https://tedboy.github.io/flask/generated/generated/werkzeug.Accept.best_match.html#werkzeug-accept-best-match
-    mime_type = request.accept.best_match(['text/html',  'application/json', 'application/ld+json'], 'application/json')
-    format = mime_type.split('/', 1)[1] # Will be 1 of 'html', 'json', 'json-ld'
+    mime_type = best_mime_type(request)
+    format = mime_type.split('/', 1)[1]  # Will be 1 of 'html', 'json', 'json-ld'
 
-    # N.B. ld+json (JSON-LD) is likely more unique case and might be sent by search engines (?) which can parse JSON-LDs.
-    # At some point we could maybe have it to be same as making an `@@object` or `?frame=object` request (?) esp if fill
+    # N.B. ld+json (JSON-LD) is likely more unique case and might be sent by search engines (?)
+    # which can parse JSON-LDs. At some point we could maybe have it to be same as
+    # making an `@@object` or `?frame=object` request (?) esp if fill
     # out @context response w/ schema(s) (or link to schema)
 
     if format == 'html':
@@ -378,7 +464,9 @@ def render_page_html_tween_factory(handler, registry):
 
     rss_limit = 256 * (1024 ** 2)  # MB
 
-    reload_process = True if registry.settings.get('reload_templates', False) else lambda proc: psutil.Process(proc.pid).memory_info().rss > rss_limit
+    reload_process = (True
+                      if registry.settings.get('reload_templates', False)
+                      else lambda proc: psutil.Process(proc.pid).memory_info().rss > rss_limit)
 
     # TransformWorker inits and manages a subprocess
     # it re-uses the subprocess so interestingly data in JS global variables

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -18,28 +18,53 @@ from snovault import DBSESSION, ROOT, UPGRADER
 from snovault.elasticsearch import ELASTIC_SEARCH, create_mapping
 from snovault.util import generate_indexer_namespace_for_testing
 from .. import main
+from ..loadxl import load_all
 from .conftest_settings import make_app_settings_dictionary
 
 
-# Done in pytest.ini now.
-#
-# pytest_plugins = [
-#     'encoded.tests.datafixtures',
-#     'snovault.tests.serverfixtures',
-# ]
+"""
+README:
+    * This file contains application level fixtures and hooks in the server/data fixtures present in
+      other files. 
+    * There are "app" based fixtures that rely only on postgres, and
+      "es_app" fixtures that use both postgres and ES (for search/ES related testing)
+"""
 
 
 @pytest.fixture(autouse=True)
 def autouse_external_tx(external_tx):
+    notice_pytest_fixtures(external_tx)
     pass
 
 
 @pytest.fixture(scope='session')
-def app_settings(request, wsgi_server_host_port, conn, DBSession):
+def app_settings(request, wsgi_server_host_port, conn, DBSession):  # noQA - We didn't choose the fixture name.
+    notice_pytest_fixtures(request, wsgi_server_host_port, conn, DBSession)
     settings = make_app_settings_dictionary()
     settings['auth0.audiences'] = 'http://%s:%s' % wsgi_server_host_port
     # add some here for file testing
     settings[DBSESSION] = DBSession
+    return settings
+
+
+INDEXER_NAMESPACE_FOR_TESTING = generate_indexer_namespace_for_testing('ff')
+
+
+@pytest.fixture(scope='session')
+def es_app_settings(wsgi_server_host_port, elasticsearch_server, postgresql_server, aws_auth):
+    settings = make_app_settings_dictionary()
+    settings['create_tables'] = True
+    settings['persona.audiences'] = 'http://%s:%s' % wsgi_server_host_port  # 2-tuple such as: ('localhost', '5000')
+    settings['elasticsearch.server'] = elasticsearch_server
+    settings['sqlalchemy.url'] = postgresql_server
+    settings['collection_datastore'] = 'elasticsearch'
+    settings['item_datastore'] = 'elasticsearch'
+    settings['indexer'] = True
+    settings['indexer.namespace'] = INDEXER_NAMESPACE_FOR_TESTING
+
+    # use aws auth to access elasticsearch
+    if aws_auth:
+        settings['elasticsearch.aws_auth'] = aws_auth
     return settings
 
 
@@ -63,6 +88,7 @@ def pytest_configure():
 
 @pytest.yield_fixture
 def threadlocals(request, dummy_request, registry):
+    notice_pytest_fixtures(request, dummy_request, registry)
     threadlocal_manager.push({'request': dummy_request, 'registry': registry})
     yield dummy_request
     threadlocal_manager.pop()
@@ -99,9 +125,20 @@ def dummy_request(root, registry, app):
 
 @pytest.fixture(scope='session')
 def app(app_settings):
-    """WSGI application level functional testing.
-    """
+    """ WSGI application level functional testing. """
     return main({}, **app_settings)
+
+
+@pytest.fixture(scope='session')
+def es_app(es_app_settings, **kwargs):
+    """
+    App that uses both Postgres and ES - pass this as "app" argument to TestApp.
+    Pass all kwargs onto create_mapping
+    """
+    app = main({}, **es_app_settings)
+    create_mapping.run(app, **kwargs)
+
+    return app
 
 
 @pytest.fixture
@@ -124,27 +161,69 @@ def root(registry):
     return registry[ROOT]
 
 
+# Available Fixtures
+# ------------------
+#
+#  ################## +-----------------------------------------+----------------------------------------------------+
+#  ################## |               Basic Application         |      Application with ES + Postgres                |
+#  ################## +-----------------------+-----------------+---------------------------+------------------------+
+#  ################## |   JSON content        |  HTML content   |      JSON content         |      HTML content      |
+#  -------------------+-----------------------+-----------------+---------------------------+------------------------+
+#  Anonymous User     | anontestapp           | anonhtmltestapp |  anon_es_testapp          | anon_html_es_testapp   |
+#  -------------------+-----------------------+-----------------+---------------------------+------------------------+
+#  System User        | testapp               | htmltestapp     |  es_testapp               | html_es_testapp        |
+#  -------------------+-----------------------+-----------------+---------------------------+------------------------+
+#  Authenticated User | authenticated_testapp | -----           |  authenticated_es_testapp | -----                  |
+#  -------------------+-----------------------+-----------------+---------------------------+------------------------+
+#  Submitter User     | submitter_testapp     | -----           |  -----                    | -----                  |
+#  -------------------+-----------------------+-----------------+---------------------------+------------------------+
+#  Indexer User       | -----                 | -----           |  indexer_testapp          | -----                  |
+#  -------------------+-----------------------+-----------------+---------------------------+------------------------+
+#  Embed User         | embed_testapp         | -----           |  -----                    | -----                  |
+#  -------------------+-----------------------+-----------------+---------------------------+------------------------+
+#
 # TODO: Reconsider naming to have some underscores interspersed for better readability.
 #       e.g., html_testapp rather than htmltestapp, and especially anon_html_test_app rather than anonhtmltestapp.
 #       -kmp 03-Feb-2020
 
 @pytest.fixture
-def anonhtmltestapp(app):
-    return webtest.TestApp(app)
-
-
-@pytest.fixture
-def htmltestapp(app):
-    """TestApp for TEST user and no HTTP_ACCEPT limitation, so HTML content can be tested."""
-    # TODO: Name may be misleading. If only for HTML testing, seems like it should be text/html.
-    #       Or if it spans CSS and other things, maybe call it page_content_testapp? -kmp 03-Feb-2020
+def anontestapp(app):
+    """TestApp for anonymous user (i.e., no user specified), accepting JSON data."""
     environ = {
-        'REMOTE_USER': 'TEST',
+        'HTTP_ACCEPT': 'application/json',
     }
     return webtest.TestApp(app, environ)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
+def anonhtmltestapp(app):
+    """TestApp for anonymous (not logged in) user, accepting text/html content."""
+    environ = {
+        'HTTP_ACCEPT': 'text/html'
+    }
+    test_app = webtest.TestApp(app, environ)
+    return test_app
+
+
+@pytest.fixture
+def anon_es_testapp(es_app):
+    """ TestApp simulating a bare Request entering the application (with ES enabled) """
+    environ = {
+        'HTTP_ACCEPT': 'application/json',
+    }
+    return webtest.TestApp(es_app, environ)
+
+
+@pytest.fixture
+def anon_html_es_testapp(es_app):
+    """TestApp with ES + Postgres for anonymous (not logged in) user, accepting text/html content."""
+    environ = {
+        'HTTP_ACCEPT': 'text/html'
+    }
+    return webtest.TestApp(es_app, environ)
+
+
+@pytest.fixture(scope="session")
 def testapp(app):
     """TestApp for username TEST, accepting JSON data."""
     environ = {
@@ -155,12 +234,34 @@ def testapp(app):
 
 
 @pytest.fixture
-def anontestapp(app):
-    """TestApp for anonymous user (i.e., no user specified), accepting JSON data."""
+def htmltestapp(app):
+    """TestApp for TEST user, accepting text/html content."""
+    environ = {
+        'HTTP_ACCEPT': 'text/html',
+        'REMOTE_USER': 'TEST',
+    }
+    test_app = webtest.TestApp(app, environ)
+    return test_app
+
+
+@pytest.fixture(scope='session')
+def es_testapp(es_app):
+    """ TestApp with ES + Postgres. Must be imported where it is needed. """
     environ = {
         'HTTP_ACCEPT': 'application/json',
+        'REMOTE_USER': 'TEST',
     }
-    return webtest.TestApp(app, environ)
+    return webtest.TestApp(es_app, environ)
+
+
+@pytest.fixture
+def html_es_testapp(es_app):
+    """TestApp with ES + Postgres for TEST user, accepting text/html content."""
+    environ = {
+        'HTTP_ACCEPT': 'text/html',
+        'REMOTE_USER': 'TEST',
+    }
+    return webtest.TestApp(es_app, environ)
 
 
 @pytest.fixture
@@ -174,6 +275,16 @@ def authenticated_testapp(app):
 
 
 @pytest.fixture
+def authenticated_es_testapp(es_app):
+    """ TestApp for authenticated non-admin user with ES """
+    environ = {
+        'HTTP_ACCEPT': 'application/json',
+        'REMOTE_USER': 'TEST_AUTHENTICATED',
+    }
+    return webtest.TestApp(es_app, environ)
+
+
+@pytest.fixture
 def submitter_testapp(app):
     """TestApp for a non-admin user (TEST_SUBMITTER), accepting JSON data."""
     environ = {
@@ -184,13 +295,14 @@ def submitter_testapp(app):
 
 
 @pytest.fixture
-def indexer_testapp(app):
-    """TestApp for indexing (user INDEXER), accepting JSON data."""
+def indexer_testapp(es_app):
+    """ Indexer testapp, meant for manually triggering indexing runs by posting to /index.
+        Always uses the ES app (obviously, but not so obvious previously) """
     environ = {
         'HTTP_ACCEPT': 'application/json',
         'REMOTE_USER': 'INDEXER',
     }
-    return webtest.TestApp(app, environ)
+    return webtest.TestApp(es_app, environ)
 
 
 @pytest.fixture
@@ -209,3 +321,38 @@ def wsgi_app(wsgi_server):
     return webtest.TestApp(wsgi_server)
 
 
+class WorkbookCache:
+    """ Caches whether or not we have already provisioned the workbook. """
+    done = None
+
+    @classmethod
+    def initialize_if_needed(cls, es_app):
+        if not cls.done:
+            cls.done = cls.make_fresh_workbook(es_app)
+
+    @classmethod
+    def make_fresh_workbook(cls, es_app):
+        environ = {
+            'HTTP_ACCEPT': 'application/json',
+            'REMOTE_USER': 'TEST',
+        }
+        testapp = webtest.TestApp(es_app, environ)
+
+        # Just load the workbook inserts
+        # Note that load_all returns None for success or an Exception on failure.
+        load_res = load_all(testapp, pkg_resources.resource_filename('encoded', 'tests/data/workbook-inserts/'), [])
+
+        if isinstance(load_res, Exception):
+            raise load_res
+        elif load_res:
+            raise RuntimeError("load_all returned a true value that was not an exception.")
+
+        testapp.post_json('/index', {})
+        return True
+
+
+@pytest.fixture(scope='session')
+def workbook(es_app):
+    """ Loads a bunch of data (tests/data/workbook-inserts) into the system on first run
+        (session scope doesn't work). """
+    WorkbookCache.initialize_if_needed(es_app)

--- a/src/encoded/tests/conftest_settings.py
+++ b/src/encoded/tests/conftest_settings.py
@@ -37,3 +37,32 @@ _app_settings = {
 
 def make_app_settings_dictionary():
     return _app_settings.copy()
+
+
+ORDER = [
+    'user', 'award', 'lab', 'static_section', 'higlass_view_config', 'page',
+    'ontology', 'ontology_term', 'file_format', 'badge', 'organism', 'gene',
+    'genomic_region', 'bio_feature', 'target', 'imaging_path', 'publication',
+    'publication_tracking', 'document', 'image', 'vendor', 'construct',
+    'modification', 'experiment_type', 'protocol', 'sop_map', 'biosample_cell_culture',
+    'individual_human', 'individual_mouse', 'individual_fly', 'individual_primate',
+    'individual_chicken', 'individual_zebrafish', 'biosource', 'antibody', 'enzyme',
+    'treatment_rnai', 'treatment_agent',
+    'biosample', 'quality_metric_fastqc', 'quality_metric_bamcheck', 'quality_metric_rnaseq',
+    'quality_metric_bamqc', 'quality_metric_pairsqc', 'quality_metric_margi',
+    'quality_metric_dedupqc_repliseq', 'quality_metric_chipseq', 'quality_metric_workflowrun',
+    'quality_metric_atacseq', 'quality_metric_rnaseq_madqc',  'quality_metric_qclist',
+    'microscope_setting_d1', 'microscope_setting_d2',
+    'microscope_setting_a1', 'microscope_setting_a2', 'file_fastq',
+    'file_processed', 'file_reference', 'file_calibration', 'file_microscopy',
+    'file_set', 'file_set_calibration', 'file_set_microscope_qc',
+    'file_vistrack', 'experiment_hi_c', 'experiment_capture_c',
+    'experiment_repliseq', 'experiment_atacseq', 'experiment_chiapet',
+    'experiment_damid', 'experiment_seq', 'experiment_tsaseq',
+    'experiment_mic', 'experiment_set', 'experiment_set_replicate',
+    'data_release_update', 'software', 'analysis_step', 'workflow',
+    'workflow_mapping', 'workflow_run_sbg', 'workflow_run_awsem',
+    'tracking_item', 'quality_metric_flag',
+    'summary_statistic', 'summary_statistic_hi_c', 'workflow_run',
+    'microscope_configuration'
+]

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -3,34 +3,10 @@ import pytest
 
 from uuid import uuid4
 
-
-ORDER = [
-    'user', 'award', 'lab', 'static_section', 'higlass_view_config', 'page',
-    'ontology', 'ontology_term', 'file_format', 'badge', 'organism', 'gene',
-    'genomic_region', 'bio_feature', 'target', 'imaging_path', 'publication',
-    'publication_tracking', 'document', 'image', 'vendor', 'construct',
-    'modification', 'experiment_type', 'protocol', 'sop_map', 'biosample_cell_culture',
-    'individual_human', 'individual_mouse', 'individual_fly', 'individual_primate',
-    'individual_chicken', 'individual_zebrafish', 'biosource', 'antibody', 'enzyme',
-    'treatment_rnai', 'treatment_agent',
-    'biosample', 'quality_metric_fastqc', 'quality_metric_bamcheck', 'quality_metric_rnaseq',
-    'quality_metric_bamqc', 'quality_metric_pairsqc', 'quality_metric_margi',
-    'quality_metric_dedupqc_repliseq', 'quality_metric_chipseq', 'quality_metric_workflowrun',
-    'quality_metric_atacseq', 'quality_metric_rnaseq_madqc',  'quality_metric_qclist',
-    'microscope_setting_d1', 'microscope_setting_d2',
-    'microscope_setting_a1', 'microscope_setting_a2', 'file_fastq',
-    'file_processed', 'file_reference', 'file_calibration', 'file_microscopy',
-    'file_set', 'file_set_calibration', 'file_set_microscope_qc',
-    'file_vistrack', 'experiment_hi_c', 'experiment_capture_c',
-    'experiment_repliseq', 'experiment_atacseq', 'experiment_chiapet',
-    'experiment_damid', 'experiment_seq', 'experiment_tsaseq',
-    'experiment_mic', 'experiment_set', 'experiment_set_replicate',
-    'data_release_update', 'software', 'analysis_step', 'workflow',
-    'workflow_mapping', 'workflow_run_sbg', 'workflow_run_awsem',
-    'tracking_item', 'quality_metric_flag',
-    'summary_statistic', 'summary_statistic_hi_c', 'workflow_run',
-    'microscope_configuration'
-]
+# If anyone else needs to import ORDER, it got moved, so get it from
+# its new nome in .conftest_settings. -kmp 14-Mar-2021
+#
+#   from .conftest_settings import ORDER
 
 
 @pytest.fixture

--- a/src/encoded/tests/test_create_mapping.py
+++ b/src/encoded/tests/test_create_mapping.py
@@ -5,7 +5,7 @@ from snovault import COLLECTIONS, TYPES
 from snovault.elasticsearch.create_mapping import type_mapping
 from snovault.util import add_default_embeds
 from unittest.mock import patch, MagicMock
-from .datafixtures import ORDER
+from .conftest_settings import ORDER
 from ..commands import create_mapping_on_deploy
 from ..commands.create_mapping_on_deploy import (
     ITEM_INDEX_ORDER,

--- a/src/encoded/tests/test_embedding.py
+++ b/src/encoded/tests/test_embedding.py
@@ -3,7 +3,7 @@ import pytest
 from snovault import TYPES
 from snovault.util import add_default_embeds, crawl_schemas_by_embeds
 from ..types.base import get_item_or_none
-from .datafixtures import ORDER
+from .conftest_settings import ORDER
 
 
 pytestmark = [pytest.mark.setone, pytest.mark.working]

--- a/src/encoded/tests/test_fixtures.py
+++ b/src/encoded/tests/test_fixtures.py
@@ -6,7 +6,8 @@ from unittest import mock
 from ..tests import datafixtures
 
 
-pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
+# in cgap these are marked broken -kmp 24-Feb-2021
+pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema, pytest.mark.indexing, pytest.mark.sloppy]
 
 
 @pytest.yield_fixture(scope='session')

--- a/src/encoded/tests/test_fixtures.py
+++ b/src/encoded/tests/test_fixtures.py
@@ -3,11 +3,11 @@ import webtest
 
 from unittest import mock
 
-from ..tests import datafixtures
+from ..tests import conftest_settings
 
 
 # in cgap these are marked broken -kmp 24-Feb-2021
-pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema, pytest.mark.indexing, pytest.mark.sloppy]
+pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema, pytest.mark.indexing]
 
 
 @pytest.yield_fixture(scope='session')
@@ -101,16 +101,22 @@ def test_fixtures2(minitestdata2, testapp):
 
 
 def test_order_complete(app, conn):
+    order_source_module = conftest_settings
     # TODO: This could use a doc string or comment. -kent & eric 29-Jun-2020
-    print("original datafixtures.ORDER =", datafixtures.ORDER)
-    print("original len(datafixtures.ORDER) =", len(datafixtures.ORDER))
-    assert "access_key" not in datafixtures.ORDER
-    order_for_testing = datafixtures.ORDER + ["access_key"]
-    with mock.patch.object(datafixtures, "ORDER", order_for_testing):
-        print("mocked datafixtures.ORDER =", datafixtures.ORDER)
-        print("len(mocked datafixtures.ORDER) =", len(datafixtures.ORDER))
-        assert "access_key" in datafixtures.ORDER
-        ORDER = datafixtures.ORDER
+    print("original order_source_module.ORDER =", order_source_module.ORDER)
+    print("original len(order_source_module.ORDER) =", len(order_source_module.ORDER))
+    assert "access_key" not in order_source_module.ORDER
+    print("confirmed: 'access_key' is NOT in ORDER")
+    order_for_testing = order_source_module.ORDER + ["access_key"]
+    assert order_source_module.ORDER is not order_for_testing
+    assert len(order_for_testing) == len(order_source_module.ORDER) + 1
+    with mock.patch.object(order_source_module, "ORDER", order_for_testing):
+        print("=" * 24, "binding ORDER to add 'access_key'", "=" * 24)
+        print("mocked order_source_module.ORDER =", order_source_module.ORDER)
+        print("len(mocked order_source_module.ORDER) =", len(order_source_module.ORDER))
+        assert "access_key" in order_source_module.ORDER
+        print("confirmed: 'access_key' IS in ORDER")
+        patched_order = order_source_module.ORDER
         environ = {
             'HTTP_ACCEPT': 'application/json',
             'REMOTE_USER': 'TEST',
@@ -118,22 +124,25 @@ def test_order_complete(app, conn):
         testapp = webtest.TestApp(app, environ)
         master_types = []
         profiles = testapp.get('/profiles/?frame=raw').json
+        print("constructing master_types from /profiles/?frame=raw")
         for a_type in profiles:
             if profiles[a_type].get('id') and profiles[a_type]['isAbstract'] is False:
                 schema_name = profiles[a_type]['id'].split('/')[-1][:-5]
                 master_types.append(schema_name)
-        print(ORDER)
-        print(master_types)
-        print(len(ORDER))
-        print(len(master_types))
+        print("patched_order=", patched_order)
+        print("master_types=", master_types)
+        print("len(patched_order)=", len(patched_order))
+        print("len(master_types)=", len(master_types))
 
-        missing_types = [i for i in master_types if i not in ORDER]
-        extra_types = [i for i in ORDER if i not in master_types]
-        print(missing_types)
-        print(extra_types)
+        missing_types = [i for i in master_types if i not in patched_order]
+        extra_types = [i for i in patched_order if i not in master_types]
+        print("missing_types=", missing_types)
+        print("extra_types=", extra_types)
 
         assert missing_types == []
         assert extra_types == []
-    print("restored datafixtures.ORDER =", datafixtures.ORDER)
-    print("restored len(datafixtures.ORDER) =", len(datafixtures.ORDER))
-    assert "access_key" not in datafixtures.ORDER
+        print("=" * 24, "exiting bound context for ORDER", "=" * 24)
+    print("restored order_source_module.ORDER =", order_source_module.ORDER)
+    print("restored len(order_source_module.ORDER) =", len(order_source_module.ORDER))
+    assert "access_key" not in order_source_module.ORDER
+    print("confirmed: 'access_key' is NOT in ORDER")

--- a/src/encoded/tests/test_renderers.py
+++ b/src/encoded/tests/test_renderers.py
@@ -1,0 +1,128 @@
+import pytest
+
+from dcicutils.misc_utils import filtered_warnings
+from dcicutils.qa_utils import MockResponse
+from unittest import mock
+from pyramid.testing import DummyRequest
+from .. import renderers
+from ..renderers import (
+    best_mime_type, should_transform, MIME_TYPES_SUPPORTED, MIME_TYPE_DEFAULT,
+    MIME_TYPE_JSON, MIME_TYPE_HTML, MIME_TYPE_LD_JSON,
+)
+
+
+pytestmark = [pytest.mark.setone, pytest.mark.working]
+
+
+DEFAULT_SHOULD_TRANSFORM = (MIME_TYPE_DEFAULT == MIME_TYPE_HTML)
+
+
+class DummyResponse(MockResponse):
+
+    def __init__(self, content_type=None, status_code: int = 200, json=None, content=None, url=None,
+                 params=None):
+        self.params = {} if params is None else params
+        self.content_type = content_type
+        super().__init__(status_code=status_code, json=json, content=content, url=url)
+
+
+def test_mime_variables():
+
+    # Really these don't need testing but it's useful visually to remind us of their values here.
+    assert MIME_TYPE_HTML == 'text/html'
+    assert MIME_TYPE_JSON == 'application/json'
+    assert MIME_TYPE_LD_JSON == 'application/ld+json'
+    assert MIME_TYPES_SUPPORTED == [MIME_TYPE_JSON, MIME_TYPE_HTML, MIME_TYPE_LD_JSON]
+    assert MIME_TYPE_DEFAULT == MIME_TYPE_JSON
+
+
+VARIOUS_MIME_TYPES_TO_TEST = ['*/*', 'text/html', 'application/json', 'application/ld+json', 'text/xml', 'who/cares']
+
+
+def test_best_mime_type(the_constant_answer=MIME_TYPE_DEFAULT):
+
+    with filtered_warnings("ignore", category=DeprecationWarning):
+        # Suppresses this warning:
+        #     DeprecationWarning: The behavior of .best_match for the Accept classes is currently being maintained
+        #       for backward compatibility, but the method will be deprecated in the future, as its behavior is not
+        #       specified in (and currently does not conform to) RFC 7231.
+
+        for requested_mime_type in VARIOUS_MIME_TYPES_TO_TEST:
+            req = DummyRequest(headers={'Accept': requested_mime_type})
+            assert best_mime_type(req, 'legacy') == the_constant_answer
+            assert best_mime_type(req, 'modern') == the_constant_answer
+            req = DummyRequest(headers={})  # The Accept header in the request just isn't being consulted
+            assert best_mime_type(req, 'modern') == the_constant_answer
+            assert best_mime_type(req, 'modern') == the_constant_answer
+
+
+def test_best_mime_type_traditional():
+
+    test_best_mime_type('application/json')
+
+
+TYPICAL_URLS = [
+    'http://whatever/foo',
+    'http://whatever/foo/',
+    'http://whatever/foo.json',
+    'http://whatever/foo.html',
+]
+
+ALLOWED_FRAMES_OR_NONE = ['raw', 'page', 'embedded', 'object', 'bad', None]
+
+SOME_HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']
+
+ALLOWED_FORMATS_OR_NONE = ['json', 'html', None]
+
+
+def test_should_transform():
+
+    for method in SOME_HTTP_METHODS:
+        for _format in ALLOWED_FORMATS_OR_NONE:
+            for requested_mime_type in VARIOUS_MIME_TYPES_TO_TEST:
+                for response_content_type in VARIOUS_MIME_TYPES_TO_TEST:
+                    for frame in [None] + ALLOWED_FRAMES_OR_NONE:
+                        for url in TYPICAL_URLS:
+
+                            params = {}
+                            if frame is not None:
+                                params['frame'] = frame
+                            if _format is not None:
+                                params['format'] = _format
+
+                            req = DummyRequest(headers={'Accept': requested_mime_type},
+                                               method=method,
+                                               url=url,
+                                               params=params)
+                            resp = DummyResponse(content_type=response_content_type, url=url)
+
+                            print("method=", method,
+                                  "format=", _format,
+                                  "params=", params,
+                                  "requested=", requested_mime_type,
+                                  "response_content_type=", response_content_type,
+                                  "frame=", frame,
+                                  )
+
+                            if req.method not in ('GET', 'HEAD'):
+                                assert not should_transform(req, resp)
+                            elif resp.content_type != 'application/json':
+                                # If the response MIME type is not application/json,
+                                # it just can't be transformed at all.
+                                assert not should_transform(req, resp)
+                            elif params.get("frame", "page") != 'page':
+                                assert not should_transform(req, resp)
+                            elif _format is not None:
+                                assert should_transform(req, resp) is (_format == 'html')
+                            else:
+                                assert should_transform(req, resp) is DEFAULT_SHOULD_TRANSFORM
+
+
+def test_should_transform_without_best_mime_type():
+
+    with mock.patch.object(renderers, "best_mime_type") as mock_best_mime_type:
+
+        # Demonstrate that best_mime_type(...) could be replaced by MIME_TYPES_SUPPORTED[0]
+        mock_best_mime_type.return_value = MIME_TYPES_SUPPORTED[0]
+
+        test_should_transform()

--- a/src/encoded/tests/test_views.py
+++ b/src/encoded/tests/test_views.py
@@ -8,7 +8,7 @@ from jsonschema_serialize_fork import Draft4Validator
 from pyramid.compat import ascii_native_
 from snovault import TYPES
 from urllib.parse import urlparse
-from .datafixtures import ORDER
+from .conftest_settings import ORDER
 
 
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]


### PR DESCRIPTION
This ports various things from cgap-portal. In some cases, who files couldn't come over, so it's worth checking this to make sure the right parts did, but it makes the tests work. Please read the caveats in this bullet list to understand what needs most attention:

* Port renderers support support and associated tests from `cgap-portal`. This means part of `src/encoded/renderers.py` got ported, so that bears some scrutiny. All of `src/encoded/tests/test_renderers.py` is brought over. Note that doing just this much actually breaks `fourfront` tests because there was a misalignment in defaulting of mime types similar to something that `cgap-portal` went (harmlessly) through.
  In particular, if no mime-types are specified, this will default to  `application/json` now, but this was never formerly tested and I"m not convinced the old default of HTML was a good one. All clients _should_ be offering an `Accept` header that will sort it out, and I think it's fair to say that modern browsers will send such a header.

  This is a small but important change. Whether it counts as a bug fix or a major version change is subjective. I'm inclined to think we should bump the major version just so if it results in issues it will be easy to spot. (Commit `[6fa56b5](https://github.com/4dn-dcic/fourfront/commit/6fa56b5ac8cbe52bc05b57b632ece059dae8e6e9)` is the relevant change.)

  Importantly, this will bring Fourfront and CGAP behavior back in line with one another.  But also, we will have a set of unit tests that cover this space and if we need to make further adjustments we'll have a baseline to understand what we're affecting.

* Much of `src/encoded/tests/conftest.py` is just rearranged into a better order and with some doc string added, but there is one change of substance made (in two places): the change that "fixes" the problem in renderers. That is, the "fix" is to the tests, to accept the new behavior of renderrs, not to the ported code, which makes the `testhtml` and `anonhtml` fixtures bind the `HTTP_ACCEPT` environment variable to `text/html` rather than leaving it unbound (and effectively leaving to chance). It seems _clear_ that these fixtures should expressly bind `HTTP_ACCEPT` to the content they want, and if anyone wants something different we could create fixtures `test_any` and `anon_any` or something like that to test those cases as well, but we have never previously distinguished those cases. Probably we should add some renderers tests of those at some point.

* Move ORDER definition from `src/encoded/tests/datafixtures.py` to `src/encoded/tests/conftest_settings.py` because it needs to be importable and one does not want to import the fixtures that are preloaded in `pytest.ini`. That seems to create some problem for PyTest.  Doing this change meant several test files had to change to import `ORDER` from `conftest_settings.py` instead.

* Changed test_indexing to use `es_app_settings` instead of `app_settings`. Because fo complicated reasons to do with the name-overriding of fixtures, I had to leave it called `app`, but that's what `cgap-portal`. I think is probably all part of the original port Will did there.

Opportunistic:

* In `Makefile` these changes were made that I think are pretty non-controversial:
  * Implement `psql-test` and reimplement `psql-dev`. These now work through new file `scripts/psql-start`.
  * Implement `make kibana-start-test` and reimplement `make kibana-start`. These work through a revised `scripts/kibana-start`.
  * Implement `make test-performance` and `make test`integration`.
  * Change the order of `make test-unit` and `make test-npm` so that `unit` goes first when doing `make test` on a local machine for development. (This does not affect the parallel way that testing works on GitHub Actions.)
  * Implement `make retest`. I'm still not sure this works well enough to be of value, but `pytest` says it's supposed to, so I want to hang onto it for a while as we do upgrades to newer versions of `pytest` where it might work better. It would be really useful if it worked as advertised.
