### PR TITLE
pi_name calculated property

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ fourfront
 Change Log
 ----------
 
+4.7.0
+======
+
+`PR pi_name calc prop <https://github.com/4dn-dcic/fourfront/pull/1746>`
+
+* add pi_name calculated property to lab and award items
+* remove Sarah from contact_persons field for 4DN-DCIC lab in master-inserts
+
 4.6.4
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.6.4"
+version = "4.7.0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/data/inserts/lab.json
+++ b/src/encoded/tests/data/inserts/lab.json
@@ -6,6 +6,7 @@
         "address2": "10 Schattuck Street",
         "address1": "Biomedical Bioinfomatics",
         "city": "Boston",
+        "pi": "986b362f-4eb6-4a9c-8173-3ab267227e3d",
         "country": "USA",
         "fax": "000-000-0000",
         "institute_label": "HMS",

--- a/src/encoded/tests/data/master-inserts/lab.json
+++ b/src/encoded/tests/data/master-inserts/lab.json
@@ -18,8 +18,7 @@
         "uuid": "828cd4fe-ebb0-4b36-a94a-d2e3a36cc989",
         "contact_persons" : [
             "andrew_schroeder@hms.harvard.edu",
-            "andrea_cosolo@hms.harvard.edu",
-            "sarah_reiff@hms.harvard.edu"
+            "andrea_cosolo@hms.harvard.edu"
         ]
     }
 ]

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -95,6 +95,20 @@ def submitter(testapp, lab, award):
 
 
 @pytest.fixture
+def pi(testapp, lab, award):
+    item = {
+        'first_name': 'ENCODE',
+        'last_name': 'PI',
+        'email': 'encode_pi@example.org',
+        'submits_for': [lab['@id']],
+        'viewing_groups': [award['viewing_group']],
+        'status': "current"
+    }
+    # User @@object view has keys omitted.
+    res = testapp.post_json('/user', item)
+    return testapp.get(res.location).json
+
+@pytest.fixture
 def access_key(testapp, submitter):
     description = 'My programmatic key'
     item = {

--- a/src/encoded/tests/test_types_award.py
+++ b/src/encoded/tests/test_types_award.py
@@ -40,3 +40,14 @@ def test_award_center_title_w_center(testapp, maward, submitter):
     maward['center'] = ctr
     res = testapp.post_json('/award', maward).json['@graph'][0]
     assert res['center_title'] == ctr
+
+
+def test_award_pi_name_w_pi(testapp, maward, pi):
+    maward['pi'] = pi['@id']
+    res = testapp.post_json('/award', maward).json['@graph'][0]
+    assert res['pi_name'] == pi['display_title']
+
+
+def test_award_pi_name_w_no_pi(testapp, maward):
+    res = testapp.post_json('/award', maward).json['@graph'][0]
+    assert 'pi_name' not in res

--- a/src/encoded/types/award.py
+++ b/src/encoded/types/award.py
@@ -13,7 +13,8 @@ from snovault import (
     load_schema,
 )
 from .base import (
-    Item
+    Item,
+    get_item_or_none,
 )
 import re
 
@@ -88,3 +89,14 @@ class Award(Item):
             # default to award number
             center = name
         return center
+
+
+    @calculated_property(schema={
+        "title": "P.I. Name",
+        "description": "Name of the lab principal investigator.",
+        "type": "string",
+    })
+    def pi_name(self, request, pi=None):
+        if pi:
+            return get_item_or_none(request, pi, 'users').get('display_title')
+        return None

--- a/src/encoded/types/lab.py
+++ b/src/encoded/types/lab.py
@@ -15,7 +15,8 @@ from snovault import (
     calculated_property
 )
 from .base import (
-    Item
+    Item,
+    get_item_or_none,
 )
 
 
@@ -129,6 +130,16 @@ class Lab(Item):
         if contact_people is not None:
             contact_people_dicts = [ fetch_and_pick_embedded_properties(person) for person in contact_people ]
             return [ person for person in contact_people_dicts if person is not None ]
+
+    @calculated_property(schema={
+        "title": "P.I. Name",
+        "description": "Name of the lab principal investigator.",
+        "type": "string",
+    })
+    def pi_name(self, request, pi=None):
+        if pi:
+            return get_item_or_none(request, pi, 'users').get('display_title')
+        return None
 
     def __init__(self, registry, models):
         super().__init__(registry, models)


### PR DESCRIPTION
Added a calculated property 'pi_name' that grabs the display_name from the User linked to Lab or Award.
This property can be used on the Lab item view page as well as the Award view where currently a standard non-admin user sees 'No view permission' (or current N/A) on the Lab view in the home page redesign branch.

Includes unit tests.  

As I am anxious to get the home page updates into master I ask @utku-ozturk if he might want to merge this branch into the home page update branch or if this should remain separate - if so hope it won't hold things up in getting that branch into master.  

I've included wranglers as reviewers as well as Utku. 

If it is decided to merge this branch independently I will bump the version and add to the changelog.