### PR TITLE
Add organism calcprop to biosource

### DIFF
--- a/deploy/post_deploy_testing/cypress/integration/03b_browse_views_barplot_as_filter_control.js
+++ b/deploy/post_deploy_testing/cypress/integration/03b_browse_views_barplot_as_filter_control.js
@@ -33,7 +33,7 @@ describe('Browse Views - BarPlotChart & QuickInfoBar I', function () {
                                 .get('.cursor-component-root .actions.buttons-container .btn-primary').should('contain', "Explore").click({ force: true }).end() // Browser will scroll after click itself (e.g. triggered by app)
                                 .location('search')
                                 .should('include', 'experiments_in_set.experiment_type.display_title=2-stage+Repli-seq')
-                                .should('include', 'experiments_in_set.biosample.biosource.individual.organism.name=human').wait(300).end()
+                                .should('include', 'experiments_in_set.biosample.biosource.organism.name=human').wait(300).end()
                                 .get('#slow-load-container').should('not.have.class', 'visible').end()
                                 .get('.search-results-container .search-result-row[data-row-number]').should('have.length', expectedFilteredResults).end()
                                 .getQuickInfoBarCounts({ 'shouldNotEqual' : '' + origCount.experiment_sets }).its('experiment_sets').should('not.equal', origCount.experiment_sets).should('equal', expectedFilteredResults).end()
@@ -58,7 +58,7 @@ describe('Browse Views - BarPlotChart & QuickInfoBar I', function () {
                                 .get('.bar-plot-chart .chart-bar .bar-part').should('have.length.greaterThan', unfilteredOnceBarPartCount)
                                 .getQuickInfoBarCounts().its('experiment_sets').should('be.greaterThan', unfilteredOnceExpSetCount).end()
                                 .location('search').should('include', 'experimentset_type=replicate')
-                                .should('not.include', 'experiments_in_set.experiment_type.display_title=2-stage+Repli-seq').should('not.include', 'experiments_in_set.biosample.biosource.individual.organism.name=human');
+                                .should('not.include', 'experiments_in_set.experiment_type.display_title=2-stage+Repli-seq').should('not.include', 'experiments_in_set.biosample.biosource.organism.name=human');
                         });
                     });
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1502,8 +1502,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#a31d01693d86c199f38c10460ddcd8842bf6289e",
-      "from": "github:4dn-dcic/shared-portal-components#0.1.30",
+      "version": "github:4dn-dcic/shared-portal-components#e9783144bd7f4f66bba041f01d62733fd6a10ad3",
+      "from": "github:4dn-dcic/shared-portal-components#0.1.35b1",
       "requires": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.8",
         "@sentry/react": "^6.8.0",
@@ -1522,12 +1522,12 @@
       },
       "dependencies": {
         "html-react-parser": {
-          "version": "1.4.5",
-          "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.5.tgz",
-          "integrity": "sha512-dxo0z1G9b3mS1VGmcVw4cUGwVsEwkJZZ7r29pOSdE69JukJyFTCL1I6TXSEp2p1LAHvuO6ZBiEVp2M5lXqKLAg==",
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.8.tgz",
+          "integrity": "sha512-5XsBdFVhJLxdtRp7tWwZ6DwqOt6fJ+2lJc0lctwjX1yaxWNB41S5uzqii7vJcSCaabM+CK28U75e5f4wIMqdSg==",
           "requires": {
             "domhandler": "4.3.0",
-            "html-dom-parser": "1.0.4",
+            "html-dom-parser": "1.1.0",
             "react-property": "2.0.0",
             "style-to-js": "1.1.0"
           }
@@ -4031,84 +4031,84 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.16.1.tgz",
-      "integrity": "sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==",
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.17.7.tgz",
+      "integrity": "sha512-0Ad6TmB5KH5o152Hgk5tlxNiooV0Rfoj7HEzxdOnHFkl57aR7VsiPkzIBl9vxn4iyy7IheUONhHSOU1osJkv2w==",
       "requires": {
-        "@sentry/core": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/core": "6.17.7",
+        "@sentry/types": "6.17.7",
+        "@sentry/utils": "6.17.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz",
-      "integrity": "sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==",
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.7.tgz",
+      "integrity": "sha512-SRhLkD05lQb4eCt1ed9Dz72DKbRDlM8PJix8eC2oJLtwyFTS0IlJNkIYRrbsSKkJUm0VsKcDkzIHvUAgBBQICw==",
       "requires": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/hub": "6.17.7",
+        "@sentry/minimal": "6.17.7",
+        "@sentry/types": "6.17.7",
+        "@sentry/utils": "6.17.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.16.1.tgz",
-      "integrity": "sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==",
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.7.tgz",
+      "integrity": "sha512-siGzcg+quGOdjRaBGAz6T3ycwHUsGgvalptSJdf5Q783FVFhU+haPul++zGOYURXOgx0RjYGWqagwO8+jljl3Q==",
       "requires": {
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/types": "6.17.7",
+        "@sentry/utils": "6.17.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.16.1.tgz",
-      "integrity": "sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==",
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.7.tgz",
+      "integrity": "sha512-+/FGem1uXsXikX9wHPw44nevO7YTVjkkiPjyLsvnWMjv64r4Au5s+NQSFHDaytRm9IlU//+OasCAS5VAwHcYRg==",
       "requires": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/types": "6.16.1",
+        "@sentry/hub": "6.17.7",
+        "@sentry/types": "6.17.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/react": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.16.1.tgz",
-      "integrity": "sha512-n8fOEKbym4kBi946q3AWXBNy1UKTmABj/hE2nAJbTWhi5IwdM7WBG6QCT2yq7oTHLuTxQrAwgKQc+A6zFTyVHg==",
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.17.7.tgz",
+      "integrity": "sha512-rt6nAa9SJ+A4va88FASBoR5/26V2uZx/yucT9NzwoBIW41jA8lAwTmFu5MdtxGDBKDUSJlL3lt/Nkiq6LkiTaw==",
       "requires": {
-        "@sentry/browser": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/browser": "6.17.7",
+        "@sentry/minimal": "6.17.7",
+        "@sentry/types": "6.17.7",
+        "@sentry/utils": "6.17.7",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/tracing": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.16.1.tgz",
-      "integrity": "sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==",
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.7.tgz",
+      "integrity": "sha512-QzIDHOjjdi/0LTdrK2LTC27YEOODI473KD8KmMJ+r9PmjDeIjNzz4hJlPwQSnXR3Mu/8foxGJGXsAt3LNmKzlQ==",
       "requires": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/hub": "6.17.7",
+        "@sentry/minimal": "6.17.7",
+        "@sentry/types": "6.17.7",
+        "@sentry/utils": "6.17.7",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
-      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ=="
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.7.tgz",
+      "integrity": "sha512-iBlJDhrSowZKeqvutY0tCkUjrWqkLFsHrbaQ553r1Nx+/4mxHjzVYtEVGMjZAxQUEbkm0TbnQIkkT7ltglNJ9A=="
     },
     "@sentry/utils": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
-      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "version": "6.17.7",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.7.tgz",
+      "integrity": "sha512-HEEEeKlZtwfQvH0waSKv5FKRFjHkVgkkEiAigXoYGQAlaUIuwRTvZGFnsmBoKMIrA4pARkA00FwwdtMU7ziC8A==",
       "requires": {
-        "@sentry/types": "6.16.1",
+        "@sentry/types": "6.17.7",
         "tslib": "^1.9.3"
       }
     },
@@ -5204,14 +5204,14 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1060.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1060.0.tgz",
-      "integrity": "sha512-c734/CZiVSsuVnEkx/7dodI8ndgOnxiCTwwlEFlMxdAZfLLJplteFwi6c/J2GZQktvz2ysV/HVtNKcJkasYJzw==",
+      "version": "2.1073.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1073.0.tgz",
+      "integrity": "sha512-TtyHDL4ZEs8Zh/DqWY/hv745DTWrIwOyBAvfjBJ45RE9h0TjpWqCIowEtb6gRPAKyPPyfGH4s+rEYu07vNK1Hg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -9690,7 +9690,8 @@
           }
         },
         "estraverse": {
-          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
           "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
         },
         "glob-parent": {
@@ -13131,9 +13132,9 @@
       "dev": true
     },
     "html-dom-parser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.0.4.tgz",
-      "integrity": "sha512-ThM/vK/18R5/cVB9UsqhNqbJU7LE2BmSA7C/FjYV88wIDW75GSUpvSE/JxE4mJ8bOuU6Kp15/I1giM2JbD+ieA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.1.0.tgz",
+      "integrity": "sha512-x3MOz8S8BkihGgggtp2N0U+JAWlD9iGERbjuBJH+gIGF9B1kGQh5x489IQ0YPqi8HyMIWCRLdJY1q3IaQlqG/Q==",
       "requires": {
         "domhandler": "4.3.0",
         "htmlparser2": "7.2.0"
@@ -19043,9 +19044,9 @@
       }
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "joi": {
       "version": "13.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1502,8 +1502,8 @@
       }
     },
     "@hms-dbmi-bgm/shared-portal-components": {
-      "version": "github:4dn-dcic/shared-portal-components#e9783144bd7f4f66bba041f01d62733fd6a10ad3",
-      "from": "github:4dn-dcic/shared-portal-components#0.1.35b1",
+      "version": "github:4dn-dcic/shared-portal-components#bcdd23f38c22d752be582d7e5032ff5cc336c57d",
+      "from": "github:4dn-dcic/shared-portal-components#0.1.35",
       "requires": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.8",
         "@sentry/react": "^6.8.0",
@@ -4031,84 +4031,84 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.17.7.tgz",
-      "integrity": "sha512-0Ad6TmB5KH5o152Hgk5tlxNiooV0Rfoj7HEzxdOnHFkl57aR7VsiPkzIBl9vxn4iyy7IheUONhHSOU1osJkv2w==",
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.17.9.tgz",
+      "integrity": "sha512-RsC8GBZmZ3YfBTaIOJ06RlFp5zG7BkUoquNJmf4YhRUZeihT9osrn8qUYGFWSV/UduwKUIlSGJA/rATWWhwPRQ==",
       "requires": {
-        "@sentry/core": "6.17.7",
-        "@sentry/types": "6.17.7",
-        "@sentry/utils": "6.17.7",
+        "@sentry/core": "6.17.9",
+        "@sentry/types": "6.17.9",
+        "@sentry/utils": "6.17.9",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.7.tgz",
-      "integrity": "sha512-SRhLkD05lQb4eCt1ed9Dz72DKbRDlM8PJix8eC2oJLtwyFTS0IlJNkIYRrbsSKkJUm0VsKcDkzIHvUAgBBQICw==",
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.9.tgz",
+      "integrity": "sha512-14KalmTholGUtgdh9TklO+jUpyQ/D3OGkhlH1rnGQGoJgFy2eYm+s+MnUEMxFdGIUCz5kOteuNqYZxaDmFagpQ==",
       "requires": {
-        "@sentry/hub": "6.17.7",
-        "@sentry/minimal": "6.17.7",
-        "@sentry/types": "6.17.7",
-        "@sentry/utils": "6.17.7",
+        "@sentry/hub": "6.17.9",
+        "@sentry/minimal": "6.17.9",
+        "@sentry/types": "6.17.9",
+        "@sentry/utils": "6.17.9",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.7.tgz",
-      "integrity": "sha512-siGzcg+quGOdjRaBGAz6T3ycwHUsGgvalptSJdf5Q783FVFhU+haPul++zGOYURXOgx0RjYGWqagwO8+jljl3Q==",
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.9.tgz",
+      "integrity": "sha512-34EdrweWDbBV9EzEFIXcO+JeoyQmKzQVJxpTKZoJA6PUwf2NrndaUdjlkDEtBEzjuLUTxhLxtOzEsYs1O6RVcg==",
       "requires": {
-        "@sentry/types": "6.17.7",
-        "@sentry/utils": "6.17.7",
+        "@sentry/types": "6.17.9",
+        "@sentry/utils": "6.17.9",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.7.tgz",
-      "integrity": "sha512-+/FGem1uXsXikX9wHPw44nevO7YTVjkkiPjyLsvnWMjv64r4Au5s+NQSFHDaytRm9IlU//+OasCAS5VAwHcYRg==",
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.9.tgz",
+      "integrity": "sha512-T3PMCHcKk6lkZq6zKgANrYJJxXBXKOe+ousV1Fas1rVBMv7dtKfsa4itqQHszcW9shusPDiaQKIJ4zRLE5LKmg==",
       "requires": {
-        "@sentry/hub": "6.17.7",
-        "@sentry/types": "6.17.7",
+        "@sentry/hub": "6.17.9",
+        "@sentry/types": "6.17.9",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/react": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.17.7.tgz",
-      "integrity": "sha512-rt6nAa9SJ+A4va88FASBoR5/26V2uZx/yucT9NzwoBIW41jA8lAwTmFu5MdtxGDBKDUSJlL3lt/Nkiq6LkiTaw==",
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.17.9.tgz",
+      "integrity": "sha512-TYu9Yl+gsNHdt763Yh35rSHJenxXqHSfWA55bYHr8hXDWu0crI/3LDuZb1RONmCM712CaQA+M5tgApA8QbHS4Q==",
       "requires": {
-        "@sentry/browser": "6.17.7",
-        "@sentry/minimal": "6.17.7",
-        "@sentry/types": "6.17.7",
-        "@sentry/utils": "6.17.7",
+        "@sentry/browser": "6.17.9",
+        "@sentry/minimal": "6.17.9",
+        "@sentry/types": "6.17.9",
+        "@sentry/utils": "6.17.9",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/tracing": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.7.tgz",
-      "integrity": "sha512-QzIDHOjjdi/0LTdrK2LTC27YEOODI473KD8KmMJ+r9PmjDeIjNzz4hJlPwQSnXR3Mu/8foxGJGXsAt3LNmKzlQ==",
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.9.tgz",
+      "integrity": "sha512-5Rb/OS4ryNJLvz2nv6wyjwhifjy6veqaF9ffLrwFYij/WDy7m62ASBblxgeiI3fbPLX0aBRFWIJAq1vko26+AQ==",
       "requires": {
-        "@sentry/hub": "6.17.7",
-        "@sentry/minimal": "6.17.7",
-        "@sentry/types": "6.17.7",
-        "@sentry/utils": "6.17.7",
+        "@sentry/hub": "6.17.9",
+        "@sentry/minimal": "6.17.9",
+        "@sentry/types": "6.17.9",
+        "@sentry/utils": "6.17.9",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.7.tgz",
-      "integrity": "sha512-iBlJDhrSowZKeqvutY0tCkUjrWqkLFsHrbaQ553r1Nx+/4mxHjzVYtEVGMjZAxQUEbkm0TbnQIkkT7ltglNJ9A=="
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.9.tgz",
+      "integrity": "sha512-xuulX6qUCL14ayEOh/h6FUIvZtsi1Bx34dSOaWDrjXUOJHJAM7214uiqW1GZxPJ13YuaUIubjTSfDmSQ9CBzTw=="
     },
     "@sentry/utils": {
-      "version": "6.17.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.7.tgz",
-      "integrity": "sha512-HEEEeKlZtwfQvH0waSKv5FKRFjHkVgkkEiAigXoYGQAlaUIuwRTvZGFnsmBoKMIrA4pARkA00FwwdtMU7ziC8A==",
+      "version": "6.17.9",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.9.tgz",
+      "integrity": "sha512-4eo9Z3JlJCGlGrQRbtZWL+L9NnlUXgTbfK3Lk7oO8D1ev8R5b5+iE6tZHTvU5rQRcq6zu+POT+tK5u9oxc/rnQ==",
       "requires": {
-        "@sentry/types": "6.17.7",
+        "@sentry/types": "6.17.9",
         "tslib": "^1.9.3"
       }
     },
@@ -5204,9 +5204,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1073.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1073.0.tgz",
-      "integrity": "sha512-TtyHDL4ZEs8Zh/DqWY/hv745DTWrIwOyBAvfjBJ45RE9h0TjpWqCIowEtb6gRPAKyPPyfGH4s+rEYu07vNK1Hg==",
+      "version": "2.1076.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1076.0.tgz",
+      "integrity": "sha512-V2nLKCPG4mtKNkmET1eQQNHpEdkBF7pW/i05Qg+umTQlbLgaiL9u4vSTbn5xXeDMwejKiz3J2MB2eemV6uRUUg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "micro-meta-app-react": "github:WU-BIMAC/MicroMetaApp-React#0.0.0.21",
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.35b1",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.35",
     "auth0-lock": "^11.30.4",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "micro-meta-app-react": "github:WU-BIMAC/MicroMetaApp-React#0.0.0.21",
     "@fortawesome/fontawesome-free": "^5.14.0",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.4",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.30",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.35b1",
     "auth0-lock": "^11.30.4",
     "babel-polyfill": "^6.26.0",
     "d3": "^5.16.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.5.9"
+version = "3.6.0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/batch_download.py
+++ b/src/encoded/batch_download.py
@@ -64,7 +64,7 @@ TSV_MAPPING = OrderedDict([
     ('Tech Rep No',                 (EXP_SET,   ['replicate_exps.tec_rep_no'], True)),
 
     ('Biosource Type',              (EXP,       ['biosample.biosource.biosource_type'], True)),
-    ('Organism',                    (EXP,       ['biosample.biosource.individual.organism.name'], True)),
+    ('Organism',                    (EXP,       ['biosample.biosource.organism.name'], True)),
     ('Related File Relationship',   (FILE,      ['related_files.relationship_type'], False)),
     ('Related File',                (FILE,      ['related_files.file.accession'], False)),
     ('Paired End',                  (FILE,      ['paired_end'], True)),

--- a/src/encoded/schemas/biosample.json
+++ b/src/encoded/schemas/biosample.json
@@ -152,7 +152,7 @@
         "biosource_summary": {
             "title": "Biosource"
         },
-        "biosource.individual.organism.name": {
+        "biosource.organism.name": {
             "title": "Organism"
         },
         "modifications.modification_type": {
@@ -163,7 +163,7 @@
         }
     },
     "columns": {
-        "biosource.individual.organism.name": {
+        "biosource.organism.name": {
           "title": "Organism"
         },
         "biosource_summary": {

--- a/src/encoded/schemas/biosource.json
+++ b/src/encoded/schemas/biosource.json
@@ -130,6 +130,15 @@
             "description": "A override name for the biosource that can be used as the biosource_name in place of the automatically generated one",
             "type": "string",
             "lookup": 1000
+        },
+        "override_organism_name": {
+            "title": "Organism Name Override",
+            "description": "An override name for the organism that can be used to find an Organism Item if the Biosource is not linked to an Individual",
+            "comment": "To get all the links to work this must be equivalent to the organism.name field",
+            "type": "string",
+            "exclude_from" : ["submit4dn"],
+            "permission": "import_items",
+            "lookup": 1000
         }
     },
     "facets": {
@@ -142,7 +151,7 @@
         "tissue.preferred_name": {
             "title": "Tissue"
         },
-        "individual.organism.name": {
+        "organism_name": {
             "title": "Organism"
         },
         "cell_line_tier": {
@@ -156,7 +165,7 @@
         }
     },
     "columns": {
-        "individual.organism.name": {
+        "organism_name": {
             "title": "Organism"
         },
         "biosource_type": {

--- a/src/encoded/schemas/biosource.json
+++ b/src/encoded/schemas/biosource.json
@@ -138,6 +138,9 @@
             "type": "string",
             "exclude_from" : ["submit4dn"],
             "permission": "import_items",
+            "suggested_enum": [
+                "hamster"
+            ],
             "lookup": 1000
         }
     },

--- a/src/encoded/schemas/biosource.json
+++ b/src/encoded/schemas/biosource.json
@@ -151,7 +151,7 @@
         "tissue.preferred_name": {
             "title": "Tissue"
         },
-        "organism_name": {
+        "organism.name": {
             "title": "Organism"
         },
         "cell_line_tier": {
@@ -165,7 +165,7 @@
         }
     },
     "columns": {
-        "organism_name": {
+        "organism.name": {
             "title": "Organism"
         },
         "biosource_type": {

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -229,7 +229,7 @@
         "experiment_type.display_title" : {
             "title" : "Experiment Type"
         },
-        "biosample.biosource.individual.organism.name": {
+        "biosample.biosource.organism.name": {
             "title": "Organism"
         },
         "biosample.biosample_type": {
@@ -252,7 +252,7 @@
         }
     },
     "columns": {
-        "biosample.biosource.individual.organism.name": {
+        "biosample.biosource.organism.name": {
             "title": "Organism"
         },
         "biosample.biosource.biosource_type": {

--- a/src/encoded/schemas/experiment_set.json
+++ b/src/encoded/schemas/experiment_set.json
@@ -156,7 +156,7 @@
         "dataset_label" : {
             "title" : "Dataset"
         },
-        "experiments_in_set.biosample.biosource.individual.organism.name": {
+        "experiments_in_set.biosample.biosource.organism.name": {
             "title": "Organism"
         },
         "experiments_in_set.biosample.biosample_type": {
@@ -246,7 +246,7 @@
         "experiments_in_set.experiment_categorizer.combined" : {
             "title" : "Assay Details"
         },
-        "experiments_in_set.biosample.biosource.individual.organism.name": {
+        "experiments_in_set.biosample.biosource.organism.name": {
             "title" : "Organism",
             "default_hidden": true
         },

--- a/src/encoded/static/components/browse/columnExtensionMap.js
+++ b/src/encoded/static/components/browse/columnExtensionMap.js
@@ -265,7 +265,7 @@ export const columnExtensionMap = _.extend({}, basicColumnExtensionMap, {
             );
         }
     },
-    'experiments_in_set.biosample.biosource.individual.organism.name' : {
+    'experiments_in_set.biosample.biosource.organism.name' : {
         'widthMap' : { 'lg' : 160, 'md' : 140, 'sm' : 120 }
     },
     'experiments_in_set.biosample.biosource_summary' : {

--- a/src/encoded/static/components/browse/components/FacetCharts.js
+++ b/src/encoded/static/components/browse/components/FacetCharts.js
@@ -46,7 +46,7 @@ export class FacetCharts extends React.PureComponent {
         'views' : ['small', 'large'],
         'initialFields' : [
             'experiments_in_set.experiment_type.display_title',
-            'experiments_in_set.biosample.biosource.individual.organism.name'
+            'experiments_in_set.biosample.biosource.organism.name'
         ]
     };
 

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -191,7 +191,7 @@ const OverviewHeading = React.memo(function OverviewHeading(props){
         <OverviewHeadingContainer {...props}>
             {/* <OverViewBodyItem result={expSet} tips={tips} property='award.project' fallbackTitle="Project" wrapInColumn={col} /> */}
             <OverViewBodyItem {...commonProps} property="experimentset_type" fallbackTitle="Set Type" />
-            <OverViewBodyItem {...commonProps} property="experiments_in_set.biosample.biosource.individual.organism" fallbackTitle="Organism" />
+            <OverViewBodyItem {...commonProps} property="experiments_in_set.biosample.biosource.organism" fallbackTitle="Organism" />
             <OverViewBodyItem {...commonProps} property="experiments_in_set.biosample.biosource.biosource_type" fallbackTitle="Biosource Type" />
             <OverViewBodyItem {...commonProps} property="experiments_in_set.biosample.biosource_summary" fallbackTitle="Biosource" />
 

--- a/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
+++ b/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
@@ -222,7 +222,7 @@ export class ItemPageTable extends React.Component {
             "display_title" : { "title" : "Title" },
             "number_of_experiments" : { "title" : "Exps" },
             "experiments_in_set.experiment_type.display_title": { "title" : "Experiment Type" },
-            "experiments_in_set.biosample.biosource.individual.organism.name": { "title" : "Organism" },
+            "experiments_in_set.biosample.biosource.organism.name": { "title" : "Organism" },
             "experiments_in_set.biosample.biosource_summary": { "title" : "Biosource Summary" },
             "experiments_in_set.experiment_categorizer.combined" : { "title" : "Assay Details" }
         },

--- a/src/encoded/static/components/util/Schemas.js
+++ b/src/encoded/static/components/util/Schemas.js
@@ -73,6 +73,7 @@ export const Term = {
             case 'individual.organism.name':
             case 'biosource.individual.organism.name':
             case 'biosample.biosource.individual.organism.name':
+            case 'biosample.biosource.organism.name':
                 name = capitalize(term);
                 break;
             case 'file_type':
@@ -142,7 +143,7 @@ export const Term = {
 export const Field = {
 
     nameMap : {
-        'experiments_in_set.biosample.biosource.individual.organism.name' : 'Organism',
+        'experiments_in_set.biosample.biosource.organism.name' : 'Organism',
         'accession' : 'Experiment Set',
         'experiments_in_set.digestion_enzyme.name' : 'Enzyme',
         'experiments_in_set.biosample.biosource_summary' : 'Biosource',

--- a/src/encoded/static/components/util/seo.js
+++ b/src/encoded/static/components/util/seo.js
@@ -168,7 +168,7 @@ export class CurrentContext extends React.PureComponent {
                 listOfPropsForKeyWords = [
                     'experiments_in_set.biosample.biosource_summary',
                     'experiments_in_set.biosample.biosource.biosource_type',
-                    'experiments_in_set.biosample.biosource.individual.organism.display_title',
+                    'experiments_in_set.biosample.biosource.organism.name',
                     'experiments_in_set.biosample.treatments.treatment_type',
                     'experiments_in_set.experiment_categorizer.value'
                 ];

--- a/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
+++ b/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
@@ -56,13 +56,13 @@ export class UIControlsWrapper extends React.PureComponent {
             //{ title : "Digestion Enzyme", field : "experiments_in_set.digestion_enzyme.name" },
             { title : "Biosource", field : "experiments_in_set.biosample.biosource_summary" },
             { title : "Biosource Type", field : 'experiments_in_set.biosample.biosource.biosource_type' },
-            { title : "Organism", field : "experiments_in_set.biosample.biosource.individual.organism.name" },
+            { title : "Organism", field : "experiments_in_set.biosample.biosource.organism.name" },
             { title : "Project", field : "award.project" },
             { title : "Lab", field : "lab.display_title" },
             { title : "Status", field : "status" }
         ],
         'availableFields_Subdivision' : [
-            { title : "Organism", field : "experiments_in_set.biosample.biosource.individual.organism.name" },
+            { title : "Organism", field : "experiments_in_set.biosample.biosource.organism.name" },
             { title : "Experiment Type", field : 'experiments_in_set.experiment_type.display_title' },
             //{ title : "Digestion Enzyme", field : "experiments_in_set.digestion_enzyme.name" },
             { title : "Biosource Type", field : 'experiments_in_set.biosample.biosource.biosource_type' },

--- a/src/encoded/static/components/viz/utilities.js
+++ b/src/encoded/static/components/viz/utilities.js
@@ -144,7 +144,7 @@ export const style = {
 
 
 const highlightTermFxn = _.debounce(function(
-    field = 'experiments_in_set.biosample.biosource.individual.organism.name',
+    field = 'experiments_in_set.biosample.biosource.organism.name',
     term = 'human',
     color = ''
 ){
@@ -227,7 +227,7 @@ const highlightTermFxn = _.debounce(function(
  * @param {string} color - A valid CSS color.
  */
 export function highlightTerm(
-    field = 'experiments_in_set.biosample.biosource.individual.organism.name',
+    field = 'experiments_in_set.biosample.biosource.organism.name',
     term = 'human',
     color = ''
 ){

--- a/src/encoded/tests/data/inserts/biosample.json
+++ b/src/encoded/tests/data/inserts/biosample.json
@@ -157,5 +157,13 @@
         "lab": "4dn-dcic-lab",
         "submitted_by": "wrangler@wrangler.com",
         "accession": "4DNBS1235556"
+    },
+    {
+        "uuid": "a9163992-7486-4edd-b21d-f492884bff63",
+        "description": "Hamster Cells prepped for ATAC-seq",
+        "biosource": ["c9165aa4-2ab5-428d-b5a7-db86dbb2d815"],
+        "award": "1U01CA200059-01",
+        "lab": "4dn-dcic-lab",
+        "submitted_by": "wrangler@wrangler.com"
     }
 ]

--- a/src/encoded/tests/data/inserts/biosource.json
+++ b/src/encoded/tests/data/inserts/biosource.json
@@ -62,7 +62,7 @@
         "uuid": "111116bc-8535-4448-903e-854af460b254",
         "description": "Brain Tissue",
         "biosource_type": "tissue",
-        "individual":"4DNINOOOAAQ1",
+        "individual": "3cfe1236-368f-45a0-9ff9-a5277f1a56a9",
         "award": "1U01CA200059-01",
         "lab": "4dn-dcic-lab",
         "submitted_by": "wrangler@wrangler.com",
@@ -72,7 +72,7 @@
         "uuid": "331111bc-8535-4448-903e-854af460b89f",
         "description": "Some iPSC cells",
         "biosource_type": "induced pluripotent stem cell",
-        "individual":"4DNINOOOAAQ1",
+        "individual":"3cfe2618-368f-45a0-9aa9-a5277f1a56a9",
         "award": "1U01CA200059-01",
         "lab": "4dn-dcic-lab",
         "submitted_by": "wrangler@wrangler.com",
@@ -87,5 +87,14 @@
         "lab": "dcic-testing-lab",
         "submitted_by": "wrangler@wrangler.com",
         "biosource_vendor": "b31106bc-8535-4448-903e-854af460b21e"
+    },
+    {
+        "uuid": "c9165aa4-2ab5-428d-b5a7-db86dbb2d815",
+        "description": "Hamster Cells",
+        "biosource_type": "primary cell",
+        "override_organism_name":"hamster",
+        "award": "1U01CA200059-01",
+        "lab": "dcic-testing-lab",
+        "submitted_by": "wrangler@wrangler.com"
     }
 ]

--- a/src/encoded/tests/data/inserts/experiment_atacseq.json
+++ b/src/encoded/tests/data/inserts/experiment_atacseq.json
@@ -1,7 +1,7 @@
 [
     {
         "accession":"4DNEX067AAA1",
-        "biosample":"231111bc-8535-4448-903e-854af460b254",
+        "biosample":"a9163992-7486-4edd-b21d-f492884bff63",
         "experiment_type": "c17b17cd-544a-3a3b-abc3-17a544544b3c",
         "enzyme_lot_number": "123456",
         "enzyme_incubation_time": 30,

--- a/src/encoded/tests/data/inserts/experiment_set_replicate.json
+++ b/src/encoded/tests/data/inserts/experiment_set_replicate.json
@@ -112,7 +112,7 @@
         "description": "Test replicate experiment set for ATAC-seq - single experiment",
         "experimentset_type": "replicate",
         "replicate_exps": [
-           {"replicate_exp": "4DNEX067AAA1", "bio_rep_no": 1, "tec_rep_no":1}
+           {"replicate_exp": "66661e2f-3e43-4388-8bbb-e861f209c444", "bio_rep_no": 1, "tec_rep_no":1}
         ],
         "lab": "test-4dn-lab",
         "award": "1U01CA200059-02",

--- a/src/encoded/tests/data/master-inserts/organism.json
+++ b/src/encoded/tests/data/master-inserts/organism.json
@@ -39,5 +39,11 @@
         "taxon_id": "7955",
         "genome_assembly": "GRCz11",
         "uuid": "30b53150-cff7-43ed-a8d6-fc5836df98a7"
-    }
+    },
+    {
+        "name": "hamster",
+        "taxon_id": "10036",
+        "scientific_name": "Mesocricetus auratus",
+        "uuid": "e15deec1-4c1f-41e4-bdd2-71c8c159bf9f"
+}
 ]

--- a/src/encoded/tests/test_indexing.py
+++ b/src/encoded/tests/test_indexing.py
@@ -452,7 +452,7 @@ class TestInvalidationScopeViewFourfront:
             DEFAULT_SCOPE + ['term_id', 'term_name', 'preferred_name', 'slim_terms', 'synonyms']
          ),
         ('Organism', 'ExperimentSet',
-            DEFAULT_SCOPE + ['name']
+            DEFAULT_SCOPE + ['name', 'scientific_name']
          ),
         ('Modification', 'ExperimentSet',
             DEFAULT_SCOPE + ['modification_type', 'genomic_change', 'override_modification_name']
@@ -465,7 +465,7 @@ class TestInvalidationScopeViewFourfront:
             DEFAULT_SCOPE + ['accession']  # XXX: this embeds calc props that are not fully reflected IMO - Will 3/31/21
          ),
         ('Biosource', 'ExperimentSet',
-            DEFAULT_SCOPE + ['biosource_type', 'cell_line_tier', 'override_biosource_name']
+            DEFAULT_SCOPE + ['biosource_type', 'cell_line_tier', 'override_biosource_name', 'override_organism_name']
          ),
         ('Construct', 'ExperimentSet',
             DEFAULT_SCOPE + ['name']

--- a/src/encoded/tests/test_types_biosource.py
+++ b/src/encoded/tests/test_types_biosource.py
@@ -107,6 +107,27 @@ def thous_genomes_biosources(testapp, human_biosource_data, thousandgen_oterms, 
     return bsources
 
 
+def test_calculated_organism_wo_ind(testapp, human_biosource_data):
+    human_biosource_data['biosource_type'] = 'primary cell'
+    del human_biosource_data['individual']
+    res = testapp.post_json('/biosource', human_biosource_data, status=201).json['@graph'][0]
+    assert 'organism' not in res
+
+
+def test_calculated_organism_wo_ind_w_override(testapp, human_biosource_data, human):
+    human_biosource_data['biosource_type'] = 'primary cell'
+    human_biosource_data['override_organism_name'] = 'human'
+    del human_biosource_data['individual']
+    res = testapp.post_json('/biosource', human_biosource_data, status=201).json['@graph'][0]
+    assert res.get('organism') == human.get('uuid')
+
+
+def test_calculated_organism_w_ind(testapp, human_biosource_data, human):
+    human_biosource_data['biosource_type'] = 'primary cell'
+    res = testapp.post_json('/biosource', human_biosource_data, status=201).json['@graph'][0]
+    assert res.get('organism') == human.get('uuid')
+
+
 def test_calculated_biosource_category_multicellular(lung_biosource, whole_biosource):
     assert 'Multicellular Tissue' in lung_biosource.get('biosource_category')
     assert 'Multicellular Tissue' in whole_biosource.get('biosource_category')

--- a/src/encoded/tests/test_types_init_collections.py
+++ b/src/encoded/tests/test_types_init_collections.py
@@ -115,7 +115,7 @@ def google_analytics_tracking_data():
                         "ga:users": 13,
                         "ga:totalEvents": 16,
                         "ga:sessions": 15,
-                        "ga:dimension3": "experiments_in_set.biosample.biosource.individual.organism.name"
+                        "ga:dimension3": "experiments_in_set.biosample.biosource.organism.name"
                     }
                 ],
                 "views_by_file": [

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -57,6 +57,8 @@ def _build_biosample_embedded_list():
             'biosource.*',
             'biosource.individual.sex',
             'biosource.individual.organism.name',
+            'biosource.organism.name',
+            'biosource.override_organism_name',
             'biosource.biosource_vendor.name',  # display_title uses this
 
             # BiosampleCellCulture linkTo + Image linkTo

--- a/src/encoded/types/biosample.py
+++ b/src/encoded/types/biosample.py
@@ -56,7 +56,6 @@ def _build_biosample_embedded_list():
             # Biosource linkTo - many calc prop dependencies
             'biosource.*',
             'biosource.individual.sex',
-            'biosource.individual.organism.name',
             'biosource.organism.name',
             'biosource.override_organism_name',
             'biosource.biosource_vendor.name',  # display_title uses this

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -57,11 +57,11 @@ def _build_biosource_embedded_list():
                 'individual.health_status',
 
                 # Organism linkTo
-                'individual.organism.name',
-                'individual.organism.scientific_name',
+                'organism.name',
+                'organism.scientific_name',
 
                 # Ontology linkTo
-                'tissue.source_ontologies.ontology_name',
+                'tissue.source_ontologies.ontology_name'
             ]
     )
 

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -177,7 +177,6 @@ class Biosource(Item):
             oterm = oterms.get(tid)
             if oterm:
                 tiered_line_cat[str(oterm.uuid)] = cat
-        # import pdb; pdb.set_trace()
         if cell_line:
             cl_term = get_item_or_none(request, cell_line, 'ontology-terms')
             cluid = cl_term.get('uuid')
@@ -218,7 +217,6 @@ class Biosource(Item):
         "linkTo": "Organism"
     })
     def organism(self, request, individual=None, override_organism_name=None):
-        # import pdb; pdb.set_trace()
         if override_organism_name:
             # if this field use as a lookup key
             org_item = get_item_or_none(request, override_organism_name, 'organisms')

--- a/src/encoded/types/biosource.py
+++ b/src/encoded/types/biosource.py
@@ -212,6 +212,28 @@ class Biosource(Item):
         return category
 
     @calculated_property(schema={
+        "title": "Organism",
+        "description": "Organism from which this Biosource was derived.",
+        "type": "string",
+        "linkTo": "Organism"
+    })
+    def organism(self, request, individual=None, override_organism_name=None):
+        # import pdb; pdb.set_trace()
+        if override_organism_name:
+            # if this field use as a lookup key
+            org_item = get_item_or_none(request, override_organism_name, 'organisms')
+            if org_item:
+                return org_item.get('uuid')
+        if individual:
+            individual_props = get_item_or_none(request, individual, 'individuals')
+            if individual_props:
+                organism = individual_props.get('organism')
+                organism_props = get_item_or_none(request, organism, 'organisms')
+                if organism_props:
+                    return organism_props.get('uuid')
+        return None
+
+    @calculated_property(schema={
         "title": "Display Title",
         "description": "A calculated title for every object in 4DN",
         "type": "string"

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -157,7 +157,6 @@ class Experiment(Item):
 
         # Organism linkTo
         'biosample.biosource.organism.name',
-        'biosample.biosource.individual.organism.name',
 
         # Modification linkTo
         'biosample.modifications.modification_type',

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -157,8 +157,6 @@ class Experiment(Item):
 
         # Organism linkTo
         'biosample.biosource.organism.name',
-        'biosample.biosource.organism.scientific_name',  # not sure we need this one
-        'biosample.biosource.individual.organism.scientific_name',
         'biosample.biosource.individual.organism.name',
 
         # Modification linkTo

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -156,8 +156,10 @@ class Experiment(Item):
         'biosample.biosource.individual.protected_data',
 
         # Organism linkTo
-        'biosample.biosource.individual.organism.name',
+        'biosample.biosource.organism.name',
+        'biosample.biosource.organism.scientific_name',  # not sure we need this one
         'biosample.biosource.individual.organism.scientific_name',
+        'biosample.biosource.individual.organism.name',
 
         # Modification linkTo
         'biosample.modifications.modification_type',

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -154,9 +154,7 @@ class ExperimentSet(Item):
 
         # Organism linkTo
         "experiments_in_set.biosample.biosource.organism.name",  # calc prop
-        "experiments_in_set.biosample.biosource.individual.organism.name",
         "experiments_in_set.biosample.biosource.organism.scientific_name",
-        "experiments_in_set.biosample.biosource.individual.organism.scientific_name",
 
         # OntologyTerm linkTo
         "experiments_in_set.biosample.cell_culture_details.tissue.preferred_name",

--- a/src/encoded/types/experiment_set.py
+++ b/src/encoded/types/experiment_set.py
@@ -136,6 +136,7 @@ class ExperimentSet(Item):
         "experiments_in_set.biosample.biosource.biosource_type",
         "experiments_in_set.biosample.biosource.cell_line_tier",
         "experiments_in_set.biosample.biosource.override_biosource_name",
+        "experiments_in_set.biosample.biosource.override_organism_name",  # do we need this?
 
         # OntologyTerm linkTo
         "experiments_in_set.biosample.biosource.cell_line.term_id",
@@ -152,7 +153,10 @@ class ExperimentSet(Item):
         "experiments_in_set.biosample.biosource.tissue.synonyms",
 
         # Organism linkTo
+        "experiments_in_set.biosample.biosource.organism.name",  # calc prop
         "experiments_in_set.biosample.biosource.individual.organism.name",
+        "experiments_in_set.biosample.biosource.organism.scientific_name",
+        "experiments_in_set.biosample.biosource.individual.organism.scientific_name",
 
         # OntologyTerm linkTo
         "experiments_in_set.biosample.cell_culture_details.tissue.preferred_name",

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -310,6 +310,8 @@ class File(Item):
         'experiments.biosample.biosource.individual.protected_data',
 
         # Organism linkTo
+        'experiments.biosample.biosource.organism.name',
+        'experiments.biosample.biosource.organism.scientific_name',
         'experiments.biosample.biosource.individual.organism.name',
         'experiments.biosample.biosource.individual.organism.scientific_name',
 

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -312,8 +312,6 @@ class File(Item):
         # Organism linkTo
         'experiments.biosample.biosource.organism.name',
         'experiments.biosample.biosource.organism.scientific_name',
-        'experiments.biosample.biosource.individual.organism.name',
-        'experiments.biosample.biosource.individual.organism.scientific_name',
 
         # FileFormat linkTo
         'file_format.file_format',


### PR DESCRIPTION
Add a calcprop to Biosource to link Organism item directly.

This get's around the issue of having datasets that are from a known organism for which we have an Item in the database but no Individual schema.

The current case is hamster data but making this change will allow us to more easily add datasets from critters that we don't have a genome for (and possible never will) and still allow faceting on their organism.

This uses a field in Biosource 'override_organism_name' that must match the 'name' property of an Organism Item to generate the linkTo if there is no Individual linked to the Biosource.

Those items with a linked Individual get the Biosource.organism linkTo via the indirect connection to the Organism that is linked to the Individual so don't need and should not have the override_organism_name property.

NOTE: this needs I think at least 2 UI changes in order for the 'Organism' property in the summary info on the RepSet page to display the scientific name properly.  Trello ticket here: https://trello.com/c/rUy5Rjfg/550-ui-changes-to-use-biosource-organism-calculated-property

~~NOTE: it may be possible to cut down on some of the embeds though maybe not as most of the ones that might be removed are used in the calcprop.~~ Believe this has been done
 