### PR TITLE
get the latest biorxiv version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.5.5"
+version = "3.5.6"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/publication.py
+++ b/src/encoded/types/publication.py
@@ -129,7 +129,7 @@ def fetch_biorxiv(url, doi):
             break
         if count == 4:
             return
-    record_dict = r.json()['collection'][0]
+    record_dict = r.json()['collection'][-1]  # get latest version
     pub_data = {k: record_dict.get(v) for k,v in fdn2biorxiv.items() if record_dict.get(v)}
     if pub_data.get('authors'):  # format authors according to 4DN schema
         pub_data['authors'] = [a.strip() for a in pub_data['authors'].split(";") if a]


### PR DESCRIPTION
Biorxiv records with multiple versions list them in order, with the most recent at the end. We should be getting the last, instead of the first one. When a publication item is re-indexed, it should be updated with the latest biorxiv version.