### PR TITLE
Repair Fargate OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,7 @@ COPY deploy/docker/production/entrypoint.bash .
 COPY deploy/docker/production/entrypoint_portal.bash .
 COPY deploy/docker/production/entrypoint_deployment.bash .
 COPY deploy/docker/production/entrypoint_indexer.bash .
+COPY deploy/docker/production/supervisord.conf .
 # Note that fourfront does not have an ingester
 # COPY deploy/docker/production/entrypoint_ingester.sh .
 COPY deploy/docker/production/assume_identity.py .

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,8 @@ RUN chown nginx:nginx development.ini && \
 
 # Production setup
 RUN touch production.ini && chown nginx:nginx production.ini && \
-    touch session-secret.b64 && chown nginx:nginx session-secret.b64 && chown nginx:nginx poetry.toml
+    touch session-secret.b64 && chown nginx:nginx session-secret.b64 && chown nginx:nginx poetry.toml && \
+    touch supervisord.log && chown nginx:nginx supervisord.log
 COPY deploy/docker/production/$INI_BASE deploy/ini_files/.
 COPY deploy/docker/production/entrypoint.bash .
 COPY deploy/docker/production/entrypoint_portal.bash .

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,9 @@ RUN chown nginx:nginx development.ini && \
 # Production setup
 RUN touch production.ini && chown nginx:nginx production.ini && \
     touch session-secret.b64 && chown nginx:nginx session-secret.b64 && chown nginx:nginx poetry.toml && \
-    touch supervisord.log && chown nginx:nginx supervisord.log
+    touch supervisord.log && chown nginx:nginx supervisord.log && \
+    touch supervisord.sock && chown nginx:nginx supervisord.sock && \
+    touch supervisord.pid && chown nginx:nginx supervisord.pid
 COPY deploy/docker/production/$INI_BASE deploy/ini_files/.
 COPY deploy/docker/production/entrypoint.bash .
 COPY deploy/docker/production/entrypoint_portal.bash .

--- a/base.ini
+++ b/base.ini
@@ -54,4 +54,4 @@ set indexer = true
 
 [filter:memlimit]
 use = egg:encoded#memlimit
-rss_limit = 400MB
+rss_limit = 500MB

--- a/base.ini
+++ b/base.ini
@@ -54,4 +54,4 @@ set indexer = true
 
 [filter:memlimit]
 use = egg:encoded#memlimit
-rss_limit = 500MB
+rss_limit = 400MB

--- a/base.ini
+++ b/base.ini
@@ -55,4 +55,3 @@ set indexer = true
 [filter:memlimit]
 use = egg:encoded#memlimit
 rss_limit = 500MB
-rss_percent_limit = 20

--- a/deploy/docker/production/entrypoint_portal.bash
+++ b/deploy/docker/production/entrypoint_portal.bash
@@ -10,11 +10,5 @@ poetry run python -m assume_identity
 service nginx start
 
 # Start application
-echo "Starting server 1"
-pserve production.ini http_port=6543 &
-echo "Starting server 2"
-pserve production.ini http_port=6544 &
-echo "Starting server 3"
-pserve production.ini http_port=6545 &
-echo "Starting server 4"
-pserve production.ini http_port=6546
+echo "Starting supervisor"
+supervisord -c supervisord.conf

--- a/deploy/docker/production/nginx.conf
+++ b/deploy/docker/production/nginx.conf
@@ -67,10 +67,11 @@ http {
 
     upstream app {
         zone app 32k;
-        server 0.0.0.0:6543 fail_timeout=45 max_fails=4;
-        server 0.0.0.0:6544 fail_timeout=45 max_fails=4;
-        server 0.0.0.0:6545 fail_timeout=45 max_fails=4;
-        server 0.0.0.0:6546 fail_timeout=45 max_fails=4;
+        server 0.0.0.0:6543 fail_timeout=45 max_fails=45;
+        server 0.0.0.0:6544 fail_timeout=45 max_fails=45;
+        server 0.0.0.0:6545 fail_timeout=45 max_fails=45;
+        server 0.0.0.0:6546 fail_timeout=45 max_fails=45;
+        server 0.0.0.0:6547 fail_timeout=45 max_fails=45 backup;
         keepalive 64;
     }
 

--- a/deploy/docker/production/nginx.conf
+++ b/deploy/docker/production/nginx.conf
@@ -67,10 +67,10 @@ http {
 
     upstream app {
         zone app 32k;
-        server 0.0.0.0:6543 fail_timeout=45;
-        server 0.0.0.0:6544 fail_timeout=45;
-        server 0.0.0.0:6545 fail_timeout=45;
-        server 0.0.0.0:6546 fail_timeout=45;
+        server 0.0.0.0:6543 fail_timeout=45 max_fails=4;
+        server 0.0.0.0:6544 fail_timeout=45 max_fails=4;
+        server 0.0.0.0:6545 fail_timeout=45 max_fails=4;
+        server 0.0.0.0:6546 fail_timeout=45 max_fails=4;
         keepalive 64;
     }
 

--- a/deploy/docker/production/nginx.conf
+++ b/deploy/docker/production/nginx.conf
@@ -36,6 +36,11 @@ http {
     types_hash_max_size 2048;
     types_hash_bucket_size 64;
 
+    # If 502 is encountered, we may have been killed for memory
+    # Fall back to the next server, until one is back
+    proxy_next_upstream error timeout http_502;
+
+
     # Allow large POST requests
     client_body_buffer_size 128K;
     client_header_buffer_size 1k;

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -1,9 +1,9 @@
 [unix_http_server]
-file=%(here)s/env/supervisor.sock
+file=%(here)s/supervisor.sock
 
 [supervisord]
-pidfile=%(here)s/env/supervisord.pid
-logfile=%(here)s/env/supervisord.log
+pidfile=%(here)s/supervisord.pid
+logfile=%(here)s/supervisord.log
 logfile_maxbytes=50MB
 logfile_backups=10
 loglevel=info
@@ -15,7 +15,7 @@ minprocs=200
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix://%(here)s/env/supervisor.sock
+serverurl=unix://%(here)s/supervisor.sock
 
 [program:ff1]
 autorestart=true

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -32,3 +32,9 @@ autorestart=true
 startsecs=6
 command=pserve production.ini http_port=6546
 redirect_stderr=true
+
+[program:ff5]
+autorestart=true
+startsecs=6
+command=pserve production.ini http_port=6547
+redirect_stderr=true

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -1,0 +1,46 @@
+[unix_http_server]
+file=%(here)s/env/supervisor.sock
+
+[supervisord]
+pidfile=%(here)s/env/supervisord.pid
+logfile=%(here)s/env/supervisord.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=info
+nodaemon=true
+minfds=1024
+minprocs=200
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix://%(here)s/env/supervisor.sock
+
+[program:ff1]
+autorestart=true
+command=pserve production.ini http_port=6543
+process_name=%(program_name)s
+numprocs_start=0
+redirect_stderr=true
+
+[program:ff2]
+autorestart=true
+command=pserve production.ini http_port=6544
+process_name=%(program_name)s
+numprocs_start=0
+redirect_stderr=true
+
+[program:ff3]
+autorestart=true
+command=pserve production.ini http_port=6545
+process_name=%(program_name)s
+numprocs_start=0
+redirect_stderr=true
+
+[program:ff4]
+autorestart=true
+command=pserve production.ini http_port=6546
+process_name=%(program_name)s
+numprocs_start=0
+redirect_stderr=true

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -1,6 +1,3 @@
-[unix_http_server]
-file=%(here)s/supervisord.sock
-
 [supervisord]
 pidfile=%(here)s/supervisord.pid
 logfile=%(here)s/supervisord.log
@@ -14,9 +11,6 @@ user=nginx
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
-
-[supervisorctl]
-serverurl=unix://%(here)s/supervisord.sock
 
 [program:ff1]
 autorestart=true

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -1,5 +1,5 @@
 [unix_http_server]
-file=%(here)s/supervisor.sock
+file=%(here)s/supervisord.sock
 
 [supervisord]
 pidfile=%(here)s/supervisord.pid
@@ -16,7 +16,7 @@ user=nginx
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix://%(here)s/supervisor.sock
+serverurl=unix://%(here)s/supervisord.sock
 
 [program:ff1]
 autorestart=true

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -9,33 +9,26 @@ minfds=1024
 minprocs=200
 user=nginx
 
-[rpcinterface:supervisor]
-supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
-
 [program:ff1]
 autorestart=true
+startsecs=5
 command=pserve production.ini http_port=6543
-process_name=%(program_name)s
-numprocs_start=0
 redirect_stderr=true
 
 [program:ff2]
 autorestart=true
+startsecs=5
 command=pserve production.ini http_port=6544
-process_name=%(program_name)s
-numprocs_start=0
 redirect_stderr=true
 
 [program:ff3]
 autorestart=true
+startsecs=5
 command=pserve production.ini http_port=6545
-process_name=%(program_name)s
-numprocs_start=0
 redirect_stderr=true
 
 [program:ff4]
 autorestart=true
+startsecs=5
 command=pserve production.ini http_port=6546
-process_name=%(program_name)s
-numprocs_start=0
 redirect_stderr=true

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -10,6 +10,7 @@ loglevel=info
 nodaemon=true
 minfds=1024
 minprocs=200
+user=nginx
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -11,24 +11,24 @@ user=nginx
 
 [program:ff1]
 autorestart=true
-startsecs=5
+startsecs=6
 command=pserve production.ini http_port=6543
 redirect_stderr=true
 
 [program:ff2]
 autorestart=true
-startsecs=5
+startsecs=6
 command=pserve production.ini http_port=6544
 redirect_stderr=true
 
 [program:ff3]
 autorestart=true
-startsecs=5
+startsecs=6
 command=pserve production.ini http_port=6545
 redirect_stderr=true
 
 [program:ff4]
 autorestart=true
-startsecs=5
+startsecs=6
 command=pserve production.ini http_port=6546
 redirect_stderr=true

--- a/poetry.lock
+++ b/poetry.lock
@@ -527,6 +527,17 @@ dev = ["check-manifest"]
 test = ["coverage", "nosetests"]
 
 [[package]]
+name = "codeguru-profiler-agent"
+version = "1.2.4"
+description = "The Python agent to be used for Amazon CodeGuru Profiler"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+boto3 = ">=1.14.0"
+
+[[package]]
 name = "colorama"
 version = "0.3.3"
 description = "Cross-platform colored terminal text."
@@ -2096,7 +2107,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.10,<3.8"
-content-hash = "c6514f4c0f1527e8ec2d40ef03532907a4ee2ec5967042ae1a39c4460c4f0b9d"
+content-hash = "ef25b89bf5bfd39829344c0b987d9a7e7aed6e3c4d1939861b79f4c564ea6537"
 
 [metadata.files]
 apipkg = [
@@ -2222,6 +2233,10 @@ click = [
 codacy-coverage = [
     {file = "codacy-coverage-1.3.11.tar.gz", hash = "sha256:b94651934745c638a980ad8d67494077e60f71e19e29aad1c275b66e0a070cbc"},
     {file = "codacy_coverage-1.3.11-py2.py3-none-any.whl", hash = "sha256:d8a1ce56b0dd156d6b1de14fa6217d32ec86097902f08a17ff2f95ba27264474"},
+]
+codeguru-profiler-agent = [
+    {file = "codeguru_profiler_agent-1.2.4-py3-none-any.whl", hash = "sha256:7325777f83acd0e5be342eba7acc5bc372a4d992eb3e22218e3f42f137bebe95"},
+    {file = "codeguru_profiler_agent-1.2.4.tar.gz", hash = "sha256:fde1bc9837b79ce9587a723ef8ac2776846e4c5c6a4acc93cc8029fb1fc9168b"},
 ]
 colorama = [
     {file = "colorama-0.3.3.tar.gz", hash = "sha256:eb21f2ba718fbf357afdfdf6f641ab393901c7ca8d9f37edd0bee4806ffa269c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1846,6 +1846,17 @@ WebOb = "*"
 test = ["webtest", "pyramid", "pytest"]
 
 [[package]]
+name = "supervisor"
+version = "4.2.4"
+description = "A system for controlling process state under UNIX"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+testing = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -2107,7 +2118,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.10,<3.8"
-content-hash = "ef25b89bf5bfd39829344c0b987d9a7e7aed6e3c4d1939861b79f4c564ea6537"
+content-hash = "9cf51c629b881a4232ae597b12b276e4c697b6708a478f38be16c6fcaa220ca4"
 
 [metadata.files]
 apipkg = [
@@ -3049,6 +3060,10 @@ submit4dn = [
 ]
 subprocess-middleware = [
     {file = "subprocess_middleware-0.3.zip", hash = "sha256:182c3ecd1d5657dbfb2e1d22629835305b26851d8baaf759f10cd1b2e4b4697e"},
+]
+supervisor = [
+    {file = "supervisor-4.2.4-py2.py3-none-any.whl", hash = "sha256:bbae57abf74e078fe0ecc9f30068b6da41b840546e233ef1e659a12e4c875af6"},
+    {file = "supervisor-4.2.4.tar.gz", hash = "sha256:40dc582ce1eec631c3df79420b187a6da276bbd68a4ec0a8f1f123ea616b97a2"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.1.1"  # 4.0.0 introduces containerization
+version = "4.2.0"  # 4.0.0 introduced containerization
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ xlwt = "1.2.0"
 "zope.interface" = "^4.7.2"
 "zope.sqlalchemy" = "1.3"
 codeguru-profiler-agent = "^1.2.4"
+supervisor = "^4.2.4"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ xlwt = "1.2.0"
 "zope.deprecation" = "4.4.0"
 "zope.interface" = "^4.7.2"
 "zope.sqlalchemy" = "1.3"
+codeguru-profiler-agent = "^1.2.4"
 
 
 [tool.poetry.dev-dependencies]

--- a/src/encoded/memlimit.py
+++ b/src/encoded/memlimit.py
@@ -51,13 +51,13 @@ def rss_checker(rss_limit=None, rss_percent_limit=None):
     def callback(environ):
         rss = process.memory_info().rss
         over_rss = rss_limit and rss > rss_limit
-        rss_perc = process.memory_percent(memtype="rss")
+        rss_perc = process.memory_percent(memtype="rss")  # XXX: this does not work on Fargate (reports host stats)
         if rss_percent_limit:
             over_perc = rss_perc > rss_percent_limit
         else:
             over_perc = True  # only consider rss if we have no percent set
         if over_rss and over_perc:
-            log.error(f"Restarting process. Memory usage: {rss}Mb (limit {rss_limit}); Percentage "
+            log.error(f"Killing process. Memory usage: {rss}Mb (limit {rss_limit}); Percentage "
                       f"{rss_perc} (limit {rss_percent_limit})")
             process.kill()
 

--- a/src/encoded/memlimit.py
+++ b/src/encoded/memlimit.py
@@ -57,8 +57,8 @@ def rss_checker(rss_limit=None, rss_percent_limit=None):
         else:
             over_perc = True  # only consider rss if we have no percent set
         if over_rss and over_perc:
-            log.error("Restarting process. Memory usage: %s (limit %s); Percentage "
-                      "%s (limit %s)" % (rss, rss_limit, rss_perc, rss_percent_limit))
+            log.error(f"Restarting process. Memory usage: {rss}Mb (limit {rss_limit}); Percentage "
+                      f"{rss_perc} (limit {rss_percent_limit})")
             process.kill()
 
     return callback


### PR DESCRIPTION
- Repairs `memlimit` memory recycling mechanism by eliminating reliance on `psutil.process.memory_percent`, which does not report accurate values on Fargate
- Wrap fourfront API workers with `supervisord`, since `memlimit` will kill the waitress processes once they exceed 400Mb
- Provide a dedicated backup server for when workers get killed due to OOM