### PR TITLE
md5 for reference files can be non-unique

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.4.7"
+version = "3.5.0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -1142,6 +1142,13 @@ class FileReference(File):
     embedded_list = File.embedded_list
     name_key = 'accession'
 
+    # reference files don't want md5 as unique key
+    def unique_keys(self, properties):
+        keys = super(FileReference, self).unique_keys(properties)
+        if keys.get('alias'):
+            keys['alias'] = [k for k in keys['alias'] if not k.startswith('md5:')]
+        return keys
+
 
 @collection(
     name='files-vistrack',
@@ -1699,10 +1706,10 @@ def validate_file_filename(context, request):
 
 
 def validate_processed_file_unique_md5_with_bypass(context, request):
-    '''validator to check md5 on processed files, unless you tell it
-       not to'''
-    # skip validator if not file processed
-    if context.type_info.item_type != 'file_processed':
+    '''validator to check md5 on processed files and reference files, unless
+    you tell it not to'''
+    # skip validator if not file processed or file reference
+    if context.type_info.item_type not in ['file_processed', 'file_reference']:
         return
     data = request.json
     if 'md5sum' not in data or not data['md5sum']:


### PR DESCRIPTION
One use case is restriction sites Reference Files. For isoschizomers (different enzymes that recognize the same sequence), we end up with identical Reference Files. Therefore, it seems reasonable to allow having duplicate Reference Files, similar to what is currently happening with Processed Files.