### PR TITLE
add untreated treatment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.4.10"  # 4.0.0 introduced containerization
+version = "4.4.11"  # 4.0.0 introduced containerization
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_types_treatment.py
+++ b/src/encoded/tests/test_types_treatment.py
@@ -5,14 +5,18 @@ pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.schema]
 
 
 @pytest.fixture
-def drug_treatment(testapp, lab, award):
+def chemical_treatment(testapp, lab, award):
     item = {
         'award': award['@id'],
         'lab': lab['@id'],
         'treatment_type': 'Chemical',
-        'chemical': 'Drug',
     }
     return testapp.post_json('/treatment_agent', item).json['@graph'][0]
+
+
+@pytest.fixture
+def drug_treatment(testapp, chemical_treatment):
+    return testapp.patch_json(chemical_treatment['@id'], {'chemical': 'Drug'}).json['@graph'][0]
 
 
 @pytest.fixture
@@ -73,6 +77,14 @@ def test_calculated_chemical_treatment_washout_display_title(testapp, drug_treat
         {'duration': 3.5, 'duration_units': 'hour', 'concentration': 0, 'concentration_units': 'M'}
     )
     assert res.json['@graph'][0]['display_title'] == 'Drug washout (3.5h)'
+
+
+def test_calculated_chemical_treatment_untreated_display_title(testapp, chemical_treatment):
+    assert chemical_treatment['display_title'] == 'Untreated'
+    res = testapp.patch_json(
+        chemical_treatment['@id'],
+        {'duration': 3.5, 'duration_units': 'hour'})
+    assert res.json['@graph'][0]['display_title'] == 'Untreated (3.5h)'
 
 
 def test_calculated_biological_treatment_display_title(testapp, viral_treatment):

--- a/src/encoded/types/treatment.py
+++ b/src/encoded/types/treatment.py
@@ -83,9 +83,12 @@ class TreatmentAgent(Treatment):
         if conditions:
             conditions = " (" + conditions + ")"
 
-        if chemical:
-            action = "treatment" if concentration != 0 else "washout"
-            disp_title = chemical + " " + action + conditions
+        if treatment_type == "Chemical":
+            if chemical is None:
+                chemical, action = "", "Untreated"
+            else:
+                action = " treatment" if concentration != 0 else " washout"
+            disp_title = chemical + action + conditions
         elif treatment_type == "Transient Transfection" and constructs:
             plasmids = ", ".join(
                 [get_item_or_none(request, construct).get('name') for construct in constructs]


### PR DESCRIPTION
Sometimes experiments compare treated and untreated conditions. So far the control condition has been handled either by:
- omitting a Treatment object, 
- or by adding a Treatment with the relevant solvent (e.g. DMSO).

However, the two are not exactly the same. There is now one example with three conditions: (i) chemical treatment, (ii) only DMSO, (iii) media change with nothing added.

I'm wondering whether explicitly saying "untreated" is more informative than omitting a Treatment (especially in the case when the experimental design suggest the need of a treatment, e.g. AID-tagged cell line). The suggestion here is to create a Treatment object of `treatment_type` "Chemical", with no `chemical` property.

I'm not sure this is a good idea. Let's discuss it. Opening this PR as a draft.