### PR TITLE
reorder primary and secondary probes in ImagingPath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "2.6.6"
+version = "2.6.7"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -198,4 +198,3 @@ memlimit = "encoded.memlimit:filter_app"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
-

--- a/src/encoded/tests/test_types_imaging.py
+++ b/src/encoded/tests/test_types_imaging.py
@@ -30,7 +30,7 @@ def test_imgpath_displaytitle(testapp, img_path_blank, prot_bio_feature):
     res = testapp.patch_json(img_path_blank['@id'], {'labeled_probe': 'secondary antibody'}).json['@graph'][0]
     assert res['display_title'] == 'RAD21 protein targeted by GFP,RFP-labeled secondary antibody'
     res = testapp.patch_json(img_path_blank['@id'], {'other_probes': ['primary Ab 1', 'primary Ab 2']}).json['@graph'][0]
-    assert res['display_title'] == 'RAD21 protein targeted by GFP,RFP-labeled secondary antibody (with primary Ab 1, primary Ab 2)'
+    assert res['display_title'] == 'RAD21 protein targeted by primary Ab 1, primary Ab 2 (with GFP,RFP-labeled secondary antibody)'
 
 
 def test_imgpath_displaytitle_labels_only(testapp, img_path_blank):

--- a/src/encoded/types/imaging.py
+++ b/src/encoded/types/imaging.py
@@ -31,30 +31,38 @@ class ImagingPath(Item):
         # create a summary for the imaging paths
         # example Chromosomes targeted by DAPI
         # example Protein:Actin_Human targeted by Atto647N-labeled phalloidin
-        # example Protein:Myoglobin_Human targeted by GFP-labeled Goat Secondary Antibody (with Human Globin Antibody)
+        # example Protein:Myoglobin_Human targeted by Human Globin Antibody (with GFP-labeled Goat Secondary Antibody)
         # example GRCh38:1:1000000 targeted by RFP-labeled BAC
-        title = ""
+
         if target:
             targets = []
             for a_target in target:
                 target_title = request.embed(a_target, '@@object').get('display_title')
                 targets.append(target_title)
-            targets_title = ", ".join(targets)
-            title = targets_title
-        if labels:
-            labels_title = ",".join(labels)
-            if title:
-                title = title + " targeted by " + labels_title
-            else:
-                title = labels_title
-        if labeled_probe:
-            if labels:
-                title = title + "-labeled " + labeled_probe
-            elif title:
-                title = title + " targeted by " + labeled_probe
+            target = ", ".join(targets)
         if other_probes:
-            mediators_title = ", ".join(other_probes)
-            title = title + " (with {})".format(mediators_title)
+            other_probes = ", ".join(other_probes)
+        if labels:
+            labels = ",".join(labels)
+
+        labels_title = ""
+        if labels and labeled_probe:
+            labels_title = labels + "-labeled " + labeled_probe
+        elif labels or labeled_probe:
+            labels_title = labels or labeled_probe
+
+        probes_title = ""
+        if other_probes and labels_title:
+            probes_title = other_probes + " (with {})".format(labels_title)
+        elif other_probes or labels_title:
+            probes_title = other_probes or labels_title
+
+        title = ""
+        if target and probes_title:
+            title = target + " targeted by " + probes_title
+        elif target or probes_title:
+            title = target or probes_title
+
         if title:
             return title
         else:


### PR DESCRIPTION
Re-ordering the `display_title` of ImagingPath so that, if `target` (e.g. antigen), `other_probes` (e.g. primary antibody) and `labeled_probe` (e.g. secondary antibody) are all present, they appear in a logic order.
Updating tests accordingly.