### PR TITLE
add external_submission to Reference Files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.3.13"
+version = "3.3.14"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/file_reference.json
+++ b/src/encoded/schemas/file_reference.json
@@ -18,6 +18,7 @@
         { "$ref": "mixins.json#/notes" },
         { "$ref": "mixins.json#/accession" },
         { "$ref": "mixins.json#/dbxrefs" },
+        { "$ref": "mixins.json#/external_submission" },
         { "$ref": "mixins.json#/tags" },
         { "$ref": "mixins.json#/static_embeds" },
         { "$ref": "mixins.json#/higlass_defaults" },


### PR DESCRIPTION
This property allows to keep track of items exported from the database, to be submitted to external resources such as GEO. In some cases, Reference Files need to be exported as well.