### PR TITLE
Imaging path embeds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.2"
+version = "3.1.3"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.1"
+version = "3.1.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/dependencies.py
+++ b/src/encoded/types/dependencies.py
@@ -106,7 +106,9 @@ class DependencyEmbedder:
             'other_probes',
             'labeled_probe',
             'primary_antibodies.antibody_name',
+            'primary_antibodies.antibody_product_no',
             'secondary_antibody.antibody_name',
+            'secondary_antibody.antibody_product_no',
             'override_display_title'
         ],
 

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -518,9 +518,11 @@ def _build_experiment_set_replicate_embedded_list():
     imaging_path_target_embeds = DependencyEmbedder.embed_defaults_for_type(
         base_path='imaging_paths.path.target',
         t='bio_feature')
-    return (ExperimentSet.embedded_list + imaging_path_embeds + imaging_path_target_embeds + [
-        'replicate_exps.replicate_exp.accession',
-    ]
+    return (
+            ExperimentSet.embedded_list + imaging_path_embeds + imaging_path_target_embeds + [
+                'replicate_exps.replicate_exp.accession',
+            ]
+    )
 
 
 @collection(

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -29,6 +29,7 @@ from .base import (
     lab_award_attribution_embed_list,
     get_item_or_none
 )
+from .dependencies import DependencyEmbedder
 import datetime
 
 
@@ -506,6 +507,22 @@ class ExperimentSet(Item):
             return len(experiments_in_set)
 
 
+def _build_experiment_set_replicate_embedded_list():
+    """ Helper function intended to be used to create the embedded list for Replicate Experiment Sets.
+        All types should implement a function like this going forward.
+    """
+    imaging_path_embeds = DependencyEmbedder.embed_for_type(
+        base_path='imaging_paths.path',
+        t='imaging_path',
+        additional_embeds=['imaging_rounds', 'experiment_type.title'])
+    imaging_path_target_embeds = DependencyEmbedder.embed_defaults_for_type(
+        base_path='imaging_paths.path.target',
+        t='bio_feature')
+    return (ExperimentSet.embedded_list + imaging_path_embeds + imaging_path_target_embeds + [
+        'replicate_exps.replicate_exp.accession',
+    ]
+
+
 @collection(
     name='experiment-set-replicates',
     unique_key='accession',
@@ -519,12 +536,7 @@ class ExperimentSetReplicate(ExperimentSet):
     item_type = 'experiment_set_replicate'
     schema = load_schema('encoded:schemas/experiment_set_replicate.json')
     name_key = "accession"
-    embedded_list = ExperimentSet.embedded_list + [
-        "experiments_in_set.imaging_paths.path.*",  # imaging_paths calc prop
-        "experiments_in_set.imaging_paths.path.primary_antibodies.antibody_name",
-        "experiments_in_set.imaging_paths.path.secondary_antibody.antibody_name",
-        "replicate_exps.replicate_exp.accession"
-    ]
+    embedded_list = _build_experiment_set_replicate_embedded_list()
 
     def _update(self, properties, sheets=None):
         all_experiments = [exp['replicate_exp'] for exp in properties.get('replicate_exps', [])]


### PR DESCRIPTION
* Updating the embeds for `imaging_paths`, a calculated property of Replicate Experiment Sets. Previously, the embeds were erroneously set for `experiments_in_set.imaging_paths`, instead of `imaging_paths`.
* Adding `antibody_product_no` to the imaging_path dependencies, since this field is required for antibody.display_title