### PR TITLE
Change permissions and status for MicroscopeConfiguration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.20"
+version = "3.1.21"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/microscope_configuration.json
+++ b/src/encoded/schemas/microscope_configuration.json
@@ -40,11 +40,11 @@
         "status": {
             "title": "Status",
             "type": "string",
+            "permission": "import_items",
             "default": "draft",
             "enum" : [
                 "released",
                 "released to project",
-                "released to lab",
                 "draft",
                 "deleted"
             ],

--- a/src/encoded/schemas/microscope_configuration.json
+++ b/src/encoded/schemas/microscope_configuration.json
@@ -12,7 +12,6 @@
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/aliases" },
         { "$ref": "mixins.json#/notes" },
-        { "$ref": "mixins.json#/status"} ,
         { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/modified" },
         { "$ref": "mixins.json#/release_dates" },
@@ -37,6 +36,30 @@
             "title": "Description",
             "description" : "Description of microscope configuration.",
             "type": "string"
+        },
+        "status": {
+            "title": "Status",
+            "type": "string",
+            "default": "draft",
+            "enum" : [
+                "released",
+                "released to project",
+                "released to lab",
+                "draft",
+                "deleted"
+            ],
+            "lookup" : 20
+        },
+        "viewable_by": {
+            "title": "Viewable By",
+            "exclude_from": ["submit4dn"],
+            "permission": "import_items",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "title": "View Group",
+                "type": "string"
+            }
         },
         "microscope" : {
             "type" : "object",

--- a/src/encoded/schemas/microscope_configuration.json
+++ b/src/encoded/schemas/microscope_configuration.json
@@ -5,6 +5,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": ["microscope"],
+    "additionalProperties": false,
     "identifyingProperties": ["uuid", "aliases"],
     "mixinProperties": [
         { "$ref": "mixins.json#/schema_version" },

--- a/src/encoded/schemas/microscope_configuration.json
+++ b/src/encoded/schemas/microscope_configuration.json
@@ -11,6 +11,7 @@
         { "$ref": "mixins.json#/uuid" },
         { "$ref": "mixins.json#/aliases" },
         { "$ref": "mixins.json#/notes" },
+        { "$ref": "mixins.json#/status"} ,
         { "$ref": "mixins.json#/submitted" },
         { "$ref": "mixins.json#/modified" },
         { "$ref": "mixins.json#/release_dates" },
@@ -35,30 +36,6 @@
             "title": "Description",
             "description" : "Description of microscope configuration.",
             "type": "string"
-        },
-        "status": {
-            "title": "Status",
-            "type": "string",
-            "default": "draft",
-            "enum" : [
-                "released",
-                "released to project",
-                "released to lab",
-                "draft",
-                "deleted"
-            ],
-            "lookup" : 20
-        },
-        "viewable_by": {
-            "title": "Viewable By",
-            "exclude_from": ["submit4dn"],
-            "permission": "import_items",
-            "type": "array",
-            "uniqueItems": true,
-            "items": {
-                "title": "View Group",
-                "type": "string"
-            }
         },
         "microscope" : {
             "type" : "object",

--- a/src/encoded/types/microscope_configuration.py
+++ b/src/encoded/types/microscope_configuration.py
@@ -8,12 +8,6 @@ from snovault import (
 )
 from .base import (
     Item,
-    ALLOW_OWNER_EDIT,
-    ALLOW_CURRENT,
-    DELETED,
-    ONLY_ADMIN_VIEW,
-    ALLOW_LAB_SUBMITTER_EDIT,
-    ALLOW_VIEWING_GROUP_VIEW,
     ALLOW_ANY_USER_ADD
 )
 
@@ -29,13 +23,6 @@ class MicroscopeConfiguration(Item):
 
     item_type = 'microscope_configuration'
     schema = load_schema('encoded:schemas/microscope_configuration.json')
-    STATUS_ACL = {
-        'released'              : ALLOW_OWNER_EDIT + ALLOW_CURRENT,
-        'deleted'               : ALLOW_OWNER_EDIT + DELETED,
-        'draft'                 : ALLOW_OWNER_EDIT + ONLY_ADMIN_VIEW,
-        'released to lab'       : ALLOW_OWNER_EDIT + ALLOW_LAB_SUBMITTER_EDIT,
-        'released to project'   : ALLOW_OWNER_EDIT + ALLOW_VIEWING_GROUP_VIEW
-    }
 
     def _update(self, properties, sheets=None):
         '''set microscope ID if empty

--- a/src/encoded/types/microscope_configuration.py
+++ b/src/encoded/types/microscope_configuration.py
@@ -11,7 +11,6 @@ from .base import (
     ALLOW_OWNER_EDIT,
     ALLOW_CURRENT,
     DELETED,
-    ONLY_ADMIN_VIEW,
     ALLOW_LAB_SUBMITTER_EDIT,
     ALLOW_VIEWING_GROUP_VIEW,
     ALLOW_ANY_USER_ADD
@@ -30,11 +29,10 @@ class MicroscopeConfiguration(Item):
     item_type = 'microscope_configuration'
     schema = load_schema('encoded:schemas/microscope_configuration.json')
     STATUS_ACL = {
-        'released'              : ALLOW_OWNER_EDIT + ALLOW_CURRENT,
-        'deleted'               : ALLOW_OWNER_EDIT + DELETED,
-        'draft'                 : ALLOW_OWNER_EDIT + ONLY_ADMIN_VIEW,
-        'released to lab'       : ALLOW_OWNER_EDIT + ALLOW_LAB_SUBMITTER_EDIT,
-        'released to project'   : ALLOW_OWNER_EDIT + ALLOW_VIEWING_GROUP_VIEW
+        'released'              : ALLOW_CURRENT,
+        'deleted'               : DELETED,
+        'draft'                 : ALLOW_OWNER_EDIT + ALLOW_LAB_SUBMITTER_EDIT,
+        'released to project'   : ALLOW_VIEWING_GROUP_VIEW
     }
 
     def _update(self, properties, sheets=None):

--- a/src/encoded/types/microscope_configuration.py
+++ b/src/encoded/types/microscope_configuration.py
@@ -8,6 +8,12 @@ from snovault import (
 )
 from .base import (
     Item,
+    ALLOW_OWNER_EDIT,
+    ALLOW_CURRENT,
+    DELETED,
+    ONLY_ADMIN_VIEW,
+    ALLOW_LAB_SUBMITTER_EDIT,
+    ALLOW_VIEWING_GROUP_VIEW,
     ALLOW_ANY_USER_ADD
 )
 
@@ -23,6 +29,13 @@ class MicroscopeConfiguration(Item):
 
     item_type = 'microscope_configuration'
     schema = load_schema('encoded:schemas/microscope_configuration.json')
+    STATUS_ACL = {
+        'released'              : ALLOW_OWNER_EDIT + ALLOW_CURRENT,
+        'deleted'               : ALLOW_OWNER_EDIT + DELETED,
+        'draft'                 : ALLOW_OWNER_EDIT + ONLY_ADMIN_VIEW,
+        'released to lab'       : ALLOW_OWNER_EDIT + ALLOW_LAB_SUBMITTER_EDIT,
+        'released to project'   : ALLOW_OWNER_EDIT + ALLOW_VIEWING_GROUP_VIEW
+    }
 
     def _update(self, properties, sheets=None):
         '''set microscope ID if empty


### PR DESCRIPTION
- keep only a few statuses: released, released to project, draft, deleted
- only admins can change status
- everyone who is logged in can create a new item (unchanged in this PR)
- 'draft' is similar to 'in review by lab', but works also if a user is not submitting for a lab
- this item cannot have additional properties in general (but the `microscope` sub-object still can)