### PR TITLE
Restore ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,7 @@ RUN poetry install --no-dev -vvv && \
 ENV NODE_ENV=production
 RUN npm run build && \
     npm run build-scss && \
-    rm -rf node_modules/ && \
-    apt-get remove --purge --auto-remove -y ca-certificates
+    rm -rf node_modules/
 
 # Copy config files in (down here for quick debugging)
 # Remove default configuration from Nginx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.5.22"
+version = "4.5.23"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Do not purge ca-certificates package, it is required for mirroring/JH to work properly (cannot call out via HTTPS without it)