### PR TITLE
Static Content Location in Pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ fourfront
 Change Log
 ----------
 
+4.7.4
+======
+
+`PR static content location in pages <https://github.com/4dn-dcic/fourfront/pull/1759>`_
+
+* new content_location property is added to the Page item to let customize static content location with respect to child pages
+
 4.7.3
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "4.7.3"
+version = "4.7.4"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/page.json
+++ b/src/encoded/schemas/page.json
@@ -110,6 +110,14 @@
             },
             "lookup" : 60
         },
+        "content_location": {
+            "title": "Content Location",
+            "description": "Content sections' location with respect to child pages",
+            "type": "string",
+            "enum": ["top", "bottom"],
+            "default": "bottom",
+            "lookup": 80
+        },
         "redirect" : {
             "title" : "Redirect",
             "type" : "object",
@@ -133,7 +141,7 @@
                     "enum" : [301, 302, 303, 307]
                 }
             },
-            "lookup" : 80
+            "lookup" : 90
         }
     },
     "columns" : {

--- a/src/encoded/static/components/static-pages/DirectoryPage.js
+++ b/src/encoded/static/components/static-pages/DirectoryPage.js
@@ -13,6 +13,7 @@ export default class DirectoryPage extends React.PureComponent {
 
     render(){
         const { context } = this.props;
+        const { content_location = 'bottom' } = context;
         const childrenHaveChildren = _.any(context.children || [], function(c){
             return c && c.children && c.children.length > 0;
         });
@@ -27,9 +28,20 @@ export default class DirectoryPage extends React.PureComponent {
         return (
             <div id="content" className="container">
                 <div className={"static-page static-directory-page" + (childrenHaveChildren ? " directory-page-of-directories" : " leaf-directory")} key="wrapper">
-                    <DirectoryBodyGrid {...this.props} childrenHaveChildren={childrenHaveChildren} />
+                    {
+                        content_location === 'bottom' ? (
+                            <React.Fragment>
+                                <DirectoryBodyGrid {...this.props} childrenHaveChildren={childrenHaveChildren} />
+                                {content}
+                            </React.Fragment>
+                        ) : (
+                            <React.Fragment>
+                                {content}
+                                <DirectoryBodyGrid {...this.props} childrenHaveChildren={childrenHaveChildren} />
+                            </React.Fragment>
+                        )
+                    }
                     { !childrenHaveChildren ? <NextPreviousPageSection context={context} nextTitle="Next Section" previousTitle="Previous Section" /> : null }
-                    { content }
                 </div>
             </div>
         );


### PR DESCRIPTION
**Trello:** https://trello.com/c/LMofyg2R

New content_location property is added to the `Page` item to let customize static content location with respect to child pages.
``` json

 "content_location": {
      "title": "Content Location",
      "description": "Content sections' location with respect to child pages",
      "type": "string",
      "enum": ["top", "bottom"],
      "default": "bottom",
     "lookup": 80
}
```

<img width="1151" alt="Screen Shot 2022-12-15 at 14 18 00" src="https://user-images.githubusercontent.com/49978017/207848242-90ecc488-6d75-4406-9695-1323bfcbb6d2.png">
<img width="1151" alt="Screen Shot 2022-12-15 at 14 16 14" src="https://user-images.githubusercontent.com/49978017/207848267-3e5c307f-78d4-4b6d-9273-3ca91f2f8fec.png">
