### PR TITLE
Port fix-dist-info script form cgap-portal and other small fixes (C4-879, C4-895)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,15 @@ Change Log
 ----------
 
 
-4.5.11
+4.5.12
 ======
 
+* Correct some classifiers in ``pyproject.toml``
+* Update ``fix-dist-info`` script to be consistent with ``cgap-portal``
+
+
+4.5.11
+======
 
 * Fix a syntax anomaly in ``pyproject.toml``.
 

--- a/deploy/tests/test_generate_production_ini.py
+++ b/deploy/tests/test_generate_production_ini.py
@@ -8,7 +8,7 @@ import subprocess
 from io import StringIO
 from unittest import mock
 
-from dcicutils.qa_utils import override_environ
+from dcicutils.misc_utils import override_environ
 from ..generate_production_ini import FourfrontDeployer
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.5.11"
+version = "4.5.12"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.5.2"
+version = "4.5.2.1b0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -31,8 +31,8 @@ classifiers = [
     # Specify the Python versions you support here. In particular, ensure
     # that you indicate whether you support Python 2, Python 3 or both.
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7'
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8'
 ]
 
 [tool.poetry.dependencies]

--- a/scripts/fix-dist-info
+++ b/scripts/fix-dist-info
@@ -12,7 +12,7 @@
 # and the value of dist_info_found will be the empty string.
 # Otherwise, it will be the file listing.
 
-dist_info_found=`ls -dal ${VIRTUAL_ENV}/lib/python3.[0-9]*/site-packages/encoded-[0-9][.][0-9]*.dist-info 2>/dev/null`
+dist_info_found=`ls -dal ${VIRTUAL_ENV}/lib/python3.[0-9]*/site-packages/encoded-[0-9]*.[0-9]*.dist-info 2>/dev/null`
 
 # Now we test whether there are files to delete, and if there are we do it.
 
@@ -20,7 +20,7 @@ if [ -n "${dist_info_found}" ]; then
     echo "Unwanted .dist_info files for the 'encoded' library were found:"
     echo "${dist_info_found}"
     echo "Cleaning up..."
-    rm -rf ${VIRTUAL_ENV}/lib/python3.[0-9]*/site-packages/encoded-[0-9][.][0-9]*.dist-info
+    rm -rf ${VIRTUAL_ENV}/lib/python3.[0-9]*/site-packages/encoded-[0-9]*.[0-9]*.dist-info
     echo "Done cleaning up."
 else
     echo "No unwanted .dist_info files for the 'encoded' library found."


### PR DESCRIPTION
* This ports the `cgap-portal` version of `scripts/fix-dist-info`, which fixes a bug that we aren't hitting yet in `fourfront` because we don't yet have a two-digit major version.

* I also fixed some classifiers that are wrong in `pyproject.toml`.

* Fixes a deprecated import ([C4-895](https://hms-dbmi.atlassian.net/browse/C4-895))