### PR TITLE
Syntax makeover for clear-db-es-contents

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,88 @@
+[flake8]
+max-line-length = 120
+ignore =
+    # ==============================================================
+    # =========  Default list of things Flake8 would ignore ========
+    # ==============================================================
+    # E121: Continuation line under-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E121.html
+    E121,
+    # E123: Closing bracket does not match indentation of opening bracket's line
+    #       https://www.flake8rules.com/rules/E123.html
+    E123,
+    # E126: Continuation line over-indented for hanging indent
+    #       https://www.flake8rules.com/rules/E126.html
+    E126,
+    # E226: Missing whitespace around arithmetic operator
+    #       https://www.flake8rules.com/rules/E226.html
+    E226,
+    # E24: ??? Hard to find doc on why this undocumented code's in default list
+    # E24,
+    # E704: Multiple statements on one line (def)
+    #       https://www.flake8rules.com/rules/E704.html
+    E704,
+    # W503: Line break occurred before a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W503,
+    # W504: Line break occurred after a binary operator
+    #       https://www.flake8rules.com/rules/W503.html
+    W504,
+    # ==============================================================
+    # =====  Other things we think it shouldn't complain about =====
+    # ==============================================================
+    # F541: f-string is missing placeholders
+    #       https://flake8.pycqa.org/en/latest/user/error-codes.html
+    F541,
+    # ==============================================================
+    # =====  We want these complaints eventually, but not now. =====
+    # ==============================================================
+    # E111 indentation is not a multiple of 4
+    E111,
+    # E116 unexpected indentation (comment)
+    E116,
+    # E122 continuation line missing indentation or outdented
+    E122,
+    # E124 closing bracket does not match visual indentation
+    E124,
+    # E127 continuation line over-indented for visual indent
+    E127,
+    # E128 continuation line under-indented for visual indent
+    E128,
+    # E201 whitespace after '['
+    E201,
+    # E202 whitespace before '}'
+    E202,
+    # E203 whitespace before ':'
+    E203,
+    # E221 multiple spaces before operator
+    E221,
+    # E222 multiple spaces after operator
+    E222,
+    # E231 missing whitespace after ':
+    E231,
+    # E241 multiple spaces after ':'
+    E241,
+    # E251 unexpected spaces around keyword / parameter equals
+    E251,
+    # E261 at least two spaces before inline comment
+    E261,
+    # E262 inline comment should start with '# '
+    E262,
+    # E265 block comment should start with '# '
+    E265,
+    # E266 too many leading '#' for block comment
+    E266,
+    # E272 multiple spaces before keyword
+    E272,
+    # W291 trailing whitespace
+    W291,
+    # W293 blank line contains whitespace
+    W293,
+    # E302 expected 2 blank lines
+    E302,
+    # E303 too many blank lines
+    E303,
+    # W391 blank line at end of file
+    W391,
+    # E501 line too long
+    E501,

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import tempfile
 
+from dcicutils.env_utils import EnvUtils
 from dcicutils.misc_utils import PRINT
 
 
@@ -61,5 +62,7 @@ elif old_identity:
 else:
     PRINT(f"The IDENTITY environment variable is being set to {new_identity} so you can assume its credentials.")
     os.environ['IDENTITY'] = new_identity
+
+EnvUtils.init(force=True)
 
 PRINT("=" * 80)

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,6 @@ from dcicutils.env_utils import EnvUtils
 from dcicutils.misc_utils import PRINT
 
 
-
 def pytest_addoption(parser):
     parser.addoption("--es", action="store", default="", dest='es',
         help="use a remote es for testing")

--- a/deploy/docker/local/entrypoint.bash
+++ b/deploy/docker/local/entrypoint.bash
@@ -5,7 +5,7 @@ if [  -z ${TEST+x} ]; then
     if [ ! -z ${LOAD+x} ]; then
 
         # Clear db/es since this is the local entry point
-        poetry run clear-db-es-contents development.ini --app-name app --env "$FOURFRONT_ENV_NAME"
+        poetry run clear-db-es-contents development.ini --app-name app --only-if-env "$FOURFRONT_ENV_NAME"
 
         # Create mapping
         poetry run create-mapping-on-deploy development.ini --app-name app --clear-queue

--- a/deploy/docker/production/entrypoint_deployment.bash
+++ b/deploy/docker/production/entrypoint_deployment.bash
@@ -9,11 +9,11 @@ poetry run python -m assume_identity
 # Clear db/es on fourfront-mastertest if we run an "initial" deploy
 # Do nothing on other environments
 if [ -n "${INITIAL_DEPLOYMENT}" ]; then
-  poetry run clear-db-es-contents production.ini --app-name app --env fourfront-mastertest
+  poetry run clear-db-es-contents production.ini --app-name app --only-if-env fourfront-mastertest
 fi
 
 ## Create mapping
-poetry run create-mapping-on-deploy production.ini --app-name app --clear-queue
+poetry run create-mapping-on-deploy production.ini --app-name app› --clear-queue
 
 # Load Data (based on development.ini, for now just master-inserts)
 # Not necessary after first deploy

--- a/deploy/tests/test_generate_production_ini.py
+++ b/deploy/tests/test_generate_production_ini.py
@@ -40,6 +40,7 @@ def test_omittable():
     assert omittable("foo=$X", "foo=   \r\n \r\n ")
 
 
+@pytest.mark.skip(reason="We're not using ini_files/*.ini any more.")
 def test_environment_template_filename():
 
     with pytest.raises(ValueError):
@@ -53,12 +54,14 @@ def test_environment_template_filename():
     assert environment_template_filename('webdev') == environment_template_filename('fourfront-webdev')
 
 
+@pytest.mark.skip(reason="We're not using ini_files/*.ini any more.")
 def test_any_environment_template_filename():
 
     actual = os.path.abspath(any_environment_template_filename())
     assert actual.endswith("/ini_files/any.ini")
 
 
+@pytest.mark.skip(reason="We're not using ini_files/*.ini any more.")
 def test_legacy_template_environment_names():
     # Containerized Fourfront will use a single generic template, but while we're still using beanstalks,
     # we do some minimal testing to make sure all the templates are there. -kmp 4-Oct-2021

--- a/poetry.lock
+++ b/poetry.lock
@@ -655,7 +655,7 @@ xlrd = ">=1.0.0,<2.0.0"
 
 [[package]]
 name = "dcicutils"
-version = "4.0.2"
+version = "4.1.0"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 category = "main"
 optional = false
@@ -2117,19 +2117,24 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.9"
-content-hash = "e5e4a91badc86d6738967cf30ccf6b07f94987c5ffb595b8dc4547915e4fdcca"
+content-hash = "8114b16c179f373f6b8b269eb6ea6e9e391c8b5d94fc7de430df3e94a20d966d"
 
 [metadata.files]
 apipkg = [
     {file = "apipkg-3.0.1-py3-none-any.whl", hash = "sha256:6c4e654de1be834c66579003abc992121745209c2d12561a0dd5888feb06906f"},
     {file = "apipkg-3.0.1.tar.gz", hash = "sha256:f8c021adafc9132ac2fba9fd3c5768365d0a8c10aa375fb15e329f1fce8a5f01"},
 ]
-atomicwrites = []
+atomicwrites = [
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
+]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
-aws-requests-auth = []
+aws-requests-auth = [
+    {file = "aws-requests-auth-0.4.3.tar.gz", hash = "sha256:33593372018b960a31dbbe236f89421678b885c35f0b6a7abfae35bb77e069b2"},
+    {file = "aws_requests_auth-0.4.3-py2.py3-none-any.whl", hash = "sha256:646bc37d62140ea1c709d20148f5d43197e6bd2d63909eb36fa4bb2345759977"},
+]
 aws-xray-sdk = [
     {file = "aws-xray-sdk-0.95.tar.gz", hash = "sha256:9e7ba8dd08fd2939376c21423376206bff01d0deaea7d7721c6b35921fed1943"},
     {file = "aws_xray_sdk-0.95-py2.py3-none-any.whl", hash = "sha256:72791618feb22eaff2e628462b0d58f398ce8c1bacfa989b7679817ab1fad60c"},
@@ -2142,7 +2147,10 @@ awscli = [
     {file = "backports.statistics-0.1.0-py2.py3-none-any.whl", hash = "sha256:2732e003151620762ba3ea25b881b5ca0debe2fcbf41b32b6eaff5842a8b99d7"},
     {file = "backports.statistics-0.1.0.tar.gz", hash = "sha256:714ab29b9b9937c6ec65d8c6a3dcc39ee4972f929d55977b018bb9f204ba1f98"},
 ]
-beautifulsoup4 = []
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
+    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
+]
 boto = [
     {file = "boto-2.49.0-py2.py3-none-any.whl", hash = "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8"},
     {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
@@ -2163,13 +2171,84 @@ botocore-stubs = [
     {file = "botocore-stubs-1.27.48.tar.gz", hash = "sha256:8de92d3869ce86461660eae28f4255be84f63efd1b307b5f53f977f96562d589"},
     {file = "botocore_stubs-1.27.48-py3-none-any.whl", hash = "sha256:1d5b65885d150864a996b0c8d497febc52eddc4c9b6b80b4a0663bc9706c425b"},
 ]
-certifi = []
-cffi = []
+certifi = [
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+]
+cffi = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
-charset-normalizer = []
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
+    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
+]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -2261,10 +2340,13 @@ dcicsnovault = [
     {file = "dcicsnovault-6.0.3.tar.gz", hash = "sha256:954868570242b736b901aac1217ae88af703840c2afdf544a26ccee319468e39"},
 ]
 dcicutils = [
-    {file = "dcicutils-4.0.2-py3-none-any.whl", hash = "sha256:0054b2161f131f536a2da68c7f3a08cbafb8feb1a09d88ccd71e03a357095943"},
-    {file = "dcicutils-4.0.2.tar.gz", hash = "sha256:2a115d35651005f2bfb35d0f6599022eedb0647849bc817addf2ffe4b95b3f3f"},
+    {file = "dcicutils-4.1.0-py3-none-any.whl", hash = "sha256:70d5b2e669ac6bee289074da5ec0dc8f3bcfa48f27becad8a33eb420c73cef30"},
+    {file = "dcicutils-4.1.0.tar.gz", hash = "sha256:f55cae4deae692666b8f1b2aaa44e1cd0668f37af0e6d9647dee5481104d793d"},
 ]
-docker = []
+docker = [
+    {file = "docker-4.4.4-py2.py3-none-any.whl", hash = "sha256:f3607d5695be025fa405a12aca2e5df702a57db63790c73b927eb6a94aac60af"},
+    {file = "docker-4.4.4.tar.gz", hash = "sha256:d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db"},
+]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
@@ -2276,8 +2358,14 @@ ecdsa = [
     {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
     {file = "ecdsa-0.18.0.tar.gz", hash = "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49"},
 ]
-elasticsearch = []
-elasticsearch-dsl = []
+elasticsearch = [
+    {file = "elasticsearch-6.8.1-py2.py3-none-any.whl", hash = "sha256:540d633afcc0a32972e4b489c4559c9a96e294850853238f7a18b1cbd267c2ed"},
+    {file = "elasticsearch-6.8.1.tar.gz", hash = "sha256:a8062a00b61bc7babeea028530667583a68ecb1a9f59ab0b22ff7feaf70d3564"},
+]
+elasticsearch-dsl = [
+    {file = "elasticsearch-dsl-6.4.0.tar.gz", hash = "sha256:26416f4dd46ceca43d62ef74970d9de4bdd6f4b0f163316f0b432c9e61a08bec"},
+    {file = "elasticsearch_dsl-6.4.0-py2.py3-none-any.whl", hash = "sha256:f60aea7fd756ac1fbe7ce114bbf4949aefbf495dfe8896640e787c67344f12f6"},
+]
 execnet = [
     {file = "execnet-1.4.1-py2.py3-none-any.whl", hash = "sha256:d2b909c7945832e1c19cfacd96e78da68bdadc656440cfc7dfe59b766744eb8c"},
     {file = "execnet-1.4.1.tar.gz", hash = "sha256:f66dd4a7519725a1b7e14ad9ae7d3df8e09b2da88062386e08e941cafc0ef3e6"},
@@ -2294,14 +2382,22 @@ flask = [
     {file = "Flask-2.2.2-py3-none-any.whl", hash = "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"},
     {file = "Flask-2.2.2.tar.gz", hash = "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b"},
 ]
-future = []
+future = [
+    {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
 futures = [
     {file = "futures-3.1.1-py2-none-any.whl", hash = "sha256:c4884a65654a7c45435063e14ae85280eb1f111d94e542396717ba9828c4337f"},
     {file = "futures-3.1.1-py3-none-any.whl", hash = "sha256:3a44f286998ae64f0cc083682fcfec16c406134a81a589a5de445d7bb7c2751b"},
     {file = "futures-3.1.1.tar.gz", hash = "sha256:51ecb45f0add83c806c68e4b06106f90db260585b25ef2abfcda0bd95c0132fd"},
 ]
-gitdb = []
-gitpython = []
+gitdb = [
+    {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
+    {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
+]
+gitpython = [
+    {file = "GitPython-3.1.27-py3-none-any.whl", hash = "sha256:5b68b000463593e05ff2b261acff0ff0972df8ab1b70d3cdbd41b546c8b8fc3d"},
+    {file = "GitPython-3.1.27.tar.gz", hash = "sha256:1c885ce809e8ba2d88a29befeb385fcea06338d3640712b59ca623c220bb5704"},
+]
 html5lib = [
     {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
     {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
@@ -2318,7 +2414,10 @@ idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
-importlib-metadata = []
+importlib-metadata = [
+    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
+    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
+]
 isodate = [
     {file = "isodate-0.6.0-py2.py3-none-any.whl", hash = "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"},
     {file = "isodate-0.6.0.tar.gz", hash = "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8"},
@@ -2420,7 +2519,9 @@ pastedeploy = [
     {file = "PasteDeploy-1.5.2-py2.py3-none-any.whl", hash = "sha256:39973e73f391335fac8bc8a8a95f7d34a9f42e2775600ce2dc518d93b37ef943"},
     {file = "PasteDeploy-1.5.2.tar.gz", hash = "sha256:d5858f89a255e6294e63ed46b73613c56e3b9a2d82a42f1df4d06c8421a9e3cb"},
 ]
-pbkdf2 = []
+pbkdf2 = [
+    {file = "pbkdf2-1.3.tar.gz", hash = "sha256:ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979"},
+]
 pillow = [
     {file = "Pillow-9.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a9c9bc489f8ab30906d7a85afac4b4944a572a7432e00698a7239f44a44e6efb"},
     {file = "Pillow-9.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:510cef4a3f401c246cfd8227b300828715dd055463cdca6176c2e4036df8bd4f"},
@@ -2501,7 +2602,40 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-psutil = []
+psutil = [
+    {file = "psutil-5.9.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:799759d809c31aab5fe4579e50addf84565e71c1dc9f1c31258f159ff70d3f87"},
+    {file = "psutil-5.9.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9272167b5f5fbfe16945be3db475b3ce8d792386907e673a209da686176552af"},
+    {file = "psutil-5.9.1-cp27-cp27m-win32.whl", hash = "sha256:0904727e0b0a038830b019551cf3204dd48ef5c6868adc776e06e93d615fc5fc"},
+    {file = "psutil-5.9.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e7e10454cb1ab62cc6ce776e1c135a64045a11ec4c6d254d3f7689c16eb3efd2"},
+    {file = "psutil-5.9.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:56960b9e8edcca1456f8c86a196f0c3d8e3e361320071c93378d41445ffd28b0"},
+    {file = "psutil-5.9.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:44d1826150d49ffd62035785a9e2c56afcea66e55b43b8b630d7706276e87f22"},
+    {file = "psutil-5.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c7be9d7f5b0d206f0bbc3794b8e16fb7dbc53ec9e40bbe8787c6f2d38efcf6c9"},
+    {file = "psutil-5.9.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd9246e4cdd5b554a2ddd97c157e292ac11ef3e7af25ac56b08b455c829dca8"},
+    {file = "psutil-5.9.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29a442e25fab1f4d05e2655bb1b8ab6887981838d22effa2396d584b740194de"},
+    {file = "psutil-5.9.1-cp310-cp310-win32.whl", hash = "sha256:20b27771b077dcaa0de1de3ad52d22538fe101f9946d6dc7869e6f694f079329"},
+    {file = "psutil-5.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:58678bbadae12e0db55186dc58f2888839228ac9f41cc7848853539b70490021"},
+    {file = "psutil-5.9.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3a76ad658641172d9c6e593de6fe248ddde825b5866464c3b2ee26c35da9d237"},
+    {file = "psutil-5.9.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a6a11e48cb93a5fa606306493f439b4aa7c56cb03fc9ace7f6bfa21aaf07c453"},
+    {file = "psutil-5.9.1-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:068935df39055bf27a29824b95c801c7a5130f118b806eee663cad28dca97685"},
+    {file = "psutil-5.9.1-cp36-cp36m-win32.whl", hash = "sha256:0f15a19a05f39a09327345bc279c1ba4a8cfb0172cc0d3c7f7d16c813b2e7d36"},
+    {file = "psutil-5.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:db417f0865f90bdc07fa30e1aadc69b6f4cad7f86324b02aa842034efe8d8c4d"},
+    {file = "psutil-5.9.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:91c7ff2a40c373d0cc9121d54bc5f31c4fa09c346528e6a08d1845bce5771ffc"},
+    {file = "psutil-5.9.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fea896b54f3a4ae6f790ac1d017101252c93f6fe075d0e7571543510f11d2676"},
+    {file = "psutil-5.9.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3054e923204b8e9c23a55b23b6df73a8089ae1d075cb0bf711d3e9da1724ded4"},
+    {file = "psutil-5.9.1-cp37-cp37m-win32.whl", hash = "sha256:d2d006286fbcb60f0b391741f520862e9b69f4019b4d738a2a45728c7e952f1b"},
+    {file = "psutil-5.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:b14ee12da9338f5e5b3a3ef7ca58b3cba30f5b66f7662159762932e6d0b8f680"},
+    {file = "psutil-5.9.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:19f36c16012ba9cfc742604df189f2f28d2720e23ff7d1e81602dbe066be9fd1"},
+    {file = "psutil-5.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:944c4b4b82dc4a1b805329c980f270f170fdc9945464223f2ec8e57563139cf4"},
+    {file = "psutil-5.9.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b6750a73a9c4a4e689490ccb862d53c7b976a2a35c4e1846d049dcc3f17d83b"},
+    {file = "psutil-5.9.1-cp38-cp38-win32.whl", hash = "sha256:a8746bfe4e8f659528c5c7e9af5090c5a7d252f32b2e859c584ef7d8efb1e689"},
+    {file = "psutil-5.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:79c9108d9aa7fa6fba6e668b61b82facc067a6b81517cab34d07a84aa89f3df0"},
+    {file = "psutil-5.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:28976df6c64ddd6320d281128817f32c29b539a52bdae5e192537bc338a9ec81"},
+    {file = "psutil-5.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b88f75005586131276634027f4219d06e0561292be8bd6bc7f2f00bdabd63c4e"},
+    {file = "psutil-5.9.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:645bd4f7bb5b8633803e0b6746ff1628724668681a434482546887d22c7a9537"},
+    {file = "psutil-5.9.1-cp39-cp39-win32.whl", hash = "sha256:32c52611756096ae91f5d1499fe6c53b86f4a9ada147ee42db4991ba1520e574"},
+    {file = "psutil-5.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:f65f9a46d984b8cd9b3750c2bdb419b2996895b005aefa6cbaba9a143b1ce2c5"},
+    {file = "psutil-5.9.1.tar.gz", hash = "sha256:57f1819b5d9e95cdfb0c881a8a5b7d542ed0b7c522d575706a80bedc848c8954"},
+]
 psycopg2-binary = [
     {file = "psycopg2-binary-2.9.3.tar.gz", hash = "sha256:761df5313dc15da1502b21453642d7599d26be88bff659382f8f9747c7ebea4e"},
     {file = "psycopg2_binary-2.9.3-cp310-cp310-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:539b28661b71da7c0e428692438efbcd048ca21ea81af618d845e06ebfd29478"},
@@ -2563,12 +2697,29 @@ psycopg2-binary = [
 ptable = [
     {file = "PTable-0.9.2.tar.gz", hash = "sha256:aa7fc151cb40f2dabcd2275ba6f7fd0ff8577a86be3365cd3fb297cbe09cc292"},
 ]
-py = []
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
 pyaml = [
     {file = "pyaml-21.10.1-py2.py3-none-any.whl", hash = "sha256:19985ed303c3a985de4cf8fd329b6d0a5a5b5c9035ea240eccc709ebacbaf4a0"},
     {file = "pyaml-21.10.1.tar.gz", hash = "sha256:c6519fee13bf06e3bb3f20cacdea8eba9140385a7c2546df5dbae4887f768383"},
 ]
-pyasn1 = []
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
 pybrowserid = [
     {file = "PyBrowserID-0.10.0.tar.gz", hash = "sha256:e540cfe54c2c3cfb8cc7e5c33fe19d9e7c2ad267063afe1f699a8e1b03d940d7"},
 ]
@@ -2576,7 +2727,10 @@ pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
     {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
 ]
-pycparser = []
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
 pycryptodome = [
     {file = "pycryptodome-3.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ff7ae90e36c1715a54446e7872b76102baa5c63aa980917f4aa45e8c78d1a3ec"},
     {file = "pycryptodome-3.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2ffd8b31561455453ca9f62cb4c24e6b8d119d6d531087af5f14b64bee2c23e6"},
@@ -2613,7 +2767,10 @@ pyflakes = [
     {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
     {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
 ]
-pyjwt = []
+pyjwt = [
+    {file = "PyJWT-1.5.3-py2.py3-none-any.whl", hash = "sha256:a4e5f1441e3ca7b382fd0c0b416777ced1f97c64ef0c33bfa39daf38505cfd2f"},
+    {file = "PyJWT-1.5.3.tar.gz", hash = "sha256:500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7"},
+]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
@@ -2672,7 +2829,10 @@ pytest-xdist = [
     {file = "pytest-xdist-1.27.0.tar.gz", hash = "sha256:a96ed691705882560fa3fc95531fbd4c224896c827f4004817eb2dcac4ba41a2"},
     {file = "pytest_xdist-1.27.0-py2.py3-none-any.whl", hash = "sha256:a64915be2b23235d6cec0992b8f59b791d64083756fbf13cf574fa5757085bc7"},
 ]
-python-dateutil = []
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
 python-jose = [
     {file = "python-jose-2.0.2.tar.gz", hash = "sha256:391f860dbe274223d73dd87de25e4117bf09e8fe5f93a417663b1f2d7b591165"},
     {file = "python_jose-2.0.2-py2.py3-none-any.whl", hash = "sha256:3b35cdb0e55a88581ff6d3f12de753aa459e940b50fe7ca5aa25149bc94cb37b"},
@@ -2685,8 +2845,51 @@ pytz = [
     {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
     {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
-pywin32 = []
-pyyaml = []
+pywin32 = [
+    {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
+    {file = "pywin32-227-cp27-cp27m-win_amd64.whl", hash = "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116"},
+    {file = "pywin32-227-cp35-cp35m-win32.whl", hash = "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"},
+    {file = "pywin32-227-cp35-cp35m-win_amd64.whl", hash = "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4"},
+    {file = "pywin32-227-cp36-cp36m-win32.whl", hash = "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be"},
+    {file = "pywin32-227-cp36-cp36m-win_amd64.whl", hash = "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2"},
+    {file = "pywin32-227-cp37-cp37m-win32.whl", hash = "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507"},
+    {file = "pywin32-227-cp37-cp37m-win_amd64.whl", hash = "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511"},
+    {file = "pywin32-227-cp38-cp38-win32.whl", hash = "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc"},
+    {file = "pywin32-227-cp38-cp38-win_amd64.whl", hash = "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e"},
+    {file = "pywin32-227-cp39-cp39-win32.whl", hash = "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295"},
+    {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
+]
+pyyaml = [
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
 rdflib = [
     {file = "rdflib-4.2.2-py3-none-any.whl", hash = "sha256:58d5994610105a457cff7fdfe3d683d87786c5028a45ae032982498a7e913d6f"},
     {file = "rdflib-4.2.2.tar.gz", hash = "sha256:da1df14552555c5c7715d8ce71c08f404c988c58a1ecd38552d0da4fc261280d"},
@@ -2699,12 +2902,18 @@ rdflib-jsonld = [
     {file = "repoze.debug-1.1-py2-none-any.whl", hash = "sha256:1d90e5b088b167bcde13bdedfe2e34f15fe8a1f53103e406e49b7c11be4d994d"},
     {file = "repoze.debug-1.1.tar.gz", hash = "sha256:f897fbb3a09499b0cee3fe2c5e4579ff04e5b0b87b1aad6098d242cbbf573000"},
 ]
-requests = []
+requests = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
 responses = [
     {file = "responses-0.21.0-py3-none-any.whl", hash = "sha256:2dcc863ba63963c0c3d9ee3fa9507cbe36b7d7b0fccb4f0bdfd9e96c539b1487"},
     {file = "responses-0.21.0.tar.gz", hash = "sha256:b82502eb5f09a0289d8e209e7bad71ef3978334f56d09b444253d5ad67bf5253"},
 ]
-rfc3986 = []
+rfc3986 = [
+    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
+]
 rsa = [
     {file = "rsa-3.3-py2.py3-none-any.whl", hash = "sha256:928fdb62edfff5c9860f932f76aea7c94bfbcd3f0e7acf6dd64ccd19a597e9c7"},
     {file = "rsa-3.3.tar.gz", hash = "sha256:03f3d9bebad06681771016b8752a40b12f615ff32363c7aa19b3798e73ccd615"},
@@ -2713,7 +2922,10 @@ rutter = [
     {file = "rutter-0.4-py2.py3-none-any.whl", hash = "sha256:f6a9b6c8b45ee686ec260265a89013041e36d8dd0000df197723837a968b1c7f"},
     {file = "rutter-0.4.tar.gz", hash = "sha256:e091ba49946022018a470701993152b96ca7b8997be3f85fc56f6b050372f914"},
 ]
-s3transfer = []
+s3transfer = [
+    {file = "s3transfer-0.6.0-py3-none-any.whl", hash = "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd"},
+    {file = "s3transfer-0.6.0.tar.gz", hash = "sha256:2ed07d3866f523cc561bf4a00fc5535827981b117dd7876f036b0c1aca42c947"},
+]
 semantic-version = [
     {file = "semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177"},
     {file = "semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c"},
@@ -2785,9 +2997,18 @@ simplejson = [
     {file = "simplejson-3.17.6-cp39-cp39-win_amd64.whl", hash = "sha256:3fe87570168b2ae018391e2b43fbf66e8593a86feccb4b0500d134c998983ccc"},
     {file = "simplejson-3.17.6.tar.gz", hash = "sha256:cf98038d2abf63a1ada5730e91e84c642ba6c225b0198c3684151b1f80c5f8a6"},
 ]
-six = []
-smmap = []
-soupsieve = []
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+smmap = [
+    {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
+    {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
+]
+soupsieve = [
+    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
+    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
+]
 sparqlwrapper = [
     {file = "SPARQLWrapper-1.8.5-py2-none-any.whl", hash = "sha256:357ee8a27bc910ea13d77836dbddd0b914991495b8cc1bf70676578155e962a8"},
     {file = "SPARQLWrapper-1.8.5-py2.7.egg", hash = "sha256:17ec44b08b8ae2888c801066249f74fe328eec25d90203ce7eadaf82e64484c7"},
@@ -2816,7 +3037,10 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.3.16-cp38-cp38-win_amd64.whl", hash = "sha256:7d98e0785c4cd7ae30b4a451416db71f5724a1839025544b4edbd92e00b91f0f"},
     {file = "SQLAlchemy-1.3.16.tar.gz", hash = "sha256:7224e126c00b8178dfd227bc337ba5e754b197a3867d33b9f30dc0208f773d70"},
 ]
-structlog = []
+structlog = [
+    {file = "structlog-19.2.0-py2.py3-none-any.whl", hash = "sha256:6640e6690fc31d5949bc614c1a630464d3aaa625284aeb7c6e486c3010d73e12"},
+    {file = "structlog-19.2.0.tar.gz", hash = "sha256:4287058cf4ce1a59bc5dea290d6386d37f29a37529c9a51cdf7387e51710152b"},
+]
 submit4dn = [
     {file = "Submit4DN-0.9.7-py2-none-any.whl", hash = "sha256:61bb192c86fc3d50c7ed679c7309c20cd0fba17d99fd8a5f355b875dc3a1496c"},
     {file = "Submit4DN-0.9.7-py3-none-any.whl", hash = "sha256:c487e00ab5b1b32bf9e17a73b0542fb2569e31f23937f353f32f9ad6b1a9ba07"},
@@ -2829,7 +3053,10 @@ supervisor = [
     {file = "supervisor-4.2.4-py2.py3-none-any.whl", hash = "sha256:bbae57abf74e078fe0ecc9f30068b6da41b840546e233ef1e659a12e4c875af6"},
     {file = "supervisor-4.2.4.tar.gz", hash = "sha256:40dc582ce1eec631c3df79420b187a6da276bbd68a4ec0a8f1f123ea616b97a2"},
 ]
-toml = []
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
 transaction = [
     {file = "transaction-2.4.0-py2.py3-none-any.whl", hash = "sha256:b96a5e9aaa73f905759bc9ccf0021bf4864c01ac36666e0d28395e871f6d584a"},
     {file = "transaction-2.4.0.tar.gz", hash = "sha256:726059c461b9ec4e69e5bead6680667a3db01bf2adf901f23e4031228a0f9f9f"},
@@ -2846,20 +3073,41 @@ types-s3transfer = [
     {file = "types-s3transfer-0.6.0.post4.tar.gz", hash = "sha256:0c45331bfd0db210f5043efd2bc3ecd4b3482a02c28faea33edf719b6be38431"},
     {file = "types_s3transfer-0.6.0.post4-py3-none-any.whl", hash = "sha256:78f9ea029fedc97e1a5d323edd149a827d4ab361d11cd92bb1b5f235ff84ba72"},
 ]
-typing-extensions = []
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
 uptime = [
     {file = "uptime-3.0.1.tar.gz", hash = "sha256:7c300254775b807ce46e3dcbcda30aa3b9a204b9c57a7ac1e79ee6dbe3942973"},
 ]
-urllib3 = []
+urllib3 = [
+    {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
+    {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
+]
 venusian = [
     {file = "venusian-1.2.0-py2.py3-none-any.whl", hash = "sha256:2f2d077a1eedc3fda40425f65687c8c494da7e83d7c23bc2c4d1a40eb3ca5b6d"},
     {file = "venusian-1.2.0.tar.gz", hash = "sha256:64ec8285b80b110d0ae5db4280e90e31848a59db98db1aba4d7d46f48ce91e3e"},
 ]
-waitress = []
-webencodings = []
-webob = []
-websocket-client = []
-webtest = []
+waitress = [
+    {file = "waitress-2.1.2-py3-none-any.whl", hash = "sha256:7500c9625927c8ec60f54377d590f67b30c8e70ef4b8894214ac6e4cad233d2a"},
+    {file = "waitress-2.1.2.tar.gz", hash = "sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"},
+]
+webencodings = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+webob = [
+    {file = "WebOb-1.8.7-py2.py3-none-any.whl", hash = "sha256:73aae30359291c14fa3b956f8b5ca31960e420c28c1bec002547fb04928cf89b"},
+    {file = "WebOb-1.8.7.tar.gz", hash = "sha256:b64ef5141be559cfade448f044fa45c2260351edcb6a8ef6b7e00c7dcef0c323"},
+]
+websocket-client = [
+    {file = "websocket-client-1.3.3.tar.gz", hash = "sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1"},
+    {file = "websocket_client-1.3.3-py3-none-any.whl", hash = "sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877"},
+]
+webtest = [
+    {file = "WebTest-2.0.35-py2.py3-none-any.whl", hash = "sha256:44ddfe99b5eca4cf07675e7222c81dd624d22f9a26035d2b93dc8862dc1153c6"},
+    {file = "WebTest-2.0.35.tar.gz", hash = "sha256:aac168b5b2b4f200af4e35867cf316712210e3d5db81c1cbdff38722647bb087"},
+]
 werkzeug = [
     {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
     {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
@@ -2945,7 +3193,10 @@ xmltodict = [
     {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
     {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
 ]
-zipp = []
+zipp = [
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
+]
 "zope.deprecation" = [
     {file = "zope.deprecation-4.4.0-py2.py3-none-any.whl", hash = "sha256:f1480b74995958b24ce37b0ef04d3663d2683e5d6debc96726eff18acf4ea113"},
     {file = "zope.deprecation-4.4.0.tar.gz", hash = "sha256:0d453338f04bacf91bbfba545d8bcdf529aa829e67b705eac8c1a7fdce66e2df"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.4.18"  # 4.0.0 introduced containerization
+version = "4.5.0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -44,7 +44,7 @@ certifi = ">=2021.5.30"
 chardet = "3.0.4"
 colorama = "0.3.3"
 dcicsnovault = "^6.0.0"
-dcicutils = "^4.0.0"
+dcicutils = "^4.1.0"
 elasticsearch = "6.8.1"
 elasticsearch-dsl = "^6.4.0"  # TODO: port code from cgap-portal to get rid of uses
 execnet = "1.4.1"

--- a/src/encoded/commands/clear_db_es_contents.py
+++ b/src/encoded/commands/clear_db_es_contents.py
@@ -4,10 +4,12 @@ import structlog
 import transaction
 
 from dcicutils.env_utils import is_stg_or_prd_env
+from dcicutils.lang_utils import disjoined_list
 from pyramid.paster import get_app
 from snovault import DBSESSION
 from snovault.elasticsearch.create_mapping import run as run_create_mapping
 from sqlalchemy import MetaData
+from typing import Optional, List
 from zope.sqlalchemy import mark_changed
 from .. import configure_dbsession
 
@@ -39,8 +41,7 @@ def clear_db_tables(app):
         for table in meta.sorted_tables:
             connection.execute(table.delete())
     except Exception as e:
-        log.error('clear_db_es_contents: error on DB drop_all/create_all.'
-                  ' Error : %s' % str(e))
+        log.error(f"clear_db_es_contents: Error on DB drop_all/create_all. {type(e)}: {e}")
         transaction.abort()
     else:
         # commit all changes to DB
@@ -51,55 +52,61 @@ def clear_db_tables(app):
     return success
 
 
-def run_clear_db_es(app, arg_env, arg_skip_es=False):
+SKIPPING_CLEAR_ATTEMPT = 'Skipping the attempt to clear DB.'
+
+
+def run_clear_db_es(app, only_envs: Optional[List[str]] = None, skip_es: bool = False) -> bool:
     """
     This function actually clears DB/ES. Takes a Pyramid app as well as two flags. _Use with care!_
 
-    For safety, this function will return without side-effect on any production system.
-
-    Also does additional checks based on arguments supplied:
-
-    If an `arg_env` (default None) is given as a non-empty string value,
-    this function will return without side-effect if the current app environment does not match the given value.
+    For safety, this function will return without side-effect if ...
+    - The current environment is any production system.
+    - The current environment is not a member of the `only_envs` argument (list).
 
     If `arg_skip_es` (default False) is True, this function will return after DB clear
     and before running create_mapping.
 
     Args:
         app: Pyramid application
-        arg_env (str): if provided, only run if environment matches this value
-        arg_skip_es (bool): if True, do not run create_mapping after DB clear
+        only_envs (list): a list of env names that are the only envs where this action will run
+        skip_es (bool): if True, do not run create_mapping after DB clear
 
     Returns:
         bool: True if DB was cleared (regardless of ES)
     """
-    env = app.registry.settings.get('env.name', '')
-    # for now, do NOT allow clearing of production systems
-    if is_stg_or_prd_env(env):
-        log.error('clear_db_es_contents: will NOT run on env %s. Exiting...' % env)
-        return False
-    if arg_env and arg_env != env:
-        log.error('clear_db_es_contents: environment mismatch! Given --env %s '
-                  'does not match current env %s. Exiting....' % (arg_env, env))
+    current_env = app.registry.settings.get('env.name', 'local')
+
+    if is_stg_or_prd_env(current_env):
+        log.error(f"clear_db_es_contents: This action cannot be performed on env {current_env}"
+                  f" because it is a production-class (stg or prd) environment."
+                  f" {SKIPPING_CLEAR_ATTEMPT}")
         return False
 
-    log.info('clear_db_es_contents: clearing DB tables...')
+    if only_envs and current_env not in only_envs:
+        log.error(f"clear_db_es_contents: The current environment, {current_env}, is not {disjoined_list(only_envs)}."
+                  f" {SKIPPING_CLEAR_ATTEMPT}")
+        return False
+
+    log.info('clear_db_es_contents: Clearing DB tables...')
     db_success = clear_db_tables(app)
     if not db_success:
-        log.error('clear_db_es_contents: clearing DB failed! Try to run again.'
-                  ' This command can fail if there are external DB connections')
+        log.error("clear_db_es_contents: Clearing DB tables failed!"
+                  " Such failures may happen, for example, when there are external DB connections."
+                  " You might want to try running clear_db_es_contents again.")
         return False
-    log.info('clear_db_es_contents: successfully cleared DB')
+    log.info("clear_db_es_contents: Successfully cleared DB.")
 
     # create mapping after clear DB to remove ES contents
-    if not arg_skip_es:
-        log.info('clear_db_es_contents: clearing ES with create_mapping...')
+    if not skip_es:
+        log.info("clear_db_es_contents: Clearing ES with create_mapping...")
         run_create_mapping(app, purge_queue=True)
-    log.info('clear_db_es_contents: done!')
+        log.info("clear_db_es_contents: Successfully cleared ES.")
+
+    log.info("clear_db_es_contents: All done.")
     return True
 
 
-def main():
+def main(simulated_args=None):
     logging.basicConfig()
     # Loading app will have configured from config file. Reconfigure here:
     logging.getLogger('encoded').setLevel(logging.DEBUG)
@@ -110,28 +117,44 @@ def main():
     )
     parser.add_argument('config_uri', help='path to configfile')
     parser.add_argument('--app-name', help='Pyramid app name in configfile')
-    parser.add_argument('--env', help='If provided, only run if on given environment')
+    parser.add_argument('--only-if-env', '--only-if-envs', dest='only_envs', default=None,
+                        help=("A comma-separated list of envs where this action is allowed to run."
+                              " If omitted, any env is OK to run."))
+    parser.add_argument("--confirm", action="store_true", dest="confirm", default=None,
+                        help="Specify --confirm to require interactive confirmation.")
+    parser.add_argument("--no-confirm", action="store_false", dest="confirm", default=None,
+                        help="Specify --no-confirm to suppress interactive confirmation.")
     parser.add_argument('--skip-es', action='store_true', default=False,
                         help='If set, do not run create_mapping after DB drop')
-    args = parser.parse_args()
+    args = parser.parse_args(simulated_args)
+
+    confirm = args.confirm
+    app_name = args.app_name
+    config_uri = args.config_uri
+    only_envs = args.only_envs
+    skip_es = args.skip_es
+
+    if confirm is None:
+        confirm = not only_envs  # If only_envs is supplied, we have better protection so don't need to confirm
 
     # get the pyramids app
-    app = get_app(args.config_uri, args.app_name)
+    app = get_app(config_uri, app_name)
 
     # create db schema
     configure_dbsession(app)
 
-    # confirm with user if not providing a specific env
-    if not args.env:
-        disp_env = app.registry.settings.get('env.name', 'local')
-        name = input('This will completely clear DB contents for environment %s.'
-                     ' Type the env name to confirm: ' % disp_env)
-        if str(name) != disp_env:
-            print("Could not confirm env. Exiting...")
+    only_envs = [x for x in (only_envs or "").split(',') if x]
+
+    if confirm:
+        env_to_confirm = app.registry.settings.get('env.name', 'local')
+        env_confirmation = input(f'This will completely clear DB contents for environment {env_to_confirm}.\n'
+                                 f' Type the env name to confirm: ')
+        if env_confirmation != env_to_confirm:
+            print(f"NOT confirmed. {SKIPPING_CLEAR_ATTEMPT}")
             return
 
     # actually run. split this out for easy testing
-    run_clear_db_es(app, args.env, args.skip_es)
+    run_clear_db_es(app=app, only_envs=only_envs, skip_es=skip_es)
 
 
 if __name__ == '__main__':

--- a/src/encoded/tests/test_clear_db_es_contents.py
+++ b/src/encoded/tests/test_clear_db_es_contents.py
@@ -1,14 +1,48 @@
+import contextlib
 import pytest
 
+from dcicutils.common import OrchestratedApp
+from dcicutils.env_utils import EnvUtils, APP_FOURFRONT
+from dcicutils.lang_utils import disjoined_list
 from unittest import mock
+from ..commands import clear_db_es_contents as clear_db_es_contents_module
 from ..commands.clear_db_es_contents import (
     clear_db_tables,
-    run_clear_db_es
+    run_clear_db_es,
+    main as clear_db_es_contents_main
 )
-from ..commands import clear_db_es_contents
 
 
-pytestmark = [pytest.mark.setone, pytest.mark.working]
+pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.indexing]
+
+
+def is_running_app(app: OrchestratedApp) -> bool:  # Move to dcicutils.env_utils
+    return app == EnvUtils.ORCHESTRATED_APP
+
+
+class MockLog:
+
+    def __init__(self, *, messages=None, key=None):
+        self.messages = messages or {}
+        self.key = key
+
+    def _addmsg(self, kind, msg):
+        self.messages[kind] = msgs = self.messages.get(kind, [])
+        msgs.append(msg[self.key] if self.key else msg)
+
+    def error(self, msg):
+        self._addmsg('error', msg)
+
+    def info(self, msg):
+        self._addmsg('info', msg)
+
+
+@contextlib.contextmanager
+def logged_messages(**kwargs):
+    mocked_log = MockLog()
+    with mock.patch.object(clear_db_es_contents_module, "log", mocked_log):
+        yield mocked_log
+        assert mocked_log.messages == dict(**kwargs)
 
 
 def test_clear_db_tables(app, testapp):
@@ -22,56 +56,254 @@ def test_clear_db_tables(app, testapp):
     testapp.get(post_res.location, status=404)
 
 
-def test_run_clear_db_envs(app, testapp):
+_FOURFRONT_PRODUCTION_ENVS = ['fourfront-production-blue', 'fourfront-production-green', 'data', 'staging']
+# Really we only care about the first of these names, but the rest are names that were at one time
+# planned to be stg or prd names for cgap, so we'll use them to tell that run_clear_db_es is properly
+# skipping any such names. -kmp 4-Jun-2022
+_CGAP_PRODUCTION_ENVS = ['fourfront-cgap', 'fourfront-cgap-green', 'cgap-green', 'fourfront-cgap-blue', 'cgap-blue']
 
-    orig_env = app.registry.settings.get('env.name')
+_PRODUCTION_ENVS = _FOURFRONT_PRODUCTION_ENVS if is_running_app(APP_FOURFRONT) else _CGAP_PRODUCTION_ENVS
 
-    def test_clear(env_to_simulate, expecting_to_clear, arg_env=None):
-        old_settings = app.registry.settings
-        app.registry.settings = app.registry.settings.copy()
-        try:
-            print("Testing clear of", env_to_simulate)
-            if env_to_simulate:
-                app.registry.settings['env.name'] = env_to_simulate
-            actually_cleared = run_clear_db_es(app, arg_env=arg_env, arg_skip_es=True)
-            assert actually_cleared == expecting_to_clear
-        finally:
-            app.registry.settings = old_settings
+TEST_ENV = 'fourfront-mastertest' if is_running_app(APP_FOURFRONT) else 'cgap-devtest'
 
-    test_clear(env_to_simulate=None, expecting_to_clear=True)
+OTHER_ENV = 'fourfront-foo' if is_running_app(APP_FOURFRONT) else 'cgap-foo'
 
-    post_res = testapp.post_json('/testing-post-put-patch/', {'required': 'abc'}, status=201)
-    testapp.get(post_res.location, status=200)
 
-    with mock.patch.object(clear_db_es_contents, "clear_db_tables") as mock_clear_db_tables:
 
-        # This is a backstop in case our logic is wrong so we don't fall through to catastrophe.
-        def mocked_clear_db_tables(*args, **kwargs):
-            raise AssertionError("mocked clear_db_tables called with %r and %r" % (args, kwargs))
+@contextlib.contextmanager
+def local_env_name_registry_setting_for_testing(app, envname):
+    old_env = app.registry.settings.get('env.name')
+    print(f"Remembering old env.name = {old_env}")
+    try:
+        app.registry.settings['env.name'] = envname
+        print(f"Set env.name = {envname}")
+        yield
+    finally:
+        if old_env is None:
+            print(f"Removing env.name")
+            del app.registry.settings['env.name']
+        else:
+            print(f"Restoring env.name to {old_env}")
+            app.registry.settings['env.name'] = old_env
 
-        mock_clear_db_tables.side_effect = mocked_clear_db_tables
 
-        # should never run on these envs (but we have mocked out the clear_db_tables just in case)
-        test_clear(env_to_simulate='data', expecting_to_clear=False)
-        test_clear(env_to_simulate='staging', expecting_to_clear=False)
-        test_clear(env_to_simulate='fourfront-production-blue', expecting_to_clear=False)
-        test_clear(env_to_simulate='fourfront-production-green', expecting_to_clear=False)
-        # Let's NOT test green and just assume it works, rather than risking a public catastrophe if we goofed
-        # on BOTH the logic and the mocking. Unlikely, but hey, weirder things have happened. -kmp 3-Apr-2020
+@contextlib.contextmanager
+def input_mocked(*inputs):
+    input_stack = list(reversed(inputs))
 
-        testapp.get(post_res.location, status=200)
+    def mocked_input(*args, **kwargs):
+        assert input_stack, "There is insufficient mocked input available."
+        return input_stack.pop()
 
-    # test if we are only running on specific envs...
+    with mock.patch.object(clear_db_es_contents_module, "input") as mock_input:
+        mock_input.side_effect = mocked_input
+        yield mock_input
+        assert not input_stack, "Not all inputs were used."
+        assert mock_input.call_count == len(inputs)
 
-    # If the current environment (simulated for our test) is NOT the same as the env we declare we want,
-    # this should return immediately False rather than clearing the DB.
-    test_clear(env_to_simulate='fourfront-test-env', expecting_to_clear=False, arg_env='fourfront-other-env')
-    testapp.get(post_res.location, status=200)
 
-    # If the current environment (simulated for our test) IS the same as the env we declare we want,
-    # this should clear the DB and return True.
-    test_clear(env_to_simulate='fourfront-test-env', expecting_to_clear=True, arg_env='fourfront-test-env')
-    testapp.get(post_res.location, status=404)
+@pytest.mark.unit
+def test_run_clear_db_es_unit(app, testapp):
 
-    # This just makes sure our cleanups on calls to test_clear() are actually working.
-    assert app.registry.settings.get('env.name') == orig_env
+    def mocked_is_stg_or_prd_env(env):
+        result = env.endswith("blue") or env.endswith("green") or env.endswith("cgap")
+        print(f"Mocked is_stg_or_prd_env({env}) returning {result}.")
+        return result
+
+    with mock.patch.object(clear_db_es_contents_module, "is_stg_or_prd_env") as mock_is_stg_or_prd_env:
+        mock_is_stg_or_prd_env.side_effect = mocked_is_stg_or_prd_env
+        with mock.patch.object(clear_db_es_contents_module, "clear_db_tables") as mock_clear_db_tables:
+            with mock.patch.object(clear_db_es_contents_module, "run_create_mapping") as mock_run_create_mapping:
+
+                expected_db_clears = 0
+                expected_es_clears = 0
+
+                assert mock_clear_db_tables.call_count == expected_db_clears
+                assert mock_run_create_mapping.call_count == expected_es_clears
+
+                # It works positionally
+                assert run_clear_db_es(app, None, True) is True
+                expected_db_clears += 1
+                expected_es_clears += 0
+
+                assert mock_clear_db_tables.call_count == expected_db_clears
+                assert mock_run_create_mapping.call_count == expected_es_clears
+
+                # It works by keyword argument
+                assert run_clear_db_es(app, only_envs=None, skip_es=True) is True
+                expected_db_clears += 1
+                expected_es_clears += 0
+
+                assert mock_clear_db_tables.call_count == expected_db_clears
+                assert mock_run_create_mapping.call_count == expected_es_clears
+
+                for production_env in _PRODUCTION_ENVS:
+                    with local_env_name_registry_setting_for_testing(app, production_env):
+                        # should never run on production envs env
+                        assert clear_db_es_contents_module.is_stg_or_prd_env(production_env) is True
+                        with logged_messages(error=[
+                            (f'clear_db_es_contents: This action cannot be performed on env {production_env}'
+                             f' because it is a production-class (stg or prd) environment.'
+                             f' Skipping the attempt to clear DB.')]):
+                            assert run_clear_db_es(app, only_envs=None, skip_es=True) is False
+                        expected_db_clears += 0
+                        expected_es_clears += 0
+                        assert mock_clear_db_tables.call_count == expected_db_clears
+                        assert mock_run_create_mapping.call_count == expected_es_clears
+
+                test_env = 'fourfront-test-env'
+                with local_env_name_registry_setting_for_testing(app, test_env):
+
+                    allowed_envs = ['fourfront-other-env']
+
+                    # test if we are only running on specific envs
+                    with logged_messages(error=[(f'clear_db_es_contents: The current environment, {test_env},'
+                                                 f' is not {disjoined_list(allowed_envs)}.'
+                                                 f' Skipping the attempt to clear DB.')]):
+                        assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=True) is False
+                    expected_db_clears += 0
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    # test again if we are only running on specific envs
+                    with logged_messages(error=[(f'clear_db_es_contents: The current environment, {test_env},'
+                                                 f' is not {disjoined_list(allowed_envs)}.'
+                                                 f' Skipping the attempt to clear DB.')]):
+                        assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=False) is False
+                    expected_db_clears += 0
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-test-env'], skip_es=True) is True
+                    expected_db_clears += 1
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    # test again if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=['fourfront-test-env'], skip_es=False) is True
+                    expected_db_clears += 1
+                    expected_es_clears += 1
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    allowed_envs = ['fourfront-test-env-decoy-1', 'fourfront-test-env-decoy-2']
+                    # test if we are only running on specific envs
+                    with logged_messages(error=[(f'clear_db_es_contents: The current environment, {test_env},'
+                                                 f' is not {disjoined_list(allowed_envs)}.'
+                                                 f' Skipping the attempt to clear DB.')]):
+                        assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=False) is False
+                    expected_db_clears += 0
+                    expected_es_clears += 0
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+                    allowed_envs = ['fourfront-test-env-decoy-1', test_env]
+                    # test if we are only running on specific envs
+                    assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=False) is True
+                    expected_db_clears += 1
+                    expected_es_clears += 1
+                    assert mock_clear_db_tables.call_count == expected_db_clears
+                    assert mock_run_create_mapping.call_count == expected_es_clears
+
+
+@pytest.mark.unit
+def test_clear_db_es_contents_main():
+
+    class FakeApp:
+
+        class Registry:
+            def __init__(self):
+                self.settings = {}
+
+        def __init__(self, config_uri, appname):
+            self.appname = appname
+            self.config_uri = config_uri
+            self.registry = self.Registry()
+
+        def __str__(self):
+            return f"<FakeApp {self.appname} {self.config_uri} {id(self)}>"
+
+        def __repr__(self):
+            return str(self)
+
+    class MockDBSession:
+
+        def __init__(self, app):
+            self.app = app
+
+    apps = {}
+
+    def mocked_get_app(config_uri, appname):
+        key = (config_uri, appname)
+        app = apps.get(key)
+        if not app:
+            apps[key] = app = FakeApp(config_uri, appname)
+        return app
+
+    def mocked_configure_dbsession(app):
+        return MockDBSession(app)
+
+    with mock.patch.object(clear_db_es_contents_module, "run_clear_db_es") as mock_run_clear_db_es:
+        with mock.patch.object(clear_db_es_contents_module, "get_app") as mock_get_app:
+            mock_get_app.side_effect = mocked_get_app
+            with mock.patch.object(clear_db_es_contents_module, "configure_dbsession") as mock_configure_dbsession:
+                mock_configure_dbsession.side_effect = mocked_configure_dbsession
+
+                config_uri = 'production.ini'
+                appname = "app"
+
+                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
+
+                    clear_db_es_contents_main([config_uri])
+                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, None),
+                                                            only_envs=[],
+                                                            skip_es=False)
+
+                with input_mocked():  # No input prompting will occur because --no-confirm was supplied.
+
+                    clear_db_es_contents_main([config_uri, "--no-confirm"])
+                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, None),
+                                                            only_envs=[],
+                                                            skip_es=False)
+
+                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
+
+                    clear_db_es_contents_main([config_uri, "--app-name", appname])
+                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                            only_envs=[],
+                                                            skip_es=False)
+
+                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
+
+                    clear_db_es_contents_main([config_uri, "--app-name", appname, '--skip-es'])
+                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                            only_envs=[],
+                                                            skip_es=True)
+
+
+                with input_mocked():  # No input prompting will occur because --only-if-env was supplied.
+
+                    clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", TEST_ENV])
+                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                            only_envs=[TEST_ENV],
+                                                            skip_es=False)
+
+                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
+
+                    clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", TEST_ENV,
+                                               "--confirm"])
+                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                            only_envs=[TEST_ENV],
+                                                            skip_es=False)
+
+                with input_mocked():  # No input prompting will occur because --only-if-env was supplied.
+
+                    clear_db_es_contents_main([config_uri, "--app-name", appname,
+                                               "--only-if-env", f"{TEST_ENV},{OTHER_ENV}"])
+                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                            only_envs=[TEST_ENV, OTHER_ENV],
+                                                            skip_es=False)

--- a/src/encoded/tests/test_clear_db_es_contents.py
+++ b/src/encoded/tests/test_clear_db_es_contents.py
@@ -1,9 +1,9 @@
 import contextlib
 import pytest
 
-from dcicutils.common import OrchestratedApp
-from dcicutils.env_utils import EnvUtils, APP_FOURFRONT
+from dcicutils.env_utils import EnvUtils
 from dcicutils.lang_utils import disjoined_list
+from dcicutils.qa_utils import logged_messages, input_mocked
 from unittest import mock
 from ..commands import clear_db_es_contents as clear_db_es_contents_module
 from ..commands.clear_db_es_contents import (
@@ -14,35 +14,6 @@ from ..commands.clear_db_es_contents import (
 
 
 pytestmark = [pytest.mark.setone, pytest.mark.working, pytest.mark.indexing]
-
-
-def is_running_app(app: OrchestratedApp) -> bool:  # Move to dcicutils.env_utils
-    return app == EnvUtils.ORCHESTRATED_APP
-
-
-class MockLog:
-
-    def __init__(self, *, messages=None, key=None):
-        self.messages = messages or {}
-        self.key = key
-
-    def _addmsg(self, kind, msg):
-        self.messages[kind] = msgs = self.messages.get(kind, [])
-        msgs.append(msg[self.key] if self.key else msg)
-
-    def error(self, msg):
-        self._addmsg('error', msg)
-
-    def info(self, msg):
-        self._addmsg('info', msg)
-
-
-@contextlib.contextmanager
-def logged_messages(**kwargs):
-    mocked_log = MockLog()
-    with mock.patch.object(clear_db_es_contents_module, "log", mocked_log):
-        yield mocked_log
-        assert mocked_log.messages == dict(**kwargs)
 
 
 def test_clear_db_tables(app, testapp):
@@ -62,12 +33,14 @@ _FOURFRONT_PRODUCTION_ENVS = ['fourfront-production-blue', 'fourfront-production
 # skipping any such names. -kmp 4-Jun-2022
 _CGAP_PRODUCTION_ENVS = ['fourfront-cgap', 'fourfront-cgap-green', 'cgap-green', 'fourfront-cgap-blue', 'cgap-blue']
 
-_PRODUCTION_ENVS = _FOURFRONT_PRODUCTION_ENVS if is_running_app(APP_FOURFRONT) else _CGAP_PRODUCTION_ENVS
+_PRODUCTION_ENVS = EnvUtils.app_case(if_fourfront=_FOURFRONT_PRODUCTION_ENVS, if_cgap=_CGAP_PRODUCTION_ENVS)
 
-TEST_ENV = 'fourfront-mastertest' if is_running_app(APP_FOURFRONT) else 'cgap-devtest'
+TEST_ENV = EnvUtils.app_case(if_fourfront='fourfront-mastertest', if_cgap='cgap-devtest')
 
-OTHER_ENV = 'fourfront-foo' if is_running_app(APP_FOURFRONT) else 'cgap-foo'
+OTHER_ENV = EnvUtils.app_case(if_fourfront='fourfront-foo', if_cgap='cgap-foo')
 
+DECOY_ENV_1 = TEST_ENV + '-decoy-1'
+DECOY_ENV_2 = TEST_ENV + '-decoy-2'
 
 
 @contextlib.contextmanager
@@ -87,33 +60,23 @@ def local_env_name_registry_setting_for_testing(app, envname):
             app.registry.settings['env.name'] = old_env
 
 
-@contextlib.contextmanager
-def input_mocked(*inputs):
-    input_stack = list(reversed(inputs))
-
-    def mocked_input(*args, **kwargs):
-        assert input_stack, "There is insufficient mocked input available."
-        return input_stack.pop()
-
-    with mock.patch.object(clear_db_es_contents_module, "input") as mock_input:
-        mock_input.side_effect = mocked_input
-        yield mock_input
-        assert not input_stack, "Not all inputs were used."
-        assert mock_input.call_count == len(inputs)
-
-
 @pytest.mark.unit
 def test_run_clear_db_es_unit(app, testapp):
 
-    def mocked_is_stg_or_prd_env(env):
-        result = env.endswith("blue") or env.endswith("green") or env.endswith("cgap")
-        print(f"Mocked is_stg_or_prd_env({env}) returning {result}.")
-        return result
+    with mock.patch.object(clear_db_es_contents_module, "clear_db_tables") as mock_clear_db_tables:
+        with mock.patch.object(clear_db_es_contents_module, "run_create_mapping") as mock_run_create_mapping:
 
-    with mock.patch.object(clear_db_es_contents_module, "is_stg_or_prd_env") as mock_is_stg_or_prd_env:
-        mock_is_stg_or_prd_env.side_effect = mocked_is_stg_or_prd_env
-        with mock.patch.object(clear_db_es_contents_module, "clear_db_tables") as mock_clear_db_tables:
-            with mock.patch.object(clear_db_es_contents_module, "run_create_mapping") as mock_run_create_mapping:
+            def mocked_is_stg_or_prd_env(env):
+                result = (env in _PRODUCTION_ENVS  # really this should be enough
+                          # for pragmatic redundancy since these will match our real production systems, protect them
+                          or env in _CGAP_PRODUCTION_ENVS
+                          or env in _FOURFRONT_PRODUCTION_ENVS
+                          or env.endswith("blue") or env.endswith("green") or env.endswith("cgap"))
+                print(f"Mocked is_stg_or_prd_env({env}) returning {result}.")
+                return result
+
+            with mock.patch.object(clear_db_es_contents_module, "is_stg_or_prd_env") as mock_is_stg_or_prd_env:
+                mock_is_stg_or_prd_env.side_effect = mocked_is_stg_or_prd_env
 
                 expected_db_clears = 0
                 expected_es_clears = 0
@@ -141,7 +104,7 @@ def test_run_clear_db_es_unit(app, testapp):
                     with local_env_name_registry_setting_for_testing(app, production_env):
                         # should never run on production envs env
                         assert clear_db_es_contents_module.is_stg_or_prd_env(production_env) is True
-                        with logged_messages(error=[
+                        with logged_messages(module=clear_db_es_contents_module, error=[
                             (f'clear_db_es_contents: This action cannot be performed on env {production_env}'
                              f' because it is a production-class (stg or prd) environment.'
                              f' Skipping the attempt to clear DB.')]):
@@ -151,13 +114,13 @@ def test_run_clear_db_es_unit(app, testapp):
                         assert mock_clear_db_tables.call_count == expected_db_clears
                         assert mock_run_create_mapping.call_count == expected_es_clears
 
-                test_env = 'fourfront-test-env'
-                with local_env_name_registry_setting_for_testing(app, test_env):
+                with local_env_name_registry_setting_for_testing(app, TEST_ENV):
 
-                    allowed_envs = ['fourfront-other-env']
+                    allowed_envs = [OTHER_ENV]
 
                     # test if we are only running on specific envs
-                    with logged_messages(error=[(f'clear_db_es_contents: The current environment, {test_env},'
+                    with logged_messages(module=clear_db_es_contents_module,
+                                         error=[(f'clear_db_es_contents: The current environment, {TEST_ENV},'
                                                  f' is not {disjoined_list(allowed_envs)}.'
                                                  f' Skipping the attempt to clear DB.')]):
                         assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=True) is False
@@ -167,7 +130,8 @@ def test_run_clear_db_es_unit(app, testapp):
                     assert mock_run_create_mapping.call_count == expected_es_clears
 
                     # test again if we are only running on specific envs
-                    with logged_messages(error=[(f'clear_db_es_contents: The current environment, {test_env},'
+                    with logged_messages(module=clear_db_es_contents_module,
+                                         error=[(f'clear_db_es_contents: The current environment, {TEST_ENV},'
                                                  f' is not {disjoined_list(allowed_envs)}.'
                                                  f' Skipping the attempt to clear DB.')]):
                         assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=False) is False
@@ -177,22 +141,23 @@ def test_run_clear_db_es_unit(app, testapp):
                     assert mock_run_create_mapping.call_count == expected_es_clears
 
                     # test if we are only running on specific envs
-                    assert run_clear_db_es(app, only_envs=['fourfront-test-env'], skip_es=True) is True
+                    assert run_clear_db_es(app, only_envs=[TEST_ENV], skip_es=True) is True
                     expected_db_clears += 1
                     expected_es_clears += 0
                     assert mock_clear_db_tables.call_count == expected_db_clears
                     assert mock_run_create_mapping.call_count == expected_es_clears
 
                     # test again if we are only running on specific envs
-                    assert run_clear_db_es(app, only_envs=['fourfront-test-env'], skip_es=False) is True
+                    assert run_clear_db_es(app, only_envs=[TEST_ENV], skip_es=False) is True
                     expected_db_clears += 1
                     expected_es_clears += 1
                     assert mock_clear_db_tables.call_count == expected_db_clears
                     assert mock_run_create_mapping.call_count == expected_es_clears
 
-                    allowed_envs = ['fourfront-test-env-decoy-1', 'fourfront-test-env-decoy-2']
+                    allowed_envs = [DECOY_ENV_1, DECOY_ENV_2]
                     # test if we are only running on specific envs
-                    with logged_messages(error=[(f'clear_db_es_contents: The current environment, {test_env},'
+                    with logged_messages(module=clear_db_es_contents_module,
+                                         error=[(f'clear_db_es_contents: The current environment, {TEST_ENV},'
                                                  f' is not {disjoined_list(allowed_envs)}.'
                                                  f' Skipping the attempt to clear DB.')]):
                         assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=False) is False
@@ -201,7 +166,7 @@ def test_run_clear_db_es_unit(app, testapp):
                     assert mock_clear_db_tables.call_count == expected_db_clears
                     assert mock_run_create_mapping.call_count == expected_es_clears
 
-                    allowed_envs = ['fourfront-test-env-decoy-1', test_env]
+                    allowed_envs = [DECOY_ENV_1, TEST_ENV]
                     # test if we are only running on specific envs
                     assert run_clear_db_es(app, only_envs=allowed_envs, skip_es=False) is True
                     expected_db_clears += 1
@@ -213,97 +178,120 @@ def test_run_clear_db_es_unit(app, testapp):
 @pytest.mark.unit
 def test_clear_db_es_contents_main():
 
-    class FakeApp:
+    # It should never get to these first two in this test, but they're ethere for safety.
+    with mock.patch.object(clear_db_es_contents_module, "clear_db_tables"):
+        with mock.patch.object(clear_db_es_contents_module, "run_create_mapping"):
 
-        class Registry:
-            def __init__(self):
-                self.settings = {}
+            class FakeApp:
 
-        def __init__(self, config_uri, appname):
-            self.appname = appname
-            self.config_uri = config_uri
-            self.registry = self.Registry()
+                class Registry:
+                    def __init__(self):
+                        self.settings = {}
 
-        def __str__(self):
-            return f"<FakeApp {self.appname} {self.config_uri} {id(self)}>"
+                def __init__(self, config_uri, appname):
+                    self.appname = appname
+                    self.config_uri = config_uri
+                    self.registry = self.Registry()
 
-        def __repr__(self):
-            return str(self)
+                def __str__(self):
+                    return f"<FakeApp {self.appname} {self.config_uri} {id(self)}>"
 
-    class MockDBSession:
+                def __repr__(self):
+                    return str(self)
 
-        def __init__(self, app):
-            self.app = app
+            class MockDBSession:
 
-    apps = {}
+                def __init__(self, app):
+                    self.app = app
 
-    def mocked_get_app(config_uri, appname):
-        key = (config_uri, appname)
-        app = apps.get(key)
-        if not app:
-            apps[key] = app = FakeApp(config_uri, appname)
-        return app
+            apps = {}
 
-    def mocked_configure_dbsession(app):
-        return MockDBSession(app)
+            def mocked_get_app(config_uri, appname):
+                key = (config_uri, appname)
+                app = apps.get(key)
+                if not app:
+                    apps[key] = app = FakeApp(config_uri, appname)
+                return app
 
-    with mock.patch.object(clear_db_es_contents_module, "run_clear_db_es") as mock_run_clear_db_es:
-        with mock.patch.object(clear_db_es_contents_module, "get_app") as mock_get_app:
-            mock_get_app.side_effect = mocked_get_app
-            with mock.patch.object(clear_db_es_contents_module, "configure_dbsession") as mock_configure_dbsession:
-                mock_configure_dbsession.side_effect = mocked_configure_dbsession
+            def mocked_configure_dbsession(app):
+                return MockDBSession(app)
 
-                config_uri = 'production.ini'
-                appname = "app"
+            with mock.patch.object(clear_db_es_contents_module, "run_clear_db_es") as mock_run_clear_db_es:
+                with mock.patch.object(clear_db_es_contents_module, "get_app") as mock_get_app:
+                    mock_get_app.side_effect = mocked_get_app
+                    with mock.patch.object(clear_db_es_contents_module,
+                                           "configure_dbsession") as mock_configure_dbsession:
+                        mock_configure_dbsession.side_effect = mocked_configure_dbsession
 
-                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
-
-                    clear_db_es_contents_main([config_uri])
-                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, None),
-                                                            only_envs=[],
-                                                            skip_es=False)
-
-                with input_mocked():  # No input prompting will occur because --no-confirm was supplied.
-
-                    clear_db_es_contents_main([config_uri, "--no-confirm"])
-                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, None),
-                                                            only_envs=[],
-                                                            skip_es=False)
-
-                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
-
-                    clear_db_es_contents_main([config_uri, "--app-name", appname])
-                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
-                                                            only_envs=[],
-                                                            skip_es=False)
-
-                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
-
-                    clear_db_es_contents_main([config_uri, "--app-name", appname, '--skip-es'])
-                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
-                                                            only_envs=[],
-                                                            skip_es=True)
+                        config_uri = 'production.ini'
+                        appname = "app"
 
 
-                with input_mocked():  # No input prompting will occur because --only-if-env was supplied.
+                        with input_mocked(
+                                # We'll be prompted for the environment name to confirm.
+                                "local",
+                                module=clear_db_es_contents_module):
 
-                    clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", TEST_ENV])
-                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
-                                                            only_envs=[TEST_ENV],
-                                                            skip_es=False)
+                            clear_db_es_contents_main([config_uri])
+                            mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, None),
+                                                                    only_envs=[],
+                                                                    skip_es=False)
 
-                with input_mocked("local"):  # We'll be prompted for the environment name to confirm.
+                        with input_mocked(
+                                # No input prompting will occur because --no-confirm was supplied.
+                                module=clear_db_es_contents_module):
 
-                    clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", TEST_ENV,
-                                               "--confirm"])
-                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
-                                                            only_envs=[TEST_ENV],
-                                                            skip_es=False)
+                            clear_db_es_contents_main([config_uri, "--no-confirm"])
+                            mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, None),
+                                                                    only_envs=[],
+                                                                    skip_es=False)
 
-                with input_mocked():  # No input prompting will occur because --only-if-env was supplied.
+                        with input_mocked(
+                                # We'll be prompted for the environment name to confirm.
+                                "local",
+                                module=clear_db_es_contents_module):
 
-                    clear_db_es_contents_main([config_uri, "--app-name", appname,
-                                               "--only-if-env", f"{TEST_ENV},{OTHER_ENV}"])
-                    mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
-                                                            only_envs=[TEST_ENV, OTHER_ENV],
-                                                            skip_es=False)
+                            clear_db_es_contents_main([config_uri, "--app-name", appname])
+                            mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                                    only_envs=[],
+                                                                    skip_es=False)
+
+                        with input_mocked(
+                                # We'll be prompted for the environment name to confirm.
+                                "local",
+                                module=clear_db_es_contents_module):
+
+                            clear_db_es_contents_main([config_uri, "--app-name", appname, '--skip-es'])
+                            mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                                    only_envs=[],
+                                                                    skip_es=True)
+
+                        with input_mocked(
+                                # No input prompting will occur because --only-if-env was supplied.
+                                module=clear_db_es_contents_module):
+
+                            clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", TEST_ENV])
+                            mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                                    only_envs=[TEST_ENV],
+                                                                    skip_es=False)
+
+                        with input_mocked(
+                                # We'll be prompted for the environment name to confirm.
+                                "local",
+                                module=clear_db_es_contents_module):
+
+                            clear_db_es_contents_main([config_uri, "--app-name", appname, "--only-if-env", TEST_ENV,
+                                                       "--confirm"])
+                            mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                                    only_envs=[TEST_ENV],
+                                                                    skip_es=False)
+
+                        with input_mocked(
+                                # No input prompting will occur because --only-if-env was supplied.
+                                module=clear_db_es_contents_module):
+
+                            clear_db_es_contents_main([config_uri, "--app-name", appname,
+                                                       "--only-if-env", f"{TEST_ENV},{OTHER_ENV}"])
+                            mock_run_clear_db_es.assert_called_with(app=mocked_get_app(config_uri, appname),
+                                                                    only_envs=[TEST_ENV, OTHER_ENV],
+                                                                    skip_es=False)

--- a/src/encoded/tests/test_create_mapping.py
+++ b/src/encoded/tests/test_create_mapping.py
@@ -111,7 +111,7 @@ def test_get_deployment_config_prod():
     assert cfg['ENV_NAME'] == my_env  # sanity
     assert cfg['SKIP'] is False
     assert cfg['WIPE_ES'] is False
-    assert cfg['STRICT'] is True
+    assert cfg['STRICT'] is False
 
 
 @patch('dcicutils.deployment_utils.compute_ff_prd_env', MagicMock(return_value='fourfront-green'))


### PR DESCRIPTION
* Port some argument changes to clear-db-es-contents from `cgap-portal`.
* Create a `.flake8` file.
