### PR TITLE
Genont termurl embed fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.8"
+version = "3.1.9"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/dependencies.py
+++ b/src/encoded/types/dependencies.py
@@ -90,6 +90,7 @@ class DependencyEmbedder:
         ONTOLOGY_TERM: [
             'term_id',
             'term_name',
+            'term_url',
             'preferred_name',
         ],
         PROTOCOL: [


### PR DESCRIPTION
In this PR, `term_url` was added to dependencies for ontology_term embeds. This should fix a problem in `generate_ontology.py`, in which synonym terms embedded in an Ontology item without a term_url caused a ValueError to be raised. 