### PR TITLE
Schema changes for MicroMeta-App

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.3.27"
+version = "3.4.0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/create_mapping_on_deploy.py
+++ b/src/encoded/commands/create_mapping_on_deploy.py
@@ -78,6 +78,7 @@ ITEM_INDEX_ORDER = [
     'MicroscopeSettingD1',
     'MicroscopeSettingD2',
     'MicroscopeConfiguration',
+    'ImageSetting',
 
     'HiglassViewConfig',
     'QualityMetricAtacseq',

--- a/src/encoded/schemas/experiment_mic.json
+++ b/src/encoded/schemas/experiment_mic.json
@@ -71,7 +71,7 @@
             "title": "Imaging Paths",
             "description": "Target to label connections in each channel.",
             "type":  "array",
-            "lookup": 63,
+            "lookup": 62,
             "items": {
                 "title": "Imaging path",
                 "type": "object",
@@ -94,9 +94,22 @@
         },
         "microscope_settings_master": {
             "type": "string",
-            "lookup": 62,
+            "lookup": 71,
             "title": "Master Microscope Settings",
             "linkTo": "MicroscopeSetting"
+        },
+        "microscope_configuration_master": {
+            "type": "string",
+            "lookup": 72,
+            "title": "Master Microscope Configuration",
+            "description": "Hardware configuration for the microscope instrument",
+            "linkTo": "MicroscopeConfiguration"
+        },
+        "image_settings_master": {
+            "type": "string",
+            "lookup": 73,
+            "title": "Master Image Settings",
+            "linkTo": "ImageSetting"
         },
         "plate_id": {
             "title": "Plate ID",

--- a/src/encoded/schemas/file_microscopy.json
+++ b/src/encoded/schemas/file_microscopy.json
@@ -60,9 +60,22 @@
         },
         "microscope_settings": {
             "type": "string",
-            "lookup": 50,
+            "lookup": 99,
             "title": "Microscope Settings",
             "linkTo": "MicroscopeSetting"
+        },
+        "microscope_configuration": {
+            "type": "string",
+            "lookup": 50,
+            "title": "Microscope Configuration",
+            "description": "Hardware configuration for the microscope instrument",
+            "linkTo": "MicroscopeConfiguration"
+        },
+        "image_settings": {
+            "type": "string",
+            "lookup": 51,
+            "title": "Image Settings",
+            "linkTo": "ImageSetting"
         },
         "related_files": {
             "exclude_from": ["submit4dn", "FFedit-create"]

--- a/src/encoded/schemas/image_setting.json
+++ b/src/encoded/schemas/image_setting.json
@@ -1,0 +1,45 @@
+{
+    "title": "Image Settings",
+    "description": "Microscopy metadata specific to the image",
+    "id": "/profiles/image_setting.json",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "required": ["settings"],
+    "additionalProperties": false,
+    "identifyingProperties": ["uuid"],
+    "mixinProperties": [
+        { "$ref": "mixins.json#/schema_version" },
+        { "$ref": "mixins.json#/uuid" },
+        { "$ref": "mixins.json#/submitted" },
+        { "$ref": "mixins.json#/modified" },
+        { "$ref": "mixins.json#/tags" },
+        { "$ref": "user_content.json#/properties" }
+    ],
+    "mixinFacets": [
+        { "$ref": "mixins.json#/facets_common" }
+    ],
+    "properties": {
+        "schema_version": {
+            "default": "1"
+        },
+        "status": {
+            "title": "Status",
+            "type": "string",
+            "permission": "import_items",
+            "default": "draft",
+            "enum": [
+                "released",
+                "released to project",
+                "draft",
+                "deleted"
+            ],
+            "lookup": 20
+        },
+        "settings": {
+            "title": "Settings",
+            "type": "object",
+            "internal_comment": "This is the container for image settings json from micrometa app",
+            "additionalProperties": true
+        }
+    }
+}

--- a/src/encoded/tests/data/inserts/image_setting.json
+++ b/src/encoded/tests/data/inserts/image_setting.json
@@ -1,0 +1,12 @@
+[
+    {
+        "uuid": "d72074eb-2a87-4b9a-813f-0b9d6414e58a",
+        "award": "1U01CA200059-01",
+        "lab": "4dn-dcic-lab",
+        "submitted_by": "4dndcic@gmail.com",
+        "title": "Test image settings",
+        "settings": {
+            "some_key": "some_value"
+        }
+    }
+]

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -1144,26 +1144,3 @@ def quality_metric_pairsqc(testapp, lab, award):
         'lab': lab['@id']
     }
     return testapp.post_json('/quality_metric_pairsqc', item).json['@graph'][0]
-
-
-@pytest.fixture
-def microscope_conf_basic_info():
-    mic = {
-        'microscope': {
-            'Tier': 1,
-            'ValidationTier': 1,
-            'Name': 'Microscope 1',
-        }
-    }
-    return mic
-
-
-@pytest.fixture
-def microscope_conf_1(testapp, microscope_conf_basic_info):
-    return testapp.post_json('/microscope_configuration', microscope_conf_basic_info).json['@graph'][0]
-
-
-@pytest.fixture
-def microscope_conf_2(testapp, microscope_conf_basic_info):
-    microscope_conf_basic_info['microscope']['Name'] = 'Microscope 2'
-    return testapp.post_json('/microscope_configuration', microscope_conf_basic_info).json['@graph'][0]

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -1144,3 +1144,26 @@ def quality_metric_pairsqc(testapp, lab, award):
         'lab': lab['@id']
     }
     return testapp.post_json('/quality_metric_pairsqc', item).json['@graph'][0]
+
+
+@pytest.fixture
+def microscope_conf_basic_info():
+    mic = {
+        'microscope': {
+            'Tier': 1,
+            'ValidationTier': 1,
+            'Name': 'Microscope 1',
+        }
+    }
+    return mic
+
+
+@pytest.fixture
+def microscope_conf_1(testapp, microscope_conf_basic_info):
+    return testapp.post_json('/microscope_configuration', microscope_conf_basic_info).json['@graph'][0]
+
+
+@pytest.fixture
+def microscope_conf_2(testapp, microscope_conf_basic_info):
+    microscope_conf_basic_info['microscope']['Name'] = 'Microscope 2'
+    return testapp.post_json('/microscope_configuration', microscope_conf_basic_info).json['@graph'][0]

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -29,7 +29,7 @@ ORDER = [
     'workflow_mapping', 'workflow_run_sbg', 'workflow_run_awsem',
     'tracking_item', 'quality_metric_flag',
     'summary_statistic', 'summary_statistic_hi_c', 'workflow_run',
-    'microscope_configuration', 'quality_metric_mcool'
+    'microscope_configuration', 'image_setting', 'quality_metric_mcool'
 ]
 
 

--- a/src/encoded/tests/test_schemas.py
+++ b/src/encoded/tests/test_schemas.py
@@ -128,7 +128,7 @@ def test_load_schema(schema, master_mixins, registry):
                 'ontology.json', 'ontology_term.json', 'page.json',
                 'static_section.json', 'badge.json', 'tracking_item.json',
                 'file_format.json', 'experiment_type.json', 'higlass_view_config.json',
-                'microscope_configuration.json'
+                'microscope_configuration.json', 'image_setting.json'
             ]
             for prop in shared_properties:
                 if schema == 'experiment.json':

--- a/src/encoded/tests/test_types_experiment.py
+++ b/src/encoded/tests/test_types_experiment.py
@@ -866,48 +866,6 @@ def test_experiment_categorizer_cap_c_w_2regions(
 
 
 @pytest.fixture
-def expt_mic_w_microscope(testapp, repliseq_info, exp_types, microscope_conf_1):
-    repliseq_info['experiment_type'] = exp_types['fish']['@id']
-    repliseq_info['microscope_configuration_master'] = microscope_conf_1['@id']
-    return testapp.post_json('/experiment_mic', repliseq_info).json['@graph'][0]
-
-
-@pytest.fixture
-def filemic_w_microscope(testapp, basic_info, file_formats, microscope_conf_2):
-    basic_info['file_format'] = file_formats.get('tiff').get('@id')
-    basic_info['microscope_configuration'] = microscope_conf_2['@id']
-    return testapp.post_json('/file_microscopy', basic_info).json['@graph'][0]
-
-
-@pytest.fixture
-def expt_mic_w_file(testapp, repliseq_info, exp_types, filemic_w_microscope):
-    repliseq_info['experiment_type'] = exp_types['fish']['@id']
-    repliseq_info['files'] = [filemic_w_microscope['@id']]
-    return testapp.post_json('/experiment_mic', repliseq_info).json['@graph'][0]
-
-
-def test_experiment_microscopes_only_master(expt_mic_w_microscope):
-    assert len(expt_mic_w_microscope.get('microscopes', [])) == 1
-
-
-def test_experiment_microscopes_only_filemic(expt_mic_w_file):
-    assert len(expt_mic_w_file.get('microscopes', [])) == 1
-
-
-def test_experiment_microscopes_master_and_file(testapp, expt_mic_w_microscope, filemic_w_microscope):
-    patch_file = {'files': [filemic_w_microscope['@id']]}
-    res = testapp.patch_json(expt_mic_w_microscope['@id'], patch_file, status=200).json['@graph'][0]
-    assert len(res.get('microscopes', [])) == 2
-
-
-def test_experiment_microscopes_same_master_and_file(testapp, expt_mic_w_file, microscope_conf_2):
-    patch_mic = {'microscope_configuration_master': microscope_conf_2['@id']}
-    res = testapp.patch_json(expt_mic_w_file['@id'], patch_mic, status=200).json['@graph'][0]
-    assert len(res.get('microscopes', [])) == 1
-    assert res['microscopes'][0] == microscope_conf_2['@id']
-
-
-@pytest.fixture
 def new_exp_type(lab, award):
     data = {
         'uuid': str(uuid4()),

--- a/src/encoded/tests/test_types_experiment.py
+++ b/src/encoded/tests/test_types_experiment.py
@@ -866,6 +866,48 @@ def test_experiment_categorizer_cap_c_w_2regions(
 
 
 @pytest.fixture
+def expt_mic_w_microscope(testapp, repliseq_info, exp_types, microscope_conf_1):
+    repliseq_info['experiment_type'] = exp_types['fish']['@id']
+    repliseq_info['microscope_configuration_master'] = microscope_conf_1['@id']
+    return testapp.post_json('/experiment_mic', repliseq_info).json['@graph'][0]
+
+
+@pytest.fixture
+def filemic_w_microscope(testapp, basic_info, file_formats, microscope_conf_2):
+    basic_info['file_format'] = file_formats.get('tiff').get('@id')
+    basic_info['microscope_configuration'] = microscope_conf_2['@id']
+    return testapp.post_json('/file_microscopy', basic_info).json['@graph'][0]
+
+
+@pytest.fixture
+def expt_mic_w_file(testapp, repliseq_info, exp_types, filemic_w_microscope):
+    repliseq_info['experiment_type'] = exp_types['fish']['@id']
+    repliseq_info['files'] = [filemic_w_microscope['@id']]
+    return testapp.post_json('/experiment_mic', repliseq_info).json['@graph'][0]
+
+
+def test_experiment_microscopes_only_master(expt_mic_w_microscope):
+    assert len(expt_mic_w_microscope.get('microscopes', [])) == 1
+
+
+def test_experiment_microscopes_only_filemic(expt_mic_w_file):
+    assert len(expt_mic_w_file.get('microscopes', [])) == 1
+
+
+def test_experiment_microscopes_master_and_file(testapp, expt_mic_w_microscope, filemic_w_microscope):
+    patch_file = {'files': [filemic_w_microscope['@id']]}
+    res = testapp.patch_json(expt_mic_w_microscope['@id'], patch_file, status=200).json['@graph'][0]
+    assert len(res.get('microscopes', [])) == 2
+
+
+def test_experiment_microscopes_same_master_and_file(testapp, expt_mic_w_file, microscope_conf_2):
+    patch_mic = {'microscope_configuration_master': microscope_conf_2['@id']}
+    res = testapp.patch_json(expt_mic_w_file['@id'], patch_mic, status=200).json['@graph'][0]
+    assert len(res.get('microscopes', [])) == 1
+    assert res['microscopes'][0] == microscope_conf_2['@id']
+
+
+@pytest.fixture
 def new_exp_type(lab, award):
     data = {
         'uuid': str(uuid4()),

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -972,6 +972,12 @@ def _build_experiment_mic_embedded_list():
         'files.microscope_settings.ch03_lasers_diodes',
         'files.microscope_settings.ch04_lasers_diodes',
 
+        # MicroscopeConfiguration linkTo
+        'microscope_configuration_master.title',
+        'microscope_configuration_master.microscope.Name',
+        'files.microscope_configuration.title',
+        'files.microscope_configuration.microscope.Name',
+
         # Image linkTo
         'sample_image.title',
         'sample_image.caption',
@@ -1056,6 +1062,30 @@ class ExperimentMic(Experiment):
                     'combined': 'Target: ' + value
                 }
         return super(ExperimentMic, self).experiment_categorizer(request, experiment_type)
+
+    @calculated_property(schema={
+        "title": "Microscopes",
+        "description": "All microscope configurations used in this experiment",
+        "type": "array",
+        "items": {
+            "title": "Microscope Configuration",
+            "description": "Hardware configuration for the microscope instrument",
+            "type": "string",
+            "linkTo": "MicroscopeConfiguration"
+        }
+    })
+    def microscopes(self, request, microscope_configuration_master=None, files=None):
+        mics = []
+        if microscope_configuration_master:
+            mic_conf = get_item_or_none(request, microscope_configuration_master)
+            if mic_conf:
+                mics.append(mic_conf.get('@id'))
+        if files:
+            for f in files:
+                filemic = get_item_or_none(request, f)
+                if filemic and filemic.get('microscope_configuration'):
+                    mics.append(filemic['microscope_configuration'])
+        return list(set(mics))
 
 
 @calculated_property(context=Experiment, category='action')

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -1063,30 +1063,6 @@ class ExperimentMic(Experiment):
                 }
         return super(ExperimentMic, self).experiment_categorizer(request, experiment_type)
 
-    @calculated_property(schema={
-        "title": "Microscopes",
-        "description": "All microscope configurations used in this experiment",
-        "type": "array",
-        "items": {
-            "title": "Microscope Configuration",
-            "description": "Hardware configuration for the microscope instrument",
-            "type": "string",
-            "linkTo": "MicroscopeConfiguration"
-        }
-    })
-    def microscopes(self, request, microscope_configuration_master=None, files=None):
-        mics = []
-        if microscope_configuration_master:
-            mic_conf = get_item_or_none(request, microscope_configuration_master)
-            if mic_conf:
-                mics.append(mic_conf['@id'])
-        if files:
-            for f in files:
-                filemic = get_item_or_none(request, f)
-                if filemic and filemic.get('microscope_configuration'):
-                    mics.append(filemic['microscope_configuration'])
-        return list(set(mics))
-
 
 @calculated_property(context=Experiment, category='action')
 def clone(context, request):

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -1079,7 +1079,7 @@ class ExperimentMic(Experiment):
         if microscope_configuration_master:
             mic_conf = get_item_or_none(request, microscope_configuration_master)
             if mic_conf:
-                mics.append(mic_conf.get('@id'))
+                mics.append(mic_conf['@id'])
         if files:
             for f in files:
                 filemic = get_item_or_none(request, f)

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -1263,6 +1263,10 @@ def _build_file_microscopy_embedded_list():
         'experiments.files.microscope_settings.ch02_lasers_diodes',
         'experiments.files.microscope_settings.ch03_lasers_diodes',
         'experiments.files.microscope_settings.ch04_lasers_diodes',
+
+        # MicroscopeConfiguration linkTo
+        'microscope_configuration.title',
+        'microscope_configuration.microscope.Name',
         ]
     )
 

--- a/src/encoded/types/user_content.py
+++ b/src/encoded/types/user_content.py
@@ -215,6 +215,7 @@ class HiglassViewConfig(UserContent):
             super(HiglassViewConfig.Collection, self).__init__(*args, **kw)
             self.__acl__ = ALLOW_ANY_USER_ADD
 
+
 @collection(
     name='microscope-configurations',
     properties={
@@ -249,7 +250,7 @@ class MicroscopeConfiguration(UserContent):
         "description": "A calculated title for every object in 4DN",
         "type": "string"
     })
-    def display_title(self, microscope, title = None):
+    def display_title(self, microscope, title=None):
         return title or microscope.get("Name")
 
     class Collection(Item.Collection):
@@ -259,6 +260,34 @@ class MicroscopeConfiguration(UserContent):
         '''
         def __init__(self, *args, **kw):
             super(MicroscopeConfiguration.Collection, self).__init__(*args, **kw)
+            self.__acl__ = ALLOW_ANY_USER_ADD
+
+
+@collection(
+    name='image-settings',
+    properties={
+        'title': 'Image Settings',
+        'description': 'Listing of ImageSetting Items.',
+    })
+class ImageSetting(UserContent):
+    """Image Settings class."""
+
+    item_type = 'image_setting'
+    schema = load_schema('encoded:schemas/image_setting.json')
+    STATUS_ACL = {
+        'released'              : ALLOW_CURRENT,
+        'deleted'               : DELETED,
+        'draft'                 : ALLOW_OWNER_EDIT + ALLOW_LAB_SUBMITTER_EDIT,
+        'released to project'   : ALLOW_VIEWING_GROUP_VIEW
+    }
+
+    class Collection(Item.Collection):
+        '''
+        This extension of the default Item collection allows any User to create a new version of these.
+        Emulates base.py Item collection setting of self.__acl__
+        '''
+        def __init__(self, *args, **kw):
+            super(ImageSetting.Collection, self).__init__(*args, **kw)
             self.__acl__ = ALLOW_ANY_USER_ADD
 
 


### PR DESCRIPTION
- Add ImageSettings item, to collect metadata from MicroMeta-App about image settings (distinct from metadata about the microscope hardware, already captured by the MicroscopeConfiguration item).
- FileMicroscope links to ImageSettings and MicroscopeConfiguration items.
- ExperimentMic also links to ImageSettings and MicroscopeConfiguration items (to be used in case the experiment has no files).
- ~~Add a microscope calcprop to Experiment, to summarize all MicroscopeConfiguration items in the experiment and its files. Add tests for the calcprop.~~