### PR TITLE
Clean NPM Cache in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN poetry install --no-root --no-dev
 # Do the front-end dependency install
 COPY package.json .
 COPY package-lock.json .
-RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python
+RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python && npm cache clean --force
 
 # Copy over the rest of the code
 COPY . .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.5.15"
+version = "4.5.16"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Adds a cache clean after `npm ci` to reduce image size