### PR TITLE
 Item-specific arbitrary viewing  groups 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.4"
+version = "3.1.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/badge.json
+++ b/src/encoded/schemas/badge.json
@@ -34,6 +34,17 @@
                 "deleted"
             ]
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "title": {
             "title": "Badge Name",
             "description": "The display name for the badge.",

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -36,6 +36,17 @@
                 "archived to project"
             ]
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "accession": {
             "accessionType": "EX"
         },

--- a/src/encoded/schemas/experiment_type.json
+++ b/src/encoded/schemas/experiment_type.json
@@ -30,6 +30,17 @@
                 "deleted"
             ]
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "title": {
             "title": "Experiment Type",
             "description": "The display name for the experiment type",

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -212,6 +212,17 @@
                 "restricted"
             ]
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "quality_metric": {
             "type": "string",
             "title": "Quality Metric",

--- a/src/encoded/schemas/file_format.json
+++ b/src/encoded/schemas/file_format.json
@@ -31,6 +31,17 @@
                 "deleted"
             ]
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "file_format": {
             "title": "File Format",
             "type": "string",

--- a/src/encoded/schemas/lab.json
+++ b/src/encoded/schemas/lab.json
@@ -29,6 +29,17 @@
                 "inactive"
             ]
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "name": {
             "title": "Name",
             "description": "A short unique name for the lab, use lower cased and hyphen delimited PI name and lab(e.g. john-doe-lab).",

--- a/src/encoded/schemas/microscope_configuration.json
+++ b/src/encoded/schemas/microscope_configuration.json
@@ -49,6 +49,17 @@
             ],
             "lookup" : 20
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "microscope" : {
             "type" : "object",
             "title" : "Microscope",
@@ -130,16 +141,16 @@
         }
     },
     "facets" : {
-        "microscope.Tier":{ 
+        "microscope.Tier":{
             "title": "Tier"
         },
-        "microscope.Manufacturer":{ 
+        "microscope.Manufacturer":{
             "title": "Manufacturer"
         },
-        "microscope.Model":{ 
+        "microscope.Model":{
             "title": "Model"
         },
-        "microscope.Type":{ 
+        "microscope.Type":{
             "title": "Type"
         }
     },
@@ -147,16 +158,16 @@
         "submitted_by.display_title" : {
             "title" : "Creator"
         },
-        "microscope.Tier":{ 
+        "microscope.Tier":{
             "title": "Tier"
         },
-        "microscope.Manufacturer":{ 
+        "microscope.Manufacturer":{
             "title": "Manufacturer"
         },
-        "microscope.Model":{ 
+        "microscope.Model":{
             "title": "Model"
         },
-        "microscope.Type":{ 
+        "microscope.Type":{
             "title": "Type"
         }
     },

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -88,6 +88,17 @@
                 "released to project",
                 "archived to project"
             ]
+        },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
         }
     },
     "submitted": {

--- a/src/encoded/schemas/page.json
+++ b/src/encoded/schemas/page.json
@@ -29,6 +29,17 @@
             ],
             "lookup" : 55
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "name": {
             "title": "Path Name",
             "comment": "Unique route/pathname of this page.",

--- a/src/encoded/schemas/publication.json
+++ b/src/encoded/schemas/publication.json
@@ -51,6 +51,17 @@
                 "released to project"
             ]
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "published_by": {
             "title": "Published by",
             "type": "string",

--- a/src/encoded/schemas/user.json
+++ b/src/encoded/schemas/user.json
@@ -63,7 +63,7 @@
             "permission": "import_items",
             "items": {
                 "type": "string",
-                "enum": [
+                "suggested_enum": [
                     "4DN",
                     "Not 4DN",
                     "NOFIC",

--- a/src/encoded/schemas/user_content.json
+++ b/src/encoded/schemas/user_content.json
@@ -42,6 +42,17 @@
             ],
             "lookup" : 20
         },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
+        },
         "description": {
             "title": "Description",
             "type": "string",

--- a/src/encoded/tests/test_permissions.py
+++ b/src/encoded/tests/test_permissions.py
@@ -276,6 +276,25 @@ def indexer_testapp(app, external_tx, zsa_savepoints):
     return remote_user_testapp(app, 'INDEXER')
 
 
+def test_arbitrary_viewing_group_can_view_item_w_viewable_by(
+        wrangler_testapp, remc_member_testapp, lab, award, remc_submitter):
+    bs_item = {
+        'biosource_type': 'primary cell',
+        'lab': lab['@id'],
+        'award': award['@id'],
+        'status': 'in review by lab'
+    }
+    import pdb; pdb.set_trace()
+    # post the item - the award has the 4DN viewing group and nothing related to remc
+    bsres = wrangler_testapp.post_json('/biosource', bs_item, status=201).json['@graph'][0]
+    # the remc testapp should not be able to get this item
+    remc_member_testapp.get(bsres['@id'], status=403)
+    # now add viewable by property to the item
+    n4_bs = wrangler_testapp.patch_json(bsres['@id'], {'viewable_by': ['Not 4DN']}, status=200).json['@graph'][0]
+    # now we can get it
+    remc_member_testapp.get(n4_bs['@id'], status=200)
+
+
 def test_wrangler_post_non_lab_collection(wrangler_testapp):
     item = {
         'name': 'human',
@@ -1051,6 +1070,7 @@ def test_4dn_can_view_nofic_released_to_project(
     eset_item['award'] = nofic_award['@id']
     eset_item['status'] = 'released to project'
     res1 = wrangler_testapp.post_json('/experiment_set', eset_item).json['@graph'][0]
+    import pdb; pdb.set_trace()
     viewing_group_member_testapp.get(res1['@id'], status=200)
 
 

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -388,8 +388,9 @@ class Item(snovault.Item):
 
         # this is for access to item specific view group
         if 'viewable_by' in properties:
-            for vg in properties.get('viewable_by', [])
-            roles['viewing_group.{}'.format(vg)] = 'role.viewing_group_member'
+            #import pdb; pdb.set_trace()
+            for vg in properties.get('viewable_by', []):
+                roles['viewing_group.{}'.format(vg)] = 'role.viewing_group_member'
 
         # This emulates __ac_local_roles__ of User.py (role.owner)
         if 'submitted_by' in properties:

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -379,7 +379,9 @@ class Item(snovault.Item):
                             roles['viewing_group.4DN'] = 'role.viewing_group_member'
                     # else leave the NOFIC viewing group role in place
                 elif (status in ['planned', 'submission in progress'] and not _is_joint_analysis(properties)) or (status == 'pre-release'):
-                    # view should be restricted to lab members
+                    # for these statuses view should be restricted to lab members so all viewing_groups are removed
+                    # unless in the case of planned and submission in progress it is a joint analysis tagged dataset
+                    # or NOFIC group dealt with in the above if
                     grps = []
                     for group, role in roles.items():
                         if role == 'role.viewing_group_member':
@@ -387,13 +389,6 @@ class Item(snovault.Item):
                     for g in grps:
                         del roles[g]
 
-        # in order to allow arbitrary item-specific viewing group view
-        # these 2 statuses map to allow viewing_groups to view but for these stati
-        # we don't want award based or other adding
-        # if status in ['pre-release', 'submission in progress']:
-        #    for role in roles:
-        #        if role.startswith('viewing_group.'):
-        #            del (roles[role])
         # this is for access to item specific view group
         if 'viewable_by' in properties:
             viewers = properties.get('viewable_by', [])

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -385,6 +385,12 @@ class Item(snovault.Item):
                             grps.append(group)
                     for g in grps:
                         del roles[g]
+
+        # this is for access to item specific view group
+        if 'viewable_by' in properties:
+            for vg in properties.get('viewable_by', [])
+            roles['viewing_group.{}'.format(vg)] = 'role.viewing_group_member'
+
         # This emulates __ac_local_roles__ of User.py (role.owner)
         if 'submitted_by' in properties:
             submitter = 'userid.%s' % properties['submitted_by']

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -57,6 +57,7 @@ ALLOW_EVERYONE_VIEW = [
 
 ALLOW_LAB_MEMBER_VIEW = [
     (Allow, 'role.lab_member', 'view'),
+    (Allow, 'role.award_member', 'view')
 ] + ONLY_ADMIN_VIEW + SUBMITTER_CREATE
 
 ALLOW_VIEWING_GROUP_VIEW = [
@@ -308,7 +309,7 @@ class Item(snovault.Item):
         # publication
         'published': ALLOW_CURRENT,
         # experiment sets
-        'pre-release': ALLOW_LAB_VIEW_ADMIN_EDIT
+        'pre-release': ALLOW_VIEWING_GROUP_VIEW,
     }
 
     # Items of these statuses are filtered out from rev links
@@ -349,6 +350,7 @@ class Item(snovault.Item):
 
         roles = {}
         properties = self.upgrade_properties()
+        status = properties.get('status')
         if 'lab' in properties:
             lab_submitters = 'submits_for.%s' % properties['lab']
             roles[lab_submitters] = 'role.lab_submitter'
@@ -367,7 +369,6 @@ class Item(snovault.Item):
                 award_group_members = 'award.%s' % properties['award']
                 roles[award_group_members] = 'role.award_member'
 
-                status = properties.get('status')
                 # need to add 4DN viewing_group to NOFIC items that are rel2proj
                 # or are JA and planned or in progress
                 if viewing_group == 'NOFIC':
@@ -377,8 +378,8 @@ class Item(snovault.Item):
                         if _is_joint_analysis(properties):
                             roles['viewing_group.4DN'] = 'role.viewing_group_member'
                     # else leave the NOFIC viewing group role in place
-                elif status in ['planned', 'submission in progress'] and not _is_joint_analysis(properties):
-                    # view should be restricted to lab members only so remove viewing_group roles
+                elif (status in ['planned', 'submission in progress'] and not _is_joint_analysis(properties)) or (status == 'pre-release'):
+                    # view should be restricted to lab members
                     grps = []
                     for group, role in roles.items():
                         if role == 'role.viewing_group_member':
@@ -386,10 +387,17 @@ class Item(snovault.Item):
                     for g in grps:
                         del roles[g]
 
+        # in order to allow arbitrary item-specific viewing group view
+        # these 2 statuses map to allow viewing_groups to view but for these stati
+        # we don't want award based or other adding
+        # if status in ['pre-release', 'submission in progress']:
+        #    for role in roles:
+        #        if role.startswith('viewing_group.'):
+        #            del (roles[role])
         # this is for access to item specific view group
         if 'viewable_by' in properties:
-            #import pdb; pdb.set_trace()
-            for vg in properties.get('viewable_by', []):
+            viewers = properties.get('viewable_by', [])
+            for vg in viewers:
                 roles['viewing_group.{}'.format(vg)] = 'role.viewing_group_member'
 
         # This emulates __ac_local_roles__ of User.py (role.owner)


### PR DESCRIPTION
It would be nice to be able to allow some Items that are not yet ready for release to all or project members to be viewable by an arbitrary set of users.  In order to provide this the following changes are proposed:

- add a viewable_by property to all items - generally through the status mixin (but for those Items with custom status enums this property was added to those schemas).
- made the viewing_groups property on User a suggested_enum
- modified the ACL mapping for pre-release so viewing_groups can see items BUT NOT Award specified viewing_groups
- modified __ac_local_roles__ to remove award specified viewing_group membership for pre-release
- and to add viewing_groups specified in Item.viewable_by property
- also made in viewing_group viewable to people who share the same award (that would otherwise be non-visible unless they also had the necessary viewing_group (the usual case so it hasn't been a problem)) - this resolves an inconsistency that has existed for quite a while (but was not problematic in general). 

The net intended result is that if an Item has a status > in review by lab an has a value(s) in viewable_by then any user who also has that value in their viewing_groups can view the Item.

Note that 'submission in progress' status is essentially equivalent to 'in review by lab' except it allows 'viewing_groups' views in some special cases that don't necessarily apply to phase 2 (i.e. NOFIC and Joint Analysis) but now will allow Item specific viewing_group viewers.

Also pre-release also now allows this type of viewing - where it previously only allowed lab members to view.  