### PR TITLE
embed file dbxrefs in experiments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.3.20"
+version = "3.3.21"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -211,6 +211,7 @@ class Experiment(Item):
         'files.file_classification',
         'files.file_type_detailed',
         'files.paired_end',
+        'files.dbxrefs',
         'files.external_references.*',
         'files.related_files.relationship_type',
         'files.related_files.file.accession',


### PR DESCRIPTION
files.external_references is a calcprop, so its update does not trigger invalidation of Experiment. For this, embedding of files.dbxrefs is required.