### PR TITLE
Static Content Added to Attribution Tab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.31"
+version = "3.1.32"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/components/AttributionTabView.js
+++ b/src/encoded/static/components/item-pages/components/AttributionTabView.js
@@ -83,13 +83,6 @@ export const AttributionTabView = React.memo(function AttributionTabView({ conte
     return (
         <div className="info-area">
 
-            { staticContent.length > 0 ?
-                <div>
-                    <UserContentBodyList contents={staticContent} />
-                    <hr className="mt-1 mb-2" />
-                </div>
-                : null }
-
             { produced_in_pub || publications_of_set.length > 0 ?
                 <div>
                     <Publications context={context} />
@@ -113,6 +106,13 @@ export const AttributionTabView = React.memo(function AttributionTabView({ conte
                     : null }
 
             </div>
+
+            { staticContent.length > 0 ?
+                <div className="mt-2">
+                    <hr />
+                    <UserContentBodyList contents={staticContent} />
+                </div>
+                : null}
 
             <ItemFooterRow {...{ context, schemas, width }} />
         </div>

--- a/src/encoded/static/components/item-pages/components/AttributionTabView.js
+++ b/src/encoded/static/components/item-pages/components/AttributionTabView.js
@@ -7,6 +7,8 @@ import ReactTooltip from 'react-tooltip';
 import { FormattedInfoBlock, WrappedCollapsibleList } from './FormattedInfoBlock';
 import { Publications } from './Publications';
 import { ItemFooterRow } from './ItemFooterRow';
+import { getTabStaticContent } from './TabbedView';
+import { UserContentBodyList } from './../../static-pages/components';
 
 
 // TODO memoized component
@@ -76,9 +78,17 @@ export const AttributionTabView = React.memo(function AttributionTabView({ conte
     const awardExists = (award && !award.error);
     const labsExist = (lab && !lab.error) || contributing_labs.length > 0;
     const submittedByExists = submitted_by && !submitted_by.error;
+    const staticContent = getTabStaticContent(context, 'tab:attribution');
 
     return (
         <div className="info-area">
+
+            { staticContent.length > 0 ?
+                <div>
+                    <UserContentBodyList contents={staticContent} />
+                    <hr className="mt-1 mb-2" />
+                </div>
+                : null }
 
             { produced_in_pub || publications_of_set.length > 0 ?
                 <div>


### PR DESCRIPTION
Trello: https://trello.com/c/76Kd4PNh

static content having "tab:attribution" are listed in attribution tab.

<img width="1164" alt="Screen Shot 2021-07-22 at 16 20 31" src="https://user-images.githubusercontent.com/49978017/126656940-2f6b15db-c501-4a55-aab8-68cb88dfaddb.png">

