### PR TITLE
Add CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Change Log
 4.5.9
 =====
 
+`PR 1715: Add CHANGELOG.rst <https://github.com/4dn-dcic/fourfront/pull/1715>`_
+
 * Add a CHANGELOG.rst
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,23 @@ Change Log
 ----------
 
 
-4.5.9
-=====
+4.5.10
+======
 
 `PR 1715: Add CHANGELOG.rst and update docutils (C4-888) <https://github.com/4dn-dcic/fourfront/pull/1715>`_
 
 * Add a CHANGELOG.rst
 * Also, unrelated, take a newer version of docutils (0.16 instead of 0.12)
   to get rid of a deprecation warning in testing. (`C4-888 <https://hms-dbmi.atlassian.net/browse/C4-888>`_).
+
+
+4.5.9
+=====
+
+`PR 1714: Twitter Iframe Updates for Cypress 00_home_page <https://github.com/4dn-dcic/fourfront/pull/1714>`_
+
+* Address `Trello ticket <https://trello.com/c/IOgmbGSB>`_
+  "Cypress test updates for the new MicroMeta app release".
 
 
 4.5.8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Change Log
 `PR 1715: Add CHANGELOG.rst <https://github.com/4dn-dcic/fourfront/pull/1715>`_
 
 * Add a CHANGELOG.rst
+* Also, unrelated, take a newer version of docutils (0.16 instead of 0.12)
+  to get rid of a deprecation warning in testing.
 
 
 4.5.8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,170 @@
+=========
+fourfront
+=========
+
+----------
+Change Log
+----------
+
+
+4.5.9
+=====
+
+* Add a CHANGELOG.rst
+
+
+4.5.8
+=====
+
+`PR 1713: Cypress 10_file_counts Update <https://github.com/4dn-dcic/fourfront/pull/1713>`_
+
+* Address `Trello ticket <https://trello.com/c/xffcEfR5>`_ "Incorrect matching of warning and warnings in 10_file count cypress test warning tab".
+
+
+4.5.7
+=====
+
+`PR 1705: Chart And Tooltip Updates <https://github.com/4dn-dcic/fourfront/pull/1705>`_
+
+* Address `Trello ticket "React Tooltip updates" <https://trello.com/c/1QQ3QPZd>`_.
+* Address `Trello ticket "Chart Updates in BrowseView" <https://trello.com/c/GhxYmNPE>`_
+
+
+4.5.6
+=====
+
+`PR 1710: Twitter Feeds <https://github.com/4dn-dcic/fourfront/pull/1710>`_
+
+* Address Trello ticket "Twitter feeds load all tweets and overflows its border.
+  The homepage seems to be stretched out." Rearrange ``autoHeight`` management in
+  ``TwitterTimelineEmbed.js``.
+
+
+4.5.5
+=====
+
+`PR 1711: Update snovault to take mime type fix <https://github.com/4dn-dcic/fourfront/pull/1711>`_
+
+* Take new version of ``dcicutils`` (4.1.0 -> 4.4.0)
+* Take new version of ``dcicsnovault`` (6.0.3 -> 6.0.4),
+  hopefully fixing some MIME type issues in the process
+  due to the ``dcicsnovault`` upgrade, which includes changes from
+  `snovault PR #225. <https://github.com/4dn-dcic/snovault/pull/225/files#diff-c37c65b10046b2cbd78eb0728eee44969b094e3cc92b7b1548f6b6904862d678>`_.
+
+
+4.5.4
+======
+
+`PR 1699: auth0_config End Point <https://github.com/4dn-dcic/fourfront/pull/1699>`_
+
+* A change to navigation componentry for `NotLoggedInAlert` per `Trello ticket <https://trello.com/c/VHOkoitc>`_.
+
+
+4.5.3
+=====
+
+`PR 1682: Health Page Updates <https://github.com/4dn-dcic/fourfront/pull/1682>`_
+
+* Add ``micro_meta_version`` and ``vitessce_version``
+* Note version incompatibilities between dependent and installed versions.
+
+
+4.5.2
+=====
+
+`PR 1708 Add David to master inserts <https://github.com/4dn-dcic/fourfront/pull/1708/files>`_
+
+* Add User record for David Michaels to master inserts.
+
+
+4.5.1
+=====
+
+`PR 1707: Repair local deploys <https://github.com/4dn-dcic/fourfront/pull/1707>`_
+
+* Disabled ``mpindexer``, which is not used in production and does not respect ini file settings.
+* Disabled ``repoze.debug`` egg pipeline
+* Pass ``GLOBAL_ENV_BUCKET`` to docker local
+* Document setting ``GLOBAL_ENV_BUCKET`` in ``docker-local.rst``
+* Update documentation so ReadTheDocs links to Docker documentation.
+
+
+4.5.0
+=====
+
+`PR 1706: Syntax makeover for clear-db-es-contents <https://github.com/4dn-dcic/fourfront/pull/1706>`_
+
+* Port some argument changes to ``clear-db-es-contents`` from ``cgap-portal``.
+* Create a ``.flake8`` file.
+
+
+4.4.18
+======
+
+`PR 1687: July Security Update <https://github.com/4dn-dcic/fourfront/pull/1687>`_
+
+* Brings in invalidation scope fixes, updates tests as needed
+* Updates libraries wherever possible
+* Enables ``EnvUtils``, repairing various mirroring interactions
+
+
+4.4.17
+======
+
+`PR 1704: add EdU biofeature mod <https://github.com/4dn-dcic/fourfront/pull/1704>`_
+
+* Add ``EdU`` to the possible ``mod_type`` values (modification type) in ``feature_mods``.
+
+
+4.4.16
+======
+
+`PR 1701: New Cypress Test for QC Tables and QC Item Page <https://github.com/4dn-dcic/fourfront/pull/1701>`_
+
+* In post-deploy Cypress tests, address `Trello ticket <https://trello.com/c/gAzhsn8V>`_ by
+  adding a test that visits quality metric tables and checks whether columns are valid
+  and in proper order (as it is in Quality Metric Item page).
+
+
+4.4.15
+======
+
+`PR 1698: TOC Navigation Updates <https://github.com/4dn-dcic/fourfront/pull/1698>`_
+
+* Address `Trello ticket <https://trello.com/c/UpUn9vfm>`_.
+
+
+4.4.14
+======
+
+`PR 1696: uuid + d3 Upgrade <https://github.com/4dn-dcic/fourfront/pull/1696>`_
+
+* In ``package.lock``:
+
+  * Upgrade ``d3`` from 6.7 to 7.5.
+  * Add ``uuid``.
+
+
+4.4.13
+======
+
+`PR 1695: Bug Fix - Rst Support in Static Content <https://github.com/4dn-dcic/fourfront/pull/1695>`_
+
+* Add rst support in static content
+
+
+Older Versions
+==============
+
+A record of older changes can be found
+`in GitHub <https://github.com/4dn-dcic/fourfront/pulls?q=is%3Apr+is%3Aclosed>`_.
+To find the specific version numbers, see the ``version`` value in
+the ``poetry.app`` section of ``pyproject.toml`` for the corresponding change, as in::
+
+   [poetry.app]
+   # Note: Various modules refer to this system as "encoded", not "fourfront".
+   name = "encoded"
+   version = "100.200.300"
+   ...etc.
+
+This would correspond with ``fourfront 100.200.300``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,11 @@ Change Log
 4.5.9
 =====
 
-`PR 1715: Add CHANGELOG.rst <https://github.com/4dn-dcic/fourfront/pull/1715>`_
+`PR 1715: Add CHANGELOG.rst and update docutils (C4-888) <https://github.com/4dn-dcic/fourfront/pull/1715>`_
 
 * Add a CHANGELOG.rst
 * Also, unrelated, take a newer version of docutils (0.16 instead of 0.12)
-  to get rid of a deprecation warning in testing.
+  to get rid of a deprecation warning in testing. (`C4-888 <https://hms-dbmi.atlassian.net/browse/C4-888>`_).
 
 
 4.5.8

--- a/poetry.lock
+++ b/poetry.lock
@@ -706,11 +706,11 @@ python-versions = "*"
 
 [[package]]
 name = "docutils"
-version = "0.12"
+version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "ecdsa"
@@ -2117,7 +2117,7 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.9"
-content-hash = "8114b16c179f373f6b8b269eb6ea6e9e391c8b5d94fc7de430df3e94a20d966d"
+content-hash = "d080244662457855e55c1cf0372aaf346b4718d6347dcd75638b6d4c5219fa5f"
 
 [metadata.files]
 apipkg = [
@@ -2351,8 +2351,8 @@ docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
 docutils = [
-    {file = "docutils-0.12-py3-none-any.whl", hash = "sha256:dcebd4928112631626f4c4d0df59787c748404e66dda952110030ea883d3b8cd"},
-    {file = "docutils-0.12.tar.gz", hash = "sha256:c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa"},
+    {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
+    {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 ecdsa = [
     {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ botocore-stubs = "^1.27.36"
 coverage = ">=6.2"
 codacy-coverage = ">=1.3.11"
 coveralls = ">=3.3.1"
-docutils = "0.12"
+docutils = ">=0.16,<1"
 flake8 = ">=3.9.2"
 flaky = ">=3.7.0"
 # flask only for moto[server]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.5.8"
+version = "4.5.9"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
-[tool.poetry]
+`[tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.5.9"
+version = "4.5.10"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/conftest_settings.py
+++ b/src/encoded/tests/conftest_settings.py
@@ -1,13 +1,13 @@
 import os
 
 
-_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+REPOSITORY_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
 
 # This fixes bug https://hms-dbmi.atlassian.net/browse/C4-776
 # The problem was a warning about a deprecated use of pkg_resources.resource_filename, using a relative name:
 # _ONTOLOGY_PATH = pkg_resources.resource_filename('encoded', '../../ontology.json'),
 # However, that names a non-existent filename. Does it mean to refer to 'schemas/ontology.json'? -kmp 6-Feb-2022
-_ONTOLOGY_PATH = os.path.join(_ROOT_DIR, 'ontology.json')
+_ONTOLOGY_PATH = os.path.join(REPOSITORY_ROOT_DIR, 'ontology.json')
 
 
 _app_settings = {

--- a/src/encoded/tests/test_misc.py
+++ b/src/encoded/tests/test_misc.py
@@ -1,0 +1,13 @@
+import os
+
+from dcicutils.qa_utils import VersionChecker
+from .conftest_settings import REPOSITORY_ROOT_DIR
+
+
+def test_version_and_changelog():
+
+    class MyAppVersionChecker(VersionChecker):
+        PYPROJECT = os.path.join(REPOSITORY_ROOT_DIR, "pyproject.toml")
+        CHANGELOG = os.path.join(REPOSITORY_ROOT_DIR, "CHANGELOG.rst")
+
+    MyAppVersionChecker.check_version()


### PR DESCRIPTION
* Make an initial start on a `CHANGELOG.rst`
* Add testing for version consistency and presence of a change log entry for current version.

Opportunistic:

* Take a newer version of docutils (0.16 instead of 0.12)  to get rid of a deprecation warning in testing. ([C4-888](https://hms-dbmi.atlassian.net/browse/C4-888))
