### PR TITLE
Port Will's fix of npm build from containerize, and other small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ beanstalk.cfg
 +.pydevproject
 *.log
 .python-version
+.python-cmd
 ~$*
 .~*#
 production.ini

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "test": "jest",
-    "build": "node --max-old-space-size=4096 ./node_modules/.bin/gulp build",
+    "build": "node --max-old-space-size=6000 ./node_modules/.bin/gulp build",
     "build-scss": "gulp build-scss",
     "watch-scss": "gulp build-scss-dev && sass ./src/encoded/static/scss/style.scss ./src/encoded/static/css/style.css --watch --style expanded",
     "dev-analyzed": "gulp dev-analyzed --preserve-symlinks",
@@ -88,10 +88,10 @@
     "webpack-deadcode-plugin": "^0.1.15"
   },
   "dependencies": {
-    "micro-meta-app-react": "github:WU-BIMAC/MicroMetaApp-React#0.0.0.21",
+    "micro-meta-app-react": "git+https:github.com/WU-BIMAC/MicroMetaApp-React#0.0.0.21",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.5",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.42",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https:github.com/4dn-dcic/shared-portal-components#0.1.42",
     "auth0-lock": "^11.32.2",
     "d3": "^5.16.0",
     "date-fns": "^2.28.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "3.6.14"
+version = "3.6.15"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
* Port Will's fix of npm build problem. Original commits that were imported:
  * https://github.com/4dn-dcic/fourfront/pull/1540/commits/c176a7f05bbb30496c68d8b217b462bc10230ae5
  * https://github.com/4dn-dcic/fourfront/pull/1540/commits/5c7dfb6018030842b2398d2de129f58df577ac87
* Port Kent's long-ago changes to `cgap-portal` so that npm building is not done by `make build` (or `make macbuild`) when `node_modules/` exists. Must use `make build-full` (or `make macbuild-full`).

Opportunistic:

* Add `.python-cmd` to `.gitignore` for some of Kent's tools
* Some other refactoring of `Makefile` to level better with `cgap-portal` in places that both agree on.
