### PR TITLE
Upd upld key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.1.32"
+version = "3.1.33"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_file.py
+++ b/src/encoded/tests/test_file.py
@@ -240,6 +240,16 @@ def test_files_aws_credentials_change_filename(testapp, fastq_uploading, file_fo
     assert res_put.json['@graph'][0]['href'].endswith('tiff')
 
 
+# def test_upload_key_modified_when_extcreds_no_match_key(testapp, fastq_uploading, file_formats):
+#     import pdb; pdb.set_trace()
+#     fastq_uploading['filename'] = 'test.zip'
+#     fastq_uploading['file_format'] = file_formats.get('zip').get('uuid')
+#     res = testapp.post_json('/file_calibration', fastq_uploading, status=201)
+#     resobj = res.json['@graph'][0]
+#     with mock.patch.object('encoded.types.file.File', 'propsheets', return_value={'external': {'a': 1}}):
+#         pres = testapp.patch_json(resobj.get('@id'), {}, status=200)
+
+
 def test_status_change_doesnt_muck_with_creds(testapp, fastq_uploading, file_formats):
     fastq_uploading['filename'] = 'test.zip'
     fastq_uploading['file_format'] = file_formats.get('zip').get('uuid')

--- a/src/encoded/tests/test_file.py
+++ b/src/encoded/tests/test_file.py
@@ -135,6 +135,7 @@ def test_restricted_no_download(testapp, fastq_json):
     s3.put_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'], Body=str.encode(''))
     download_link = resobj['href']
     testapp.get(download_link, status=307)
+    testapp.patch_json(resobj['@id'], {'status': 'restricted'}, status=200)
     # fail download of restricted file (although with a 200 status?)
     testapp.get(download_link, status=403)
     s3.delete_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'])
@@ -151,6 +152,7 @@ def test_upload_key_updated_on_accession_change(testapp, proc_file_json):
     presobj = pres.json['@graph'][0]
     assert resobj['upload_key'] != presobj['upload_key']
     assert presobj['upload_key'].endswith("{}.{}".format(newacc, fext))
+    s3.delete_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'])
 
 
 def test_extra_files_stuff(testapp, proc_file_json, file_formats):

--- a/src/encoded/tests/test_file.py
+++ b/src/encoded/tests/test_file.py
@@ -136,7 +136,7 @@ def test_restricted_no_download(testapp, fastq_json):
     download_link = resobj['href']
     testapp.get(download_link, status=307)
     testapp.patch_json(resobj['@id'], {'status': 'restricted'}, status=200)
-    # fail download of restricted file (although with a 200 status?)
+    # fail download of restricted file
     testapp.get(download_link, status=403)
     s3.delete_object(Bucket='test-wfout-bucket', Key=resobj['upload_key'])
 

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -887,14 +887,14 @@ class File(Item):
         fformat = properties.get('file_format')
         if fformat.startswith('/file-formats/'):
             fformat = fformat[len('/file-formats/'):-1]
-            prop_format = registry['collections']['FileFormat'].get(fformat)
-            try:
-                file_extension = prop_format.properties['standard_file_extension']
-            except KeyError:
-                raise Exception('File format not in list of supported file types')
-            return '{uuid}/{accession}.{file_extension}'.format(
-                file_extension=file_extension, uuid=uuid,
-                accession=properties.get('accession'))
+        prop_format = registry['collections']['FileFormat'].get(fformat)
+        try:
+            file_extension = prop_format.properties['standard_file_extension']
+        except KeyError:
+            raise Exception('File format not in list of supported file types')
+        return '{uuid}/{accession}.{file_extension}'.format(
+            file_extension=file_extension, uuid=uuid,
+            accession=properties.get('accession'))
 
     @classmethod
     def build_external_creds(cls, registry, uuid, properties):


### PR DESCRIPTION
Modifed the upload_key function to compare existing values stored in external propsheets and update if they are different than 
the calculated key.

Added a build_key class method that is used by this function as well as build_external_creds to make comparison possible.  

No explicit tests yet but the existing credential tests indicate nothing broken in build_external creds