### PR TITLE
Sum targets when imaging paths are split

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.19"
+version = "3.1.20"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_types_experiment.py
+++ b/src/encoded/tests/test_types_experiment.py
@@ -726,6 +726,9 @@ def microscopy_w_multipath(testapp, repliseq_info, imaging_path_1, imaging_path_
 def microscopy_w_splitpath(testapp, repliseq_info, exp_types,
                            imaging_path_1, imaging_path_3,
                            basic_region_bio_feature, genomic_region_bio_feature):
+    '''Sometimes a (group of) target(s) is split into different imaging paths,
+    e.g. due to multiplexing. If text is formatted as follows, the split group
+    will be found and replaced with the sum'''
     repliseq_info['experiment_type'] = exp_types['fish']['@id']
     img_path1 = {'path': imaging_path_1['@id'], 'channel': 'ch01'}
     img_path3 = {'path': imaging_path_3['@id'], 'channel': 'ch03'}
@@ -778,6 +781,8 @@ def test_experiment_categorizer_4_mic_w_multi_path(testapp, microscopy_w_multipa
 
 
 def test_experiment_categorizer_4_mic_w_split_path(testapp, microscopy_w_splitpath):
+    '''Sometimes a (group of) target(s) is split into different imaging paths,
+    e.g. due to multiplexing. Sum the split targets and return only one string.'''
     assert microscopy_w_splitpath['experiment_categorizer']['value'] == '37 TADs on chr19'
 
 

--- a/src/encoded/tests/test_types_experiment.py
+++ b/src/encoded/tests/test_types_experiment.py
@@ -722,6 +722,21 @@ def microscopy_w_multipath(testapp, repliseq_info, imaging_path_1, imaging_path_
     return testapp.post_json('/experiment_mic', repliseq_info).json['@graph'][0]
 
 
+@pytest.fixture
+def microscopy_w_splitpath(testapp, repliseq_info, exp_types,
+                           imaging_path_1, imaging_path_3,
+                           basic_region_bio_feature, genomic_region_bio_feature):
+    repliseq_info['experiment_type'] = exp_types['fish']['@id']
+    img_path1 = {'path': imaging_path_1['@id'], 'channel': 'ch01'}
+    img_path3 = {'path': imaging_path_3['@id'], 'channel': 'ch03'}
+    repliseq_info['imaging_paths'] = [img_path1, img_path3]
+    testapp.patch_json(basic_region_bio_feature['@id'],
+                       {'preferred_label': '15 TADs on chr19'}).json['@graph'][0]
+    testapp.patch_json(genomic_region_bio_feature['@id'],
+                       {'preferred_label': '22 TADs on chr19'}).json['@graph'][0]
+    return testapp.post_json('/experiment_mic', repliseq_info).json['@graph'][0]
+
+
 def test_experiment_atacseq_display_title(experiment_atacseq):
     assert experiment_atacseq.get('display_title') == 'ATAC-seq on GM12878 - ' + experiment_atacseq.get('accession')
 
@@ -760,6 +775,10 @@ def test_experiment_categorizer_4_mic_w_multi_path(testapp, microscopy_w_multipa
     assert len(value) == len2chk
     for v in vals2chk:
         assert v in value
+
+
+def test_experiment_categorizer_4_mic_w_split_path(testapp, microscopy_w_splitpath):
+    assert microscopy_w_splitpath['experiment_categorizer']['value'] == '37 TADs on chr19'
 
 
 def test_experiment_categorizer_4_chiapet_no_fusion(testapp, repliseq_info, exp_types):

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -1,6 +1,7 @@
 """Abstract collection for experiment and integration of all experiment types."""
 
 import itertools
+import re
 
 from snovault import (
     abstract_collection,
@@ -1014,12 +1015,25 @@ class ExperimentMic(Experiment):
         if imaging_paths:
             path_targets = []
             for pathobj in imaging_paths:
-                path = request.embed('/', pathobj['path'], '@@object')
+                path = get_item_or_none(request, pathobj['path'], 'imaging_path')
                 for target in path.get('target', []):
-                    summ = request.embed('/', target, '@@object')['display_title']
+                    summ = get_item_or_none(request, target, 'bio_feature')['display_title']
                     path_targets.append(summ)
             if path_targets:
-                value = ', '.join(list(set(path_targets)))
+                value = []
+                sum_targets = {}
+                for target in path_targets:
+                    # check if target starts with numbers, e.g. '50 TADs', '40 TADs'
+                    # sum them if there are more: '90 TADs'
+                    split_target = re.split(r'(^[0-9]+)([^0-9].*)', target)
+                    if len(split_target) > 1:
+                        t_num, t_name = split_target[1:3]
+                        sum_targets[t_name] = sum_targets.setdefault(t_name, 0) + int(t_num)
+                    elif target not in value:
+                        value.append(target)
+                if sum_targets:
+                    value = [str(n) + t for t, n in sum_targets.items()] + value
+                value = ', '.join(value)
                 return {
                     'field': 'Target',
                     'value': value,

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -1025,7 +1025,7 @@ class ExperimentMic(Experiment):
                 for target in path_targets:
                     # check if target starts with numbers, e.g. '50 TADs', '40 TADs'
                     # sum them if there are more: '90 TADs'
-                    split_target = re.split(r'(^[0-9]+)([^0-9].*)', target)
+                    split_target = re.split(r'(^[0-9]+)', target, maxsplit=1)
                     if len(split_target) > 1:
                         t_num, t_name = split_target[1:3]
                         sum_targets[t_name] = sum_targets.setdefault(t_name, 0) + int(t_num)


### PR DESCRIPTION
Some ExperimentMic can have multiple imaging_paths with the same target. For example, 90 TADs can be imaged splitting '50 TADs' in one path and '40 TADs' in another. In this case, the Target listed by experiment_categorizer will detect them and sum them.

- modified experiment_categorizer for ExperimentMic
- added test