### PR TITLE
use doi.org and biorxiv.org APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.3.24"
+version = "3.3.25"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_types_publication.py
+++ b/src/encoded/tests/test_types_publication.py
@@ -62,7 +62,7 @@ def test_update_publication_doi_biorxiv(testapp, publication_doi_biorxiv):
     assert publication_doi_biorxiv['title'][:50] == 'Designing Robustness to Temperature in a Feedforwa'
     assert publication_doi_biorxiv['abstract'][:50] == 'Incoherent feedforward loops represent important b'
     assert publication_doi_biorxiv['authors'] == ['Shaunak Sen', 'Jongmin Kim', 'Richard M. Murray']
-    assert publication_doi_biorxiv['url'] == 'https://www.biorxiv.org/content/10.1101/000091v1'
+    assert publication_doi_biorxiv['url'] == 'http://biorxiv.org/lookup/doi/10.1101/000091'
     assert publication_doi_biorxiv['date_published'] == '2013-11-07'
     assert publication_doi_biorxiv['journal'] == 'bioRxiv'
 

--- a/src/encoded/types/publication.py
+++ b/src/encoded/types/publication.py
@@ -132,7 +132,7 @@ def fetch_biorxiv(url, doi):
     record_dict = r.json()['collection'][0]
     pub_data = {k: record_dict.get(v) for k,v in fdn2biorxiv.items() if record_dict.get(v)}
     if pub_data.get('authors'):  # format authors according to 4DN schema
-        pub_data['authors'] = [a.lstrip().replace(". ", "").replace(".", "") for a in pub_data['authors'].split(";")]
+        pub_data['authors'] = [a.replace(". ", "").replace(".", "").replace(",", "") for a in pub_data['authors'].split("; ")]
     pub_data['url'] = url
     pub_data['journal'] = 'bioRxiv'
     return pub_data

--- a/src/encoded/types/publication.py
+++ b/src/encoded/types/publication.py
@@ -113,42 +113,26 @@ def fetch_pubmed(PMID):
     return {k: v for k, v in pub_data.items() if v is not None}
 
 
-class BioRxivExtractor(HTMLParser):
-    def __init__(self):
-        HTMLParser.__init__(self)
-        self.title = ''
-        self.abstract = ''
-        self.authors = []
-        self.date_published = ''
-
-    def handle_starttag(self, tag, attrs):
-        attr = ''
-        if tag == 'meta':
-            attr = {k[0]: k[1] for k in attrs}
-            if attr.get('name') == "DC.Title":
-                self.title = attr.get('content')
-            if attr.get('name') == "DC.Description":
-                self.abstract = attr.get('content')
-            if attr.get('name') == "DC.Contributor":
-                self.authors.append(attr.get('content'))
-            if attr.get('name') == "DC.Date":
-                self.date_published = attr.get('content')
-
-
-def fetch_biorxiv(url):
-    """Takes Url, uses the BioRxivExtractor class and returns title abstract authors url"""
-    parserfields = ['title', 'abstract', 'authors', 'date_published']
+def fetch_biorxiv(url, doi):
+    """Takes url and doi, returns title abstract authors date url journal"""
+    fdn2biorxiv = {
+        'title': 'title',
+        'abstract': 'abstract',
+        'authors': 'authors',
+        'date_published': 'date'
+    }
+    biorxiv_api = 'https://api.biorxiv.org/details/biorxiv/'
     # try fetching data 5 times and return empty if fails
     for count in range(5):
-        r = requests.get(url)
+        r = requests.get(biorxiv_api + doi)
         if r.status_code == 200:
             break
         if count == 4:
             return
-    resp = r.text.encode('utf-8').decode('ascii', 'ignore')
-    parser = BioRxivExtractor()
-    parser.feed(resp)
-    pub_data = {f: getattr(parser, f) for f in parserfields if hasattr(parser, f)}
+    record_dict = r.json()['collection'][0]
+    pub_data = {k: record_dict.get(v) for k,v in fdn2biorxiv.items() if record_dict.get(v)}
+    if pub_data.get('authors'):  # format authors according to 4DN schema
+        pub_data['authors'] = [a.lstrip().replace(". ", "").replace(".", "") for a in pub_data['authors'].split(";")]
     pub_data['url'] = url
     pub_data['journal'] = 'bioRxiv'
     return pub_data
@@ -175,14 +159,18 @@ def map_doi_pmid(doi):
 
 def map_doi_biox(doi):
     "If a doi is not mapped to pubmed, check where it goes"
-    DOIad = "https://doi.org/"
-    www = "{DOIad}{doi}".format(DOIad=DOIad, doi=doi)
+    DOIapi = "https://doi.org/api/handles/"
+    www = "{DOIapi}{doi}".format(DOIapi=DOIapi, doi=doi)
     for count in range(5):
         resp = requests.get(www)
         if resp.status_code == 200:
             break
-    landing_page = resp.url
-    if "biorxiv" in landing_page.lower():
+    if resp.json().get('values'):
+        for value in resp.json()['values']:
+            if value.get('type', '') == 'URL':
+                landing_page = value['data']['value']
+                break
+    if "biorxiv" in landing_page:
         return landing_page
     else:
         return
@@ -249,7 +237,7 @@ class Publication(Item, ItemWithAttachment):
                 else:
                     biox_url = map_doi_biox(doi_id)
                     if biox_url:
-                        pub_data = fetch_biorxiv(biox_url)
+                        pub_data = fetch_biorxiv(biox_url, doi_id)
                     else:
                         pass
         except Exception:

--- a/src/encoded/types/publication.py
+++ b/src/encoded/types/publication.py
@@ -132,7 +132,7 @@ def fetch_biorxiv(url, doi):
     record_dict = r.json()['collection'][0]
     pub_data = {k: record_dict.get(v) for k,v in fdn2biorxiv.items() if record_dict.get(v)}
     if pub_data.get('authors'):  # format authors according to 4DN schema
-        pub_data['authors'] = [a.replace(". ", "").replace(".", "").replace(",", "") for a in pub_data['authors'].split("; ")]
+        pub_data['authors'] = [a.strip() for a in pub_data['authors'].split(";") if a]
     pub_data['url'] = url
     pub_data['journal'] = 'bioRxiv'
     return pub_data


### PR DESCRIPTION
Biorxiv seems to require using its API for programmatic access. Requests to doi.org were failing because it was redirecting to biorxiv.

Instead, use the doi.org API (no redirects) to determine whether the doi points to biorxiv, and then use the biorxiv API to get the Publication metadata.