### PR TITLE
Top Search Bar Redesign

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.4.6"
+version = "3.4.7"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/navigation/NavigationBar.js
+++ b/src/encoded/static/components/navigation/NavigationBar.js
@@ -177,7 +177,7 @@ const CollapsedNav = React.memo(function CollapsedNav(props) {
         <Navbar.Collapse>
             <BigDropdownGroupController {...{ addToBodyClassList, removeFromBodyClassList }}>
                 <LeftNav {...leftNavProps} />
-                <SearchBar {...{ href, currentAction, browseBaseState }} />
+                {/* <SearchBar {...{ href, currentAction, browseBaseState }} /> */}
                 <AccountNav {...userActionNavProps} />
             </BigDropdownGroupController>
         </Navbar.Collapse>

--- a/src/encoded/static/components/navigation/components/AccountNav.js
+++ b/src/encoded/static/components/navigation/components/AccountNav.js
@@ -70,7 +70,7 @@ export const AccountNav = React.memo(function AccountNav(props){
     const navItemTitle = (
         <React.Fragment>
             { acctIcon }
-            { acctTitle }
+            <span className="d-inline d-md-none d-lg-inline">{ acctTitle }</span>
         </React.Fragment>
     );
 

--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownContainer.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownContainer.js
@@ -60,7 +60,7 @@ export class BigDropdownContainer extends React.PureComponent {
         const { autoHideOnClick = true } = this.props;
         const targetElem = (evt && evt.target) || null;
 
-        if ((autoHideOnClick === true)  && layout.elementIsChildOfLink(targetElem)){
+        if (autoHideOnClick && layout.elementIsChildOfLink(targetElem) ){
             // Let bubble up - app.js will catch and navigate via handleClick and BigDropdownGroupController will catch and hide menu.
             return false;
         }
@@ -74,7 +74,7 @@ export class BigDropdownContainer extends React.PureComponent {
             return false;
         }
 
-        const elemDataId = targetElem.getAttribute("data-is-form-button");
+        const elemDataId = targetElem.getAttribute("data-handle-click");
         if (elemDataId && elemDataId === "true") {
             targetElem["escalateToAppJs"] = true;
             return false;

--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownContainer.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownContainer.js
@@ -57,9 +57,10 @@ export class BigDropdownContainer extends React.PureComponent {
      * Makes it easier in BigDropdownGroupController to close dropdown on any click in window (outside of menu).
      */
     onBackgroundClick(evt){
+        const { autoHideOnClick = true } = this.props;
         const targetElem = (evt && evt.target) || null;
 
-        if (layout.elementIsChildOfLink(targetElem)){
+        if ((autoHideOnClick === true)  && layout.elementIsChildOfLink(targetElem)){
             // Let bubble up - app.js will catch and navigate via handleClick and BigDropdownGroupController will catch and hide menu.
             return false;
         }
@@ -70,6 +71,12 @@ export class BigDropdownContainer extends React.PureComponent {
         if (Array.isArray(targetElemClassList) && targetElemClassList.indexOf("big-dropdown-menu-background") > -1){
             // Clicked on semi-opaque background - close.
             // Let click event bubble up to be caught by BigDropdownGroupController window click handler and dropdown closed.
+            return false;
+        }
+
+        const elemDataId = targetElem.getAttribute("data-is-form-button");
+        if (elemDataId && elemDataId === "true") {
+            targetElem["escalateToAppJs"] = true;
             return false;
         }
 

--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownGroupController.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownGroupController.js
@@ -72,8 +72,11 @@ export class BigDropdownGroupController extends React.PureComponent {
 
     onCloseDropdown(mouseEvt = null, cb){
         if (mouseEvt){
-            mouseEvt.stopPropagation && mouseEvt.stopPropagation();
-            mouseEvt.preventDefault && mouseEvt.preventDefault();
+            const escalateToAppJs = mouseEvt.target && mouseEvt.target.escalateToAppJs && mouseEvt.target.escalateToAppJs === true;
+            if (!escalateToAppJs) {
+                mouseEvt.stopPropagation && mouseEvt.stopPropagation();
+                mouseEvt.preventDefault && mouseEvt.preventDefault();
+            }
         }
         this.setState(function({ visibleDropdownID, closingDropdown }){
             if (visibleDropdownID === null && !closingDropdown) return null;

--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownNavItem.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownNavItem.js
@@ -79,6 +79,7 @@ export class BigDropdownNavItem extends React.PureComponent {
             visibleDropdownID,
             closingDropdownID,
             className = null,
+            autoHideOnClick,
             ...passProps
         } = this.props;
         const { windowHeight, windowWidth } = passProps;
@@ -120,7 +121,7 @@ export class BigDropdownNavItem extends React.PureComponent {
 
         const dropdownContainerProps = {
             href, overlaysContainer, id, open, closing,
-            isDesktopView, testWarningVisible,
+            isDesktopView, testWarningVisible, autoHideOnClick,
             windowWidth, windowHeight,
             'onClose' : this.onCloseDropdown,
             'onToggle': this.handleToggle,

--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownPageTreeMenu.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownPageTreeMenu.js
@@ -22,7 +22,7 @@ export function BigDropdownPageTreeMenuIntroduction(props) {
     return (
         <BigDropdownIntroductionWrapper {...{ windowHeight, windowWidth, titleIcon, isActive }}>
             <h4 className="mt-0 mb-0">
-                <a href={'/' + pathName}>{ display_title }</a>
+                <a href={'/' + pathName} data-handle-click={true}>{ display_title }</a>
             </h4>
             { description ? <div className="description">{ description }</div> : null }
         </BigDropdownIntroductionWrapper>

--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -1,8 +1,11 @@
 'use strict';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import Nav from 'react-bootstrap/esm/Nav';
+import DropdownItem from 'react-bootstrap/esm/DropdownItem';
+import DropdownButton from 'react-bootstrap/esm/DropdownButton';
 import url from 'url';
+import _ from 'underscore';
 import { console, memoizedUrlParse } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { navigate } from './../../util'; // Extended w. browseBaseHref & related fxns.
 import {
@@ -23,6 +26,7 @@ export const LeftNav = React.memo(function LeftNav(props){
             <ToolsNavItem {...props} />
             <ResourcesNavItem {...props} />
             <HelpNavItem {...props} />
+            <SearchNavItem {...props} />
         </Nav>
     );
 });
@@ -164,5 +168,114 @@ const DataNavItemBody = React.memo(function DataNavItemBody(props) {
             </BigDropdownBigLink>
 
         </React.Fragment>
+    );
+});
+
+function SearchNavItem(props){
+    const { href, browseBaseState, ...navItemProps } = props;
+
+    /** @see https://reactjs.org/docs/hooks-reference.html#usememo */
+    const bodyProps = useMemo(function(){
+        // Figure out if any items are active
+        const { query = {}, pathname = "/a/b/c/d/e" } = memoizedUrlParse(href);
+
+        const browseHref = navigate.getBrowseBaseHref(browseBaseState);
+        const searchHref = "/search/?type=Item";
+        const isSearchActive = pathname === "/search/";
+        const isBrowseActive = pathname === "/browse/";
+        const isAnyActive = (isSearchActive || isBrowseActive);
+        return {
+            browseHref, searchHref, isAnyActive, isSearchActive, isBrowseActive
+        };
+    }, [ href, browseBaseState ]);
+
+    const navLink = (
+        <React.Fragment>
+            <span className="border border-secondary rounded p-2 ml-8">
+                <span className="text-black" style={{ display: 'inline-block', fontSize: '1rem', width: '150px' }}>Search ...</span>
+                <i className="icon icon-fw icon-search fas mr-05 align-middle" style={{ color: '#22656d' }} />
+            </span>
+        </React.Fragment>
+    );
+
+    return ( // `navItemProps` contains: href, windowHeight, windowWidth, isFullscreen, testWarning, mounted, overlaysContainer
+        <BigDropdownNavItem {...navItemProps} id="search-menu-item" navItemHref="/search" navItemContent={navLink}
+            active={false} autoHideOnClick={false}>
+            <SearchNavItemBody {...bodyProps} />
+        </BigDropdownNavItem>
+    );
+}
+
+const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
+    const [ searchText, setSearchText ] = useState('');
+    const [ searchItemType, setSearchItemType ] = useState(null);
+    const {
+        browseHref,
+        searchHref,
+        isSearchActive = false,
+        isBrowseActive = false,
+        ...passProps
+    } = props;
+
+    const onChangeSearchItemType = useCallback((evtKey) => {
+        if (typeof evtKey === 'string') {
+            setSearchItemType(evtKey);
+        }
+    });
+
+    return (//Form submission gets serialized and AJAXed via onSubmit handlers in App.js
+        <React.Fragment>
+            <h4>Search</h4>
+            <form action={'/search/'} method="GET" className="form-inline navbar-search-form-container">
+                <div className="container">
+                    <div className="row">
+                        <div className="col-3">
+                            <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
+                        </div>
+                        <div className="form-inputs-container description col-8">
+                            <input type="search" className="form-control search-query w-100" placeholder="Search 4DN Data Portal" name="q"
+                                value={searchText} onChange={function (e) { setSearchText(e.target.value); }} />
+                        </div>
+                        <div className="form-visibility-toggle col-1">
+                            <button type="submit" className="btn btn-outline-light" data-id="global-search-button" data-is-form-button={true}>
+                                <i className="icon icon-fw icon-search fas" data-id="global-search-button-icon" data-is-form-button={true} />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <input type="hidden" name="type" value={searchItemType} key="type" />
+            </form>
+        </React.Fragment>
+    );
+});
+
+const AvailableSearchItemTypes = [
+    { type: 'Item', text: 'General (All Item Types)' },
+    { type: 'ExperimentSetReplicate', text: 'Experiment Sets' },
+    { type: 'Publication', text: 'Publications' },
+    { type: 'File', text: 'Files' },
+    { type: 'QualityMetric', text: 'Quality Metrics' },
+    { type: 'Biosource', text: 'Biosources' },
+];
+
+const SelectItemTypeDropdownBtn = React.memo(function SelectItemTypeDropdownBtn(props){
+    const { currentAction, searchItemType, onChangeSearchItemType, onToggleSearchItemType, href, getDropdownTitleText, disabled = true } = props;
+    const selectedItem = _.find(AvailableSearchItemTypes, (item) => item.type == searchItemType);
+
+    return (
+        <div className="search-item-type-wrapper">
+            <DropdownButton id="search-item-type-selector" size="l" variant="outline-light w-100" disabled={disabled}
+                title={searchItemType == null ? 'Search in specific type ...' : selectedItem.text} >
+                {
+                    AvailableSearchItemTypes.map(function (item) {
+                        return (
+                            <DropdownItem key={item.type} eventKey={item.type} data-key={item.type}
+                                className="w-100" onSelect={onChangeSearchItemType} active={searchItemType == item.type}>
+                                {item.text}
+                            </DropdownItem>);
+                    })
+                }
+            </DropdownButton>
+        </div>
     );
 });

--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -188,9 +188,9 @@ function SearchNavItem(props){
 
     const navLink = (
         <React.Fragment>
-            <span className="border border-secondary rounded p-2 ml-8">
-                <span className="text-black" style={{ display: 'inline-block', fontSize: '1rem', width: '150px' }}>Search ...</span>
-                <i className="icon icon-fw icon-search fas mr-05 align-middle" style={{ color: '#22656d' }} />
+            <span className="border border-secondary rounded p-2 ml-lg-5">
+                <span className="d-inline-block text-black">Search ...</span>
+                <i className="icon icon-fw icon-search fas align-middle" />
             </span>
         </React.Fragment>
     );
@@ -239,7 +239,7 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
             case 'Item':
                 return 'Search 4DN Data Portal';
             case 'ByAccession':
-                return 'Type item\'s accession (e.g. 4DNXXXX ...)';
+                return 'Type Item\'s Accession (e.g. 4DNXXXX ...)';
             default:
                 return "Search in " + AvailableSearchItemTypes[searchItemType].text;
         }
@@ -268,15 +268,15 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
             <form action={action} method="GET" className="form-inline navbar-search-form-container" onSubmit={navigateByAccession}>
                 <div className="container">
                     <div className="row">
-                        <div className="col-3">
+                        <div className="col-lg-3 col-md-4 col-sm-12 mt-1">
                             <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
                         </div>
-                        <div className="form-inputs-container description col-8">
+                        <div className="form-inputs-container description col-lg-8 col-md-6 col-sm-12 mt-1">
                             <input type="search" className="form-control search-query w-100" placeholder={getSearchTextPlaceholder()} name="q"
                                 value={searchText} onChange={function (e) { setSearchText(e.target.value); }} onFocus={handleFocus} />
                         </div>
-                        <div className="form-visibility-toggle col-1">
-                            <button type="submit" className="btn btn-outline-light" data-id="global-search-button" data-is-form-button={true} disabled={btnDisabled}>
+                        <div className="form-visibility-toggle col-lg-1 col-md-2 col-sm-12 mt-1">
+                            <button type="submit" className="btn btn-outline-light w-100" data-id="global-search-button" data-is-form-button={true} disabled={btnDisabled}>
                                 <i className={btnIconClassName} data-id="global-search-button-icon" data-is-form-button={true} />
                             </button>
                         </div>
@@ -313,9 +313,8 @@ const SelectItemTypeDropdownBtn = React.memo(function SelectItemTypeDropdownBtn(
 const AvailableSearchItemTypes = {
     'Item': { type: 'Item', text: 'General (All Item Types)' },
     'ByAccession': { type: 'ByAccession', text: "By Accession" },
-    'ExperimentSetReplicate': { type: 'ExperimentSetReplicate', text: 'Experiment Set Replicates', action: '/browse' },
+    'ExperimentSetReplicate': { type: 'ExperimentSetReplicate', text: 'Experiment Sets', action: '/browse' },
     'Publication': { type: 'Publication', text: 'Publications' },
     'File': { type: 'File', text: 'Files' },
-    'QualityMetric': { type: 'QualityMetric', text: 'Quality Metrics' },
     'Biosource': { type: 'Biosource', text: 'Biosources' },
 };

--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import Nav from 'react-bootstrap/esm/Nav';
 import DropdownItem from 'react-bootstrap/esm/DropdownItem';
 import DropdownButton from 'react-bootstrap/esm/DropdownButton';
@@ -206,6 +206,13 @@ function SearchNavItem(props){
 const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
     const { searchQueryFromHref, searchTypeFromHref } = props;
 
+    const searchTextInputEl = useRef(null);
+    useEffect(() => {
+        if (searchTextInputEl && searchTextInputEl.current) {
+            searchTextInputEl.current.focus();
+        }
+    }, []);
+
     const initialItemType = AvailableSearchItemTypes[searchTypeFromHref] ? searchTypeFromHref : 'Item';
     const [searchText, setSearchText] = useState(searchQueryFromHref || '');
     const [searchItemType, setSearchItemType] = useState(initialItemType);
@@ -284,6 +291,7 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
     const action = (selectedItem && selectedItem.action) || '/search';
     const btnIconClassName = 'icon icon-fw fas ' + (searchItemType === 'ByAccession' ? 'icon-arrow-right' : 'icon-search');
     const btnDisabled = !(searchText &&  typeof searchText === 'string' && searchText.length > 0);
+    const searchTextClassName = 'form-control search-query w-100' + (!searchInputIsValid ? ' border border-danger' : '');
 
     return (//Form submission gets serialized and AJAXed via onSubmit handlers in App.js
         <React.Fragment>
@@ -295,8 +303,8 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
                             <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
                         </div>
                         <div className="form-inputs-container description col-lg-8 col-md-6 col-sm-12 mt-1">
-                            <input type="search" className={"form-control search-query w-100" + (!searchInputIsValid ? ' border border-danger' : '')} placeholder={getSearchTextPlaceholder()} name="q"
-                                value={searchText} onChange={handleOnChange} onFocus={handleFocus} key="global-search-input" id="global-search-input" autoComplete="off" />
+                            <input type="search" key="global-search-input" name="q" className={searchTextClassName} placeholder={getSearchTextPlaceholder()}
+                                value={searchText} onChange={handleOnChange} onFocus={handleFocus} autoComplete="off" ref={searchTextInputEl} />
                         </div>
                         <div className="form-visibility-toggle col-lg-1 col-md-2 col-sm-12 mt-1">
                             <button type="submit" className="btn btn-outline-light w-100" data-id="global-search-button" data-is-form-button={true} disabled={btnDisabled}>

--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -6,7 +6,7 @@ import DropdownItem from 'react-bootstrap/esm/DropdownItem';
 import DropdownButton from 'react-bootstrap/esm/DropdownButton';
 import url from 'url';
 import _ from 'underscore';
-import { console, memoizedUrlParse } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
+import { object, console, memoizedUrlParse } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { navigate } from './../../util'; // Extended w. browseBaseHref & related fxns.
 import {
     BigDropdownNavItem,
@@ -209,10 +209,20 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
     const initialItemType = AvailableSearchItemTypes[searchTypeFromHref] ? searchTypeFromHref : 'Item';
     const [searchText, setSearchText] = useState(searchQueryFromHref || '');
     const [searchItemType, setSearchItemType] = useState(initialItemType);
+    const [searchInputIsValid, setSearchInputIsValid] = useState(true);
 
     const onChangeSearchItemType = useCallback(function (evtKey) {
         if (typeof evtKey === 'string') {
             setSearchItemType(evtKey);
+
+            //validate accession
+            let isValid = true;
+            if (evtKey === 'ByAccession') {
+                isValid = object.isAccessionRegex(searchText);
+            }
+            if (searchInputIsValid !== isValid) {
+                setSearchInputIsValid(isValid);
+            }
         }
     });
     //render hidden form inputs
@@ -252,6 +262,19 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
             navigate('/' + searchText);
         }
     });
+    const handleOnChange = useCallback(function (evt) {
+        const value = evt.target.value;
+        setSearchText(value);
+
+        //validate accession
+        let isValid = true;
+        if (searchItemType === 'ByAccession') {
+            isValid = object.isAccessionRegex(value);
+        }
+        if (searchInputIsValid !== isValid) {
+            setSearchInputIsValid(isValid);
+        }
+    });
     //select all text when focused
     const handleFocus = useCallback(function (evt) {
         evt.target.select();
@@ -272,8 +295,8 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
                             <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
                         </div>
                         <div className="form-inputs-container description col-lg-8 col-md-6 col-sm-12 mt-1">
-                            <input type="search" className="form-control search-query w-100" placeholder={getSearchTextPlaceholder()} name="q"
-                                value={searchText} onChange={function (e) { setSearchText(e.target.value); }} onFocus={handleFocus} />
+                            <input type="search" className={"form-control search-query w-100" + (!searchInputIsValid ? ' border border-danger' : '')} placeholder={getSearchTextPlaceholder()} name="q"
+                                value={searchText} onChange={handleOnChange} onFocus={handleFocus} key="global-search-input" id="global-search-input" autoComplete="off" />
                         </div>
                         <div className="form-visibility-toggle col-lg-1 col-md-2 col-sm-12 mt-1">
                             <button type="submit" className="btn btn-outline-light w-100" data-id="global-search-button" data-is-form-button={true} disabled={btnDisabled}>

--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -224,22 +224,9 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
     const [searchItemType, setSearchItemType] = useState(initialItemType);
     const [searchInputIsValid, setSearchInputIsValid] = useState(true);
 
-    const onChangeSearchItemType = useCallback(function (evtKey) {
-        if (typeof evtKey === 'string') {
-            setSearchItemType(evtKey);
-
-            //validate accession
-            let isValid = true;
-            if (evtKey === 'ByAccession') {
-                isValid = object.isAccessionRegex(searchText);
-            }
-            if (searchInputIsValid !== isValid) {
-                setSearchInputIsValid(isValid);
-            }
-        }
-    });
-    //render hidden form inputs
-    const renderHiddenInputsForURIQuery = useCallback(function () {
+    //hidden form inputs & search placeholder text
+    const [hiddenInputsForURIQuery, placeholderText] = useMemo(function () {
+        // hiddenInputsForURIQuery
         const query = {};
         switch (searchItemType) {
             case 'ExperimentSetReplicate': {
@@ -254,28 +241,49 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
             }
                 break;
         }
-        return SearchBar.renderHiddenInputsForURIQuery(query);
-    });
-    //custom placeholder text for search item type
-    const getSearchTextPlaceholder = useCallback(function () {
+        const hiddenInputsForURIQuery = SearchBar.renderHiddenInputsForURIQuery(query);
+
+        //placeholder text
+        let placeholderText = '';
         switch (searchItemType) {
             case 'Item':
-                return 'Search in All Items';
+                placeholderText = 'Search in All Items';
+                break;
             case 'ByAccession':
-                return 'Type Item\'s Accession (e.g. 4DNXXXX ...)';
+                placeholderText = 'Type Item\'s Accession (e.g. 4DNXXXX ...)';
+                break;
             default:
-                return "Search in " + AvailableSearchItemTypes[searchItemType].text;
+                placeholderText = "Search in " + AvailableSearchItemTypes[searchItemType].text;
+                break;
+        }
+
+        return [hiddenInputsForURIQuery, placeholderText];
+    }, [searchItemType]);
+    //handler for search item selection
+    const onChangeSearchItemType = useCallback(function (evtKey) {
+        if (typeof evtKey === 'string') {
+            setSearchItemType(evtKey);
+
+            //validate accession
+            let isValid = true;
+            if (evtKey === 'ByAccession') {
+                isValid = object.isAccessionRegex(searchText);
+            }
+            if (searchInputIsValid !== isValid) {
+                setSearchInputIsValid(isValid);
+            }
         }
     });
     //navigate to Item page directly without searching
-    const navigateByAccession = useCallback(function (evt) {
+    const navigateByAccession = function (evt) {
         if (searchItemType === 'ByAccession') {
             evt.preventDefault();
             evt.stopPropagation();
             navigate('/' + searchText);
         }
-    });
-    const handleOnChange = useCallback(function (evt) {
+    };
+    //handler for search text change
+    const handleOnChange = function (evt) {
         const value = evt.target.value;
         setSearchText(value);
 
@@ -287,11 +295,11 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
         if (searchInputIsValid !== isValid) {
             setSearchInputIsValid(isValid);
         }
-    });
+    };
     //select all text when focused
-    const handleFocus = useCallback(function (evt) {
+    const handleFocus = function (evt) {
         evt.target.select();
-    });
+    };
 
     const selectedItem = AvailableSearchItemTypes[searchItemType];
     const action = (selectedItem && selectedItem.action) || '/search';
@@ -308,7 +316,7 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
                         <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
                     </div>
                     <div className="col-lg-8 col-md-6 col-sm-12 mt-1">
-                        <input type="search" key="global-search-input" name="q" className={searchTextClassName} placeholder={getSearchTextPlaceholder()}
+                        <input type="search" key="global-search-input" name="q" className={searchTextClassName} placeholder={placeholderText}
                             value={searchText} onChange={handleOnChange} onFocus={handleFocus} autoComplete="off" ref={searchTextInputEl} />
                     </div>
                     <div className="col-lg-1 col-md-2 col-sm-12 mt-1">
@@ -317,7 +325,7 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
                         </button>
                     </div>
                 </div>
-                {renderHiddenInputsForURIQuery()}
+                {hiddenInputsForURIQuery}
             </form>
         </React.Fragment>
     );

--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -15,7 +15,7 @@ import {
     BigDropdownPageTreeMenuIntroduction,
     BigDropdownBigLink
 } from './BigDropdown';
-import { SearchBar } from '.';
+import { SearchBar } from './SearchBar';
 
 
 export const LeftNav = React.memo(function LeftNav(props){
@@ -291,22 +291,22 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
     const action = (selectedItem && selectedItem.action) || '/search';
     const btnIconClassName = 'icon icon-fw fas ' + (searchItemType === 'ByAccession' ? 'icon-arrow-right' : 'icon-search');
     const btnDisabled = !(searchText &&  typeof searchText === 'string' && searchText.length > 0);
-    const searchTextClassName = 'form-control search-query w-100' + (!searchInputIsValid ? ' border border-danger' : '');
+    const searchTextClassName = 'form-control' + (!searchInputIsValid ? ' border border-danger' : '');
 
     return (//Form submission gets serialized and AJAXed via onSubmit handlers in App.js
         <React.Fragment>
             <h4>Search</h4>
-            <form action={action} method="GET" className="form-inline navbar-search-form-container" onSubmit={navigateByAccession}>
+            <form action={action} method="GET" className="navbar-search-form-container" onSubmit={navigateByAccession}>
                 <div className="container">
                     <div className="row">
                         <div className="col-lg-3 col-md-4 col-sm-12 mt-1">
                             <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
                         </div>
-                        <div className="form-inputs-container description col-lg-8 col-md-6 col-sm-12 mt-1">
+                        <div className="col-lg-8 col-md-6 col-sm-12 mt-1">
                             <input type="search" key="global-search-input" name="q" className={searchTextClassName} placeholder={getSearchTextPlaceholder()}
                                 value={searchText} onChange={handleOnChange} onFocus={handleFocus} autoComplete="off" ref={searchTextInputEl} />
                         </div>
-                        <div className="form-visibility-toggle col-lg-1 col-md-2 col-sm-12 mt-1">
+                        <div className="col-lg-1 col-md-2 col-sm-12 mt-1">
                             <button type="submit" className="btn btn-outline-light w-100" data-id="global-search-button" data-is-form-button={true} disabled={btnDisabled}>
                                 <i className={btnIconClassName} data-id="global-search-button-icon" data-is-form-button={true} />
                             </button>

--- a/src/encoded/static/components/navigation/components/LeftNav.js
+++ b/src/encoded/static/components/navigation/components/LeftNav.js
@@ -180,9 +180,14 @@ function SearchNavItem(props){
         const hrefParts = memoizedUrlParse(href);
         const searchQueryFromHref = (hrefParts && hrefParts.query && hrefParts.query.q) || '';
         const searchTypeFromHref = (hrefParts && hrefParts.query && hrefParts.query.type) || '';
+        const title = {
+            display_title: 'Search',
+            description: 'Search Items in the 4D Nucleome Database',
+            name: 'search'
+        };
 
         return {
-            searchQueryFromHref, searchTypeFromHref
+            searchQueryFromHref, searchTypeFromHref, title
         };
     }, [ href, browseBaseState ]);
 
@@ -196,21 +201,22 @@ function SearchNavItem(props){
     );
 
     return ( // `navItemProps` contains: href, windowHeight, windowWidth, isFullscreen, testWarning, mounted, overlaysContainer
-        <BigDropdownNavItem {...navItemProps} id="search-menu-item" navItemHref="/search" navItemContent={navLink}
-            active={false} autoHideOnClick={false}>
+        <BigDropdownNavItem {...navItemProps} id="search-menu-item" navItemHref="/search" navItemContent={navLink} autoHideOnClick={false}>
             <SearchNavItemBody {...bodyProps} />
         </BigDropdownNavItem>
     );
 }
 
 const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
-    const { searchQueryFromHref, searchTypeFromHref } = props;
+    const { searchQueryFromHref, searchTypeFromHref, title } = props;
 
     const searchTextInputEl = useRef(null);
     useEffect(() => {
-        if (searchTextInputEl && searchTextInputEl.current) {
-            searchTextInputEl.current.focus();
-        }
+        setTimeout(() => {
+            if (searchTextInputEl && searchTextInputEl.current) {
+                searchTextInputEl.current.focus();
+            }
+        }, 350);
     }, []);
 
     const initialItemType = AvailableSearchItemTypes[searchTypeFromHref] ? searchTypeFromHref : 'Item';
@@ -254,7 +260,7 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
     const getSearchTextPlaceholder = useCallback(function () {
         switch (searchItemType) {
             case 'Item':
-                return 'Search 4DN Data Portal';
+                return 'Search in All Items';
             case 'ByAccession':
                 return 'Type Item\'s Accession (e.g. 4DNXXXX ...)';
             default:
@@ -295,22 +301,20 @@ const SearchNavItemBody = React.memo(function SearchNavItemBody(props) {
 
     return (//Form submission gets serialized and AJAXed via onSubmit handlers in App.js
         <React.Fragment>
-            <h4>Search</h4>
+            <BigDropdownPageTreeMenuIntroduction titleIcon="search fas" menuTree={title} />
             <form action={action} method="GET" className="navbar-search-form-container" onSubmit={navigateByAccession}>
-                <div className="container">
-                    <div className="row">
-                        <div className="col-lg-3 col-md-4 col-sm-12 mt-1">
-                            <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
-                        </div>
-                        <div className="col-lg-8 col-md-6 col-sm-12 mt-1">
-                            <input type="search" key="global-search-input" name="q" className={searchTextClassName} placeholder={getSearchTextPlaceholder()}
-                                value={searchText} onChange={handleOnChange} onFocus={handleFocus} autoComplete="off" ref={searchTextInputEl} />
-                        </div>
-                        <div className="col-lg-1 col-md-2 col-sm-12 mt-1">
-                            <button type="submit" className="btn btn-outline-light w-100" data-id="global-search-button" data-is-form-button={true} disabled={btnDisabled}>
-                                <i className={btnIconClassName} data-id="global-search-button-icon" data-is-form-button={true} />
-                            </button>
-                        </div>
+                <div className="row">
+                    <div className="col-lg-3 col-md-4 col-sm-12 mt-1">
+                        <SelectItemTypeDropdownBtn {...{ searchItemType }} disabled={false} onChangeSearchItemType={onChangeSearchItemType} />
+                    </div>
+                    <div className="col-lg-8 col-md-6 col-sm-12 mt-1">
+                        <input type="search" key="global-search-input" name="q" className={searchTextClassName} placeholder={getSearchTextPlaceholder()}
+                            value={searchText} onChange={handleOnChange} onFocus={handleFocus} autoComplete="off" ref={searchTextInputEl} />
+                    </div>
+                    <div className="col-lg-1 col-md-2 col-sm-12 mt-1">
+                        <button type="submit" className="btn btn-outline-light w-100" data-id="global-search-button" data-handle-click={true} disabled={btnDisabled}>
+                            <i className={btnIconClassName} data-id="global-search-button-icon" data-handle-click={true} />
+                        </button>
                     </div>
                 </div>
                 {renderHiddenInputsForURIQuery()}

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -1300,6 +1300,14 @@ body[data-pathname="/search/"][data-current-action="multiselect"] {
                 .dropdown-menu {
                     width: 100%;
                 }
+                input[type="search"] {
+                    &::-webkit-search-cancel-button {
+                        display: none;
+                    }
+                    &.border-danger {
+                        border-width: 2px !important;
+                    }
+                }
             }
 
 		}

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -53,6 +53,20 @@ $navbar-link-hover-bg: #d7d7d7 !default;
         }
     }
 
+    &.id-search-menu-item {
+        &:hover {
+            color: $navbar-link-active-color !important; /* Set in _base.scss */
+            text-shadow: 0 0 0 0;
+            background-color: transparent !important;
+        }
+        &.dropdown-open-for {
+            display: none;
+        }
+        &.dropdown-toggle:after {
+            content: none;
+        }
+    }
+
     &[disabled] {
         color: $gray-300;
 
@@ -1271,6 +1285,13 @@ body[data-pathname="/search/"][data-current-action="multiselect"] {
                         visibility: hidden;
                         transition: visibility 0s 0.01s;
                     }
+                }
+            }
+
+            > .big-dropdown-menu[data-open-id="search-menu-item"] {
+                overflow-y: unset;
+                .dropdown-menu {
+                    width: 100%;
                 }
             }
 

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -65,6 +65,13 @@ $navbar-link-hover-bg: #d7d7d7 !default;
         &.dropdown-toggle:after {
             content: none;
         }
+        .icon-search {
+            color: $primary-dark;
+        }
+        > span > span.text-black {
+            font-size: 1rem;
+            width: 90%;
+        }
     }
 
     &[disabled] {


### PR DESCRIPTION
**Trello:** https://trello.com/c/lBg8kPJ8

1. Top Search Bar's single search icon is replaced with search text box to make it more prominent.

![resim](https://user-images.githubusercontent.com/49978017/148776149-afec7017-02e8-408d-8b53-1fdc9998ede1.png)

2. When a user clicks the search text in the top search bar, a form that includes a search type dropdown and a text box is displayed in the big drop-down menu. 

![resim](https://user-images.githubusercontent.com/49978017/148776904-5ce8ec59-e5a1-43aa-97cc-613868572cb4.png)

3. While Experiment Sets navigates search to /browse, the other search types' endpoint is a /search query. (By Accession is an exception, that navigates to the Item page directly.)

<img width="1175" alt="Screen Shot 2022-01-10 at 16 54 26" src="https://user-images.githubusercontent.com/49978017/148777470-fdb79ae6-e35c-4f16-b703-755ad8f8cd15.png">

4. Mobile display
<img width="379" alt="Screen Shot 2022-01-10 at 16 56 32" src="https://user-images.githubusercontent.com/49978017/148777726-f8ad4071-3ee2-44e1-a80f-8506e5f12297.png">

