### PR TITLE
Link to Microscope Configuration in Experiment/File View

### DIFF
--- a/deploy/post_deploy_testing/cypress/integration/01c_static_content_joint_analysis.js
+++ b/deploy/post_deploy_testing/cypress/integration/01c_static_content_joint_analysis.js
@@ -111,7 +111,7 @@ describe('Joint Analysis Page', function () {
                     expect(nextTotalCount).to.be.greaterThan(origTotalCount);
                     expect(nextTotalCount).to.be.greaterThan(49);
                 });
-            }).wait(250).end().window().screenshot().end().wait(250).end().logout4DN();
+            }).wait(250).end()/*.window().screenshot().end().wait(250).end()*/.logout4DN();
         });
 
     });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.4.2"
+version = "3.4.3"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/components/file-tables.js
+++ b/src/encoded/static/components/browse/components/file-tables.js
@@ -420,7 +420,12 @@ export class RawFilesStackedTable extends React.PureComponent {
         if (!showMicroscopeConfigurationColumns) return null;
 
         return [
-            { columnClass: 'file-detail', title: 'Microscope Configuration', initialWidth: 40, render: renderFileMicroscopeConfigurationLinkButton }
+            {
+                columnClass: 'file-detail', title: 'Microscope Configuration', initialWidth: 40, render: renderFileMicroscopeConfigurationLinkButton,
+                visibleTitle: function () {
+                    return <i className="icon icon-fw icon-microscope fas" data-tip="Microscope Configuration" />;
+                }
+            }
         ];
     }
     /**

--- a/src/encoded/static/components/browse/components/file-tables.js
+++ b/src/encoded/static/components/browse/components/file-tables.js
@@ -384,7 +384,7 @@ export class RawFilesStackedTable extends React.PureComponent {
     }
 
     /**
-     * Adds Total Sequences metric column if any raw files in expSet have a `quality_metric`.
+     * Adds Total Sequences metric column if any raw files in expOrExpSet have a `quality_metric`.
      * Or if param `showMetricColumns` is set to true;
      *
      * @see fileUtil.filterFilesWithEmbeddedMetricItem
@@ -404,7 +404,7 @@ export class RawFilesStackedTable extends React.PureComponent {
         ];
     }
     /**
-     * Adds Notes column if any raw files in expSet have a `microscope_configuration`.
+     * Adds Microscope Configuration column if any raw files in expOrExpSet have a `microscope_configuration`.
      * Or if param `showMicroscopeConfigurationColumns` is set to true;
      *
      * @param {*} showNotesColumns - Skips check for microscope_configuration and returns column if true.
@@ -424,7 +424,7 @@ export class RawFilesStackedTable extends React.PureComponent {
         ];
     }
     /**
-     * Adds Notes column if any raw files in expSet have a `notes_to_tsv`.
+     * Adds Notes column if any raw files in expOrExpSet have a `notes_to_tsv`.
      * Or if param `showNotesColumns` is set to true;
      *
      * @param {*} showNotesColumns - Skips check for notes_to_tsv and returns column if true.

--- a/src/encoded/static/components/browse/components/file-tables.js
+++ b/src/encoded/static/components/browse/components/file-tables.js
@@ -442,22 +442,22 @@ export class RawFilesStackedTable extends React.PureComponent {
         ];
     }
 
-    static columnHeaders = memoize(function(columnHeaders, showMetricColumns, showMicroscopeConfigurationColumns, showNotesColumns, expOrExpSet){
+    static columnHeaders(columnHeaders, showMetricColumns, showMicroscopeConfigurationColumns, showNotesColumns, expOrExpSet){
         return (RawFilesStackedTable.staticColumnHeaders(columnHeaders, expOrExpSet) || [])
             .concat(RawFilesStackedTable.customColumnHeaders(columnHeaders, expOrExpSet) || [])
             .concat(RawFilesStackedTable.metricColumnHeaders(showMetricColumns, expOrExpSet) || [])
             .concat(RawFilesStackedTable.microscopeConfigurationColumnHeaders(showMicroscopeConfigurationColumns, expOrExpSet) || [])
             .concat(RawFilesStackedTable.notesColumnHeaders(showNotesColumns, expOrExpSet) || []);
-    });
+    }
 
-    static isExperimentSet = memoize(function (expOrExpSet) {
+    static isExperimentSet(expOrExpSet) {
         const itemType = schemaTransforms.getItemType(expOrExpSet);
         return itemType && itemType.indexOf('ExperimentSet') >= 0;
-    });
+    }
 
-    static allRawFiles = memoize(function (expOrExpSet) {
+    static allRawFiles(expOrExpSet) {
         return RawFilesStackedTable.isExperimentSet(expOrExpSet) ? expFxn.allFilesFromExperimentSet(expOrExpSet, false) : expOrExpSet.files;
-    });
+    }
 
     static propTypes = {
         'columnHeaders'             : PropTypes.array,
@@ -515,7 +515,8 @@ export class RawFilesStackedTable extends React.PureComponent {
                 );
                 const allRawFiles = expFxn.allFilesFromExperimentSet(experimentSet, false);
                 return { experimentsGroupedByBiosample, allRawFiles };
-            })
+            }),
+            columnHeaders: memoize(RawFilesStackedTable.columnHeaders)
         };
     }
 
@@ -572,7 +573,7 @@ export class RawFilesStackedTable extends React.PureComponent {
         const haveUngroupedFiles = Array.isArray(ungroupedFiles) && ungroupedFiles.length > 0;
         const haveGroups = Array.isArray(fileGroups) && fileGroups.length > 0;
 
-        var fullColumnHeaders   = RawFilesStackedTable.columnHeaders(columnHeaders, showMetricsColumns, showMicroscopeConfigurationColumns, showNotesColumns, experimentSet || exp),
+        var fullColumnHeaders   = this.memoized.columnHeaders(columnHeaders, showMetricsColumns, showMicroscopeConfigurationColumns, showNotesColumns, experimentSet || exp),
             contentsClassName   = 'files',
             contents            = [];
 
@@ -735,7 +736,7 @@ export class RawFilesStackedTable extends React.PureComponent {
             </React.Fragment>
         );
 
-        const columnHeaders = RawFilesStackedTable.columnHeaders(propColHeaders, showMetricsColumns, showMicroscopeConfigurationColumns, showNotesColumns, experimentSet || experiment);
+        const columnHeaders = this.memoized.columnHeaders(propColHeaders, showMetricsColumns, showMicroscopeConfigurationColumns, showNotesColumns, experimentSet || experiment);
 
         return (
             <div className="stacked-block-table-outer-container overflow-auto">
@@ -773,11 +774,11 @@ export class ProcessedFilesStackedTable extends React.PureComponent {
         return [{ columnClass: 'file-detail', title: 'Notes', initialWidth: 20, render: renderFileNotesColumn }];
     }
 
-    static columnHeaders = memoize(function (columnHeaders, showNotesColumns, processedFiles) {
+    static columnHeaders(columnHeaders, showNotesColumns, processedFiles) {
         let clonedColumnHeaders = columnHeaders.slice(0);
         clonedColumnHeaders = clonedColumnHeaders.concat(ProcessedFilesStackedTable.notesColumnHeaders(showNotesColumns, processedFiles) || []);
         return clonedColumnHeaders;
-    });
+    }
 
     static propTypes = {
         // These must have .experiments property, which itself should have .experiment_sets property. There's a utility function to get all files
@@ -836,7 +837,8 @@ export class ProcessedFilesStackedTable extends React.PureComponent {
         this.oddExpRow = false;
 
         this.memoized = {
-            filesGroupedByExperimentOrGlobal: memoize(ProcessedFilesStackedTable.filesGroupedByExperimentOrGlobal)
+            filesGroupedByExperimentOrGlobal: memoize(ProcessedFilesStackedTable.filesGroupedByExperimentOrGlobal),
+            columnHeaders: memoize(ProcessedFilesStackedTable.columnHeaders)
         };
     }
 
@@ -953,7 +955,7 @@ export class ProcessedFilesStackedTable extends React.PureComponent {
         const { files, columnHeaders: propColHeaders, showNotesColumns, collapseLongLists } = this.props;
         const filesGroupedByExperimentOrGlobal = this.memoized.filesGroupedByExperimentOrGlobal(files);
         const experimentBlocks = this.renderExperimentBlocks(filesGroupedByExperimentOrGlobal);
-        const columnHeaders = ProcessedFilesStackedTable.columnHeaders(propColHeaders, showNotesColumns, files);
+        const columnHeaders = this.memoized.columnHeaders(propColHeaders, showNotesColumns, files);
         return (
             <div className="stacked-block-table-outer-container overflow-auto">
                 <StackedBlockTable {..._.omit(this.props, 'children', 'files', 'columnHeaders')} columnHeaders={columnHeaders}

--- a/src/encoded/static/components/item-pages/DefaultItemView.js
+++ b/src/encoded/static/components/item-pages/DefaultItemView.js
@@ -638,7 +638,7 @@ export class OverViewBodyItem extends React.PureComponent {
         this.handleCollapseToggle = this.handleCollapseToggle.bind(this);
         this.state = {
             'collapsed': true
-        }
+        };
     }
 
     handleCollapseToggle(){

--- a/src/encoded/static/components/item-pages/ExperimentView.js
+++ b/src/encoded/static/components/item-pages/ExperimentView.js
@@ -82,7 +82,7 @@ export default class ExperimentView extends WorkflowRunTracingView {
         const tabs = [];
 
         const extendedExp = _.extend({ from_experiment_set: { accession: 'NONE' } }, context);
-        
+
         const commonProps = { width, context, schemas, windowWidth, href, session, mounted };
         const propsForTableSections = _.extend(SelectedFilesController.pick(this.props), commonProps);
 
@@ -305,6 +305,9 @@ const OverviewHeadingMic = React.memo(function OverviewHeadingMic(props){
             <OverViewBodyItem {...commonBioProps} property="treatments_summary" fallbackTitle="Biosample Treatments" />
             <OverViewBodyItem {...commonProps} property="microscopy_technique" fallbackTitle="Microscopy Technique" />
             <OverViewBodyItem {...commonProps} property="microscope_qc" fallbackTitle="Microscope Quality Control" />
+            <OverViewBodyItem {...commonProps} property="microscope_configuration_master" fallbackTitle="Microscope Configuration" />
+
+            <div className="w-100"></div>
 
             <OverViewBodyItem {...commonProps} property="sample_image" fallbackTitle="Sample Image"
                 wrapInColumn="col-12 col-md-3" singleItemClassName="block"

--- a/src/encoded/static/components/item-pages/ExperimentView.js
+++ b/src/encoded/static/components/item-pages/ExperimentView.js
@@ -305,7 +305,7 @@ const OverviewHeadingMic = React.memo(function OverviewHeadingMic(props){
             <OverViewBodyItem {...commonBioProps} property="treatments_summary" fallbackTitle="Biosample Treatments" />
             <OverViewBodyItem {...commonProps} property="microscopy_technique" fallbackTitle="Microscopy Technique" />
             <OverViewBodyItem {...commonProps} property="microscope_qc" fallbackTitle="Microscope Quality Control" />
-            <OverViewBodyItem {...commonProps} property="microscope_configuration_master" fallbackTitle="Microscope Configuration" />
+            <OverViewBodyItem {...commonProps} property="microscope_configuration_master" fallbackTitle="Microscope Configuration" wrapInColumn="col-12 col-md-6" />
 
             <div className="w-100"></div>
 

--- a/src/encoded/static/components/item-pages/FileMicroscopyView.js
+++ b/src/encoded/static/components/item-pages/FileMicroscopyView.js
@@ -126,16 +126,20 @@ const FileMicOverViewBody = React.memo(function FileMicOverViewBody(props){
 
                 { thumbnailLink ? <div className="col-sm-4">{ thumbnailLink }</div> : null }
 
-                {microscope_configuration ?
-                    <OverViewBodyItem result={file} property="microscope_configuration" fallbackTitle="Microscope Configuration" wrapInColumn={"col-12 pull-right col-sm-" + (thumbnailLink ? '8' : '12')} />
-                    : null}
+                {microscope_configuration || parentExperimentWithImagingPaths ?
+                    <div className={"overview-blocks col-12 pull-right col-sm-" + (thumbnailLink ? '8' : '12')}>
+                        {microscope_configuration ?
+                            <OverViewBodyItem result={file} property="microscope_configuration" fallbackTitle="Microscope Configuration" wrapInColumn="col-12" />
+                            : null}
 
-                { parentExperimentWithImagingPaths ?
-                    <OverViewBodyItem
-                        result={parentExperimentWithImagingPaths} tips={object.tipsFromSchema(schemas, parentExperimentWithImagingPaths)}
-                        wrapInColumn={"col-12 pull-right col-sm-" + (thumbnailLink ? '8' : '12')} property="imaging_paths" fallbackTitle="Imaging Paths"
-                        listItemElement="div" listWrapperElement="div" singleItemClassName="block" titleRenderFxn={OverViewBodyItem.titleRenderPresets.imaging_paths_from_exp} />
-                    : null }
+                        {parentExperimentWithImagingPaths ?
+                            <OverViewBodyItem
+                                result={parentExperimentWithImagingPaths} tips={object.tipsFromSchema(schemas, parentExperimentWithImagingPaths)}
+                                wrapInColumn="col-12" property="imaging_paths" fallbackTitle="Imaging Paths"
+                                listItemElement="div" listWrapperElement="div" singleItemClassName="block" titleRenderFxn={OverViewBodyItem.titleRenderPresets.imaging_paths_from_exp} />
+                            : null}
+                    </div>
+                    : null}
 
             </div>
             <div className="row overview-blocks">

--- a/src/encoded/static/components/item-pages/FileMicroscopyView.js
+++ b/src/encoded/static/components/item-pages/FileMicroscopyView.js
@@ -127,7 +127,7 @@ const FileMicOverViewBody = React.memo(function FileMicOverViewBody(props){
                 { thumbnailLink ? <div className="col-sm-4">{ thumbnailLink }</div> : null }
 
                 {microscope_configuration ?
-                    <OverViewBodyItem result={file} property="microscope_configuration" fallbackTitle="Microscope Configuration" wrapInColumn={"col-12 col-sm-" + (thumbnailLink ? '8' : '12')} />
+                    <OverViewBodyItem result={file} property="microscope_configuration" fallbackTitle="Microscope Configuration" wrapInColumn={"col-12 pull-right col-sm-" + (thumbnailLink ? '8' : '12')} />
                     : null}
 
                 { parentExperimentWithImagingPaths ?

--- a/src/encoded/static/components/item-pages/FileMicroscopyView.js
+++ b/src/encoded/static/components/item-pages/FileMicroscopyView.js
@@ -87,6 +87,7 @@ class FileMicroscopyViewOverview extends React.Component {
 const FileMicOverViewBody = React.memo(function FileMicOverViewBody(props){
     const { context, schemas, windowWidth } = props;
     const file = context;
+    const { microscope_configuration } = file;
 
     const parentExperimentsReversed = (file.experiments || []).slice(0).reverse(); // Last is newest.
 
@@ -124,6 +125,10 @@ const FileMicOverViewBody = React.memo(function FileMicOverViewBody(props){
             <div className="row overview-blocks">
 
                 { thumbnailLink ? <div className="col-sm-4">{ thumbnailLink }</div> : null }
+
+                {microscope_configuration ?
+                    <OverViewBodyItem result={file} property="microscope_configuration" fallbackTitle="Microscope Configuration" wrapInColumn={"col-12 col-sm-" + (thumbnailLink ? '8' : '12')} />
+                    : null}
 
                 { parentExperimentWithImagingPaths ?
                     <OverViewBodyItem

--- a/src/encoded/static/components/item-pages/FileView.js
+++ b/src/encoded/static/components/item-pages/FileView.js
@@ -214,6 +214,8 @@ export class FileOverviewHeading extends React.PureComponent {
                             fallbackTitle="General Classification" titleRenderFxn={FileOverviewHeading.fileClassificationRenderFxn} />
                         <OverViewBodyItem {...commonHeadingBlockProps} key="file_size" property="file_size"
                             fallbackTitle="File Size" titleRenderFxn={FileOverviewHeading.fileSizeTitleRenderFxn} />
+                        {/* <OverViewBodyItem {...commonHeadingBlockProps} key="microscope_configuration" property="microscope_configuration"
+                            fallbackTitle="Microscope Configuration" wrapInColumn={"col-12 col-md-6"} /> */}
                     </OverviewHeadingContainer>
                 </div>
                 <div className="col-12 col-md-4 mt-1 mb-3">

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -211,6 +211,7 @@ class Experiment(Item):
         'files.file_classification',
         'files.file_type_detailed',
         'files.paired_end',
+        'files.notes_to_tsv',
         'files.dbxrefs',
         'files.external_references.*',
         'files.related_files.relationship_type',

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -234,6 +234,10 @@ class ExperimentSet(Item):
         "experiments_in_set.files.lab.display_title",
         "experiments_in_set.files.track_and_facet_info.*",
 
+        # MicroscopeConfiguration linkTo
+        "experiments_in_set.files.microscope_configuration.title",
+        "experiments_in_set.files.microscope_configuration.microscope.Name",
+
         # FileFormat linkTo
         "experiments_in_set.files.file_format.file_format",
 


### PR DESCRIPTION
Trello: https://trello.com/c/NKCfQAOY

1. Microscope Configuration is added into the `Properties` section on `Experiment` page.
2. Microscope Configuration column is added into Raw Files table in Experiment/ExperimentSet pages. The column displays a microscope icon and the column is hidden unless at least one raw file is associated with a configuration.
3. Microscope Configuration is added into the `Overview` tab on the `Microscopy File` page.
4. New memoized `allRawFiles` function is added to increase performance since Notes, QC, Microscope Configuration columns check the existence of relevant fields in raw files.
5. `showNotesColumns` prop was used to be a string ("never", "conditional", "always") but it is not so performant and prone to mistyping errors. So it is converted to bool (true, false, null/undefined for conditional case)
6. Additionally, missing `files.notes_to_tsv` and `files.file_type` embeds added. (extra)

<img width="1130" alt="Screen Shot 2021-12-05 at 23 55 15" src="https://user-images.githubusercontent.com/49978017/144878747-87b2b0da-71a3-487b-89ca-c27c0177818c.png">


<img width="1139" alt="Screen Shot 2021-12-06 at 17 16 47" src="https://user-images.githubusercontent.com/49978017/144878625-cc441c9d-5169-4d75-9171-9b36ec20f120.png">
