### PR TITLE
remove sorting of treatments_summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.13"
+version = "3.1.14"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -145,7 +145,7 @@ class Biosample(Item):  # CalculatedBiosampleSlims, CalculatedBiosampleSynonyms)
             for tmt in treatments:
                 treat_props = get_item_or_none(request, tmt, 'treatments')
                 treat_list.append(treat_props.get('display_title'))
-            return ' and '.join(sorted([t for t in treat_list if t]))
+            return ' and '.join([t for t in treat_list if t])
         return 'None'
 
     @calculated_property(schema={


### PR DESCRIPTION
The order of treatments in a biosample sometimes has a meaning (e.g. in case of a chemical treatment followed by its washout) and this should be preserved also in the treatments_summary.