### PR TITLE
Cypress Test for Not Facet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ fourfront
 Change Log
 ----------
 
+5.3.5
+=====
+
+`PR Cypress test for not facet  <https://github.com/4dn-dcic/fourfront/pull/1804>`_
+
+* it toggles between included and excluded properties in facets
+* it excludes a award.project term and compares the exact Exp Set’s before and after counts
+* it removes the excluded item's selection, then includes it, and compares the before and after counts.
+
+
 5.3.4
 =====
 

--- a/deploy/post_deploy_testing/cypress/e2e/03a_browse_views_basic.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03a_browse_views_basic.cy.js
@@ -36,24 +36,41 @@ describe('Browse Views - Basic Tests', function () {
 
         it('Switch between included and excluded properties in facets, exclude a term and check ExpSet counts', function(){
 
+            let initialExpSetCount, excludeExpSetCount, includeExpSetCount, externalProjectCount;
             cy.visit('/browse').wait(100).end()
                 .getQuickInfoBarCounts().then((initialCounts) => {
-                    let externalProjectCount;
-                    cy.get(".facets-header .facets-title").should('have.text', 'Included Properties').end()
-                        .get(".facets-header button").first().click().end()
-                        .get(".facets-header .facets-title").should('have.text', 'Excluded Properties').end()
-                        .get('.facet.closed[data-field="award.project"] > h5').scrollToCenterElement().click({ force: true }).end()
-                        .get('.facet[data-field="award.project"] .facet-list-element[data-key="External"] a').within(($term) => {
-                            cy.get('span.facet-count').then(function(facetCount){
-                                externalProjectCount = parseInt(facetCount.text());
-                                expect(externalProjectCount).to.be.greaterThan(0);
-                            }).end();
-                            cy.wrap($term).click().wait(1000).end();
-                        }).end()
-                        .getQuickInfoBarCounts().then((nextCounts)=>{
-                            expect(nextCounts.experiment_sets).to.be.equal(initialCounts.experiment_sets - externalProjectCount);
-                        });
-                });
+                    initialExpSetCount = initialCounts.experiment_sets;
+                    expect(initialExpSetCount).to.be.greaterThan(0);
+                }).end()
+                .get(".facets-header .facets-title").should('have.text', 'Included Properties').end()
+                .get(".facets-header button").first().click().end()
+                .get(".facets-header .facets-title").should('have.text', 'Excluded Properties').end()
+                .get('.facet.closed[data-field="award.project"] > h5').scrollToCenterElement().click({ force: true }).end()
+                .get('.facet[data-field="award.project"] .facet-list-element[data-key="External"] a').within(($term) => {
+                    cy.get('span.facet-count').then(function (facetCount) {
+                        externalProjectCount = parseInt(facetCount.text());
+                        expect(externalProjectCount).to.be.greaterThan(0);
+                    }).end();
+                    cy.wrap($term).click().wait(1000).end();
+                }).end()
+                .getQuickInfoBarCounts().then((nextCounts) => {
+                    excludeExpSetCount = nextCounts.experiment_sets;
+                    expect(excludeExpSetCount).to.be.equal(initialExpSetCount - externalProjectCount);
+                })
+                .get(".facets-header button").first().click().end()
+                .get(".facets-header .facets-title").should('have.text', 'Included Properties').end()
+                .get('.facet[data-field="award.project"] .facet-list-element[data-key="External"] a').click().wait(1000).end() //reset
+                .getQuickInfoBarCounts().then((nextCounts) => {
+                    expect(initialExpSetCount).to.be.equal(nextCounts.experiment_sets);
+                }).end()
+                .get('.facet[data-field="award.project"] .facet-list-element[data-key="External"] a').within(($term) => {
+                    cy.wrap($term).click().wait(1000).end();
+                }).end()
+                .getQuickInfoBarCounts().then((nextCounts) => {
+                    includeExpSetCount = nextCounts.experiment_sets;
+                    expect(includeExpSetCount).to.be.equal(externalProjectCount);
+                }).end();
+
         });
 
         it('"/browse/?public_release.to=2017-10-31" redirects to correct URL, includes 100 < x < 150 results.', function(){

--- a/deploy/post_deploy_testing/cypress/e2e/03a_browse_views_basic.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03a_browse_views_basic.cy.js
@@ -34,6 +34,28 @@ describe('Browse Views - Basic Tests', function () {
             cy.getQuickInfoBarCounts().its('experiment_sets').should('be.greaterThan', 99);
         });
 
+        it('Switch between included and excluded properties in facets, exclude a term and check ExpSet counts', function(){
+
+            cy.visit('/browse').wait(100).end()
+                .getQuickInfoBarCounts().then((initialCounts) => {
+                    let externalProjectCount;
+                    cy.get(".facets-header .facets-title").should('have.text', 'Included Properties').end()
+                        .get(".facets-header button").first().click().end()
+                        .get(".facets-header .facets-title").should('have.text', 'Excluded Properties').end()
+                        .get('.facet.closed[data-field="award.project"] > h5').scrollToCenterElement().click({ force: true }).end()
+                        .get('.facet[data-field="award.project"] .facet-list-element[data-key="External"] a').within(($term) => {
+                            cy.get('span.facet-count').then(function(facetCount){
+                                externalProjectCount = parseInt(facetCount.text());
+                                expect(externalProjectCount).to.be.greaterThan(0);
+                            }).end();
+                            cy.wrap($term).click().wait(1000).end();
+                        }).end()
+                        .getQuickInfoBarCounts().then((nextCounts)=>{
+                            expect(nextCounts.experiment_sets).to.be.equal(initialCounts.experiment_sets - externalProjectCount);
+                        });
+                });
+        });
+
         it('"/browse/?public_release.to=2017-10-31" redirects to correct URL, includes 100 < x < 150 results.', function(){
             cy.visit('/browse/?public_release.to=2017-10-31').end()
                 .location('search').should('include','ExperimentSetReplicate' ).should('include', 'public_release.to=2017-10-31').end()

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2380,14 +2380,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
-      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.1",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -2448,9 +2448,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
-      "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
+      "integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4190,162 +4190,202 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@loaders.gl/3d-tiles": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.3.3.tgz",
-      "integrity": "sha512-fQqUFgsrWIeckQVzOYfGJPtvPNErGhuxrj96fPxMFA+AAhnEeC+rlrzQkLRCANDTmHKD/5/cvPtXEqkVE6IHUg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.4.0.tgz",
+      "integrity": "sha512-LszVEkFknDWsl/93qQkqkDBIg3cf02N8Yo8escUiNuxIgr2dU3hZ/QOBaHpy3p8JrY7410fieEtVVGeXUs5e6Q==",
       "dependencies": {
-        "@loaders.gl/draco": "3.3.3",
-        "@loaders.gl/gltf": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/math": "3.3.3",
-        "@loaders.gl/tiles": "3.3.3",
+        "@loaders.gl/draco": "3.4.0",
+        "@loaders.gl/gltf": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/math": "3.4.0",
+        "@loaders.gl/tiles": "3.4.0",
         "@math.gl/core": "^3.5.1",
-        "@math.gl/geospatial": "^3.5.1"
+        "@math.gl/geospatial": "^3.5.1",
+        "long": "^5.2.1"
       },
       "peerDependencies": {
         "@loaders.gl/core": "^3.2.0"
       }
     },
+    "node_modules/@loaders.gl/3d-tiles/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/@loaders.gl/core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.3.3.tgz",
-      "integrity": "sha512-kModKGZ3V1AYue8eQxM9H19PZQt9HxtVJUvAMmOeFiXZmhIiEO8gf5+c7Ph6C/+whPff8cRbMd06P93PJD5PlA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-Zxg2ECGT94jX0e3XJ1Alj5j/0wXMIK2+O0derEm8QOAy2hiwjefE2QsbgyDfC2eI1t//c7r9m/4079mzh/6qyA==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/worker-utils": "3.3.3",
-        "@probe.gl/log": "^3.5.0"
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/worker-utils": "3.4.0",
+        "@probe.gl/log": "^4.0.1"
+      }
+    },
+    "node_modules/@loaders.gl/core/node_modules/@probe.gl/env": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.0.3.tgz",
+      "integrity": "sha512-Iz2/xPHMa5adDBw/m7nyQ0bKgLXZqMauPfV2ePU9ZOfkt6NnWMzQAjBeeXufujE6vndJUAALgpweO/YjYkKo+Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/core/node_modules/@probe.gl/log": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.0.3.tgz",
+      "integrity": "sha512-GAvGo87nYAcS/sLs00qts+thzlYPXLzkAG1xdtY3NxeI9oJAo+EU/sw+qcnfews4HO/u60QLMHrQJgSSbCGmjQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@probe.gl/env": "4.0.3"
       }
     },
     "node_modules/@loaders.gl/draco": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.3.3.tgz",
-      "integrity": "sha512-26r253By6Q9n2xQWG2Dht+VDCqQGVGetM1lJXa3GLrWxNNz4m7et/q9v8TC270/65BgB7Uz58NlZdpweeeIEqA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.0.tgz",
+      "integrity": "sha512-HPVqhEri1TZUQpOViaLYHDpz8buWG1VXiBz9GzMuID+Bc1eaNjU/UdTWzOWDMu6KQDGmQnMxbT6DAJmiI7sNiA==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
-        "@loaders.gl/worker-utils": "3.3.3",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
+        "@loaders.gl/worker-utils": "3.4.0",
         "draco3d": "1.5.5"
       }
     },
     "node_modules/@loaders.gl/gis": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.3.3.tgz",
-      "integrity": "sha512-/lv8KYQxGDeSYmYgkR7zxKWtva8jLVLsQFcCCLhkmcEQY3rUrIjaXL0twZRNRrLMqFMvOFZScVvF4oA/9uXTlA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.0.tgz",
+      "integrity": "sha512-VJpAB7dJmVdKEPVh8Dy90K9w/aRIoBxx4yv7ZmdjazPoNl3S1P1iHR6lMlXuPj1FBFzKS+gZrWkhhqvIQG7Plg==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "node_modules/@loaders.gl/gltf": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.3.3.tgz",
-      "integrity": "sha512-qE2IqWTGJ+36om90t8GJQneGNfYdi/u7R4twM3IpmOVP5zH5Oh4JpJY4JPy8cGmni77UVVZqahNa/czCOIeXJw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.0.tgz",
+      "integrity": "sha512-YqJOiR6vu0BnOvvifIGgLUaAsyw7e1BrTJL/XTJ9bECSlabB4ZZ5bGtic3fgKPiBhRIZDq/7+uvonNAwUvMbYA==",
       "dependencies": {
-        "@loaders.gl/draco": "3.3.3",
-        "@loaders.gl/images": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/textures": "3.3.3",
+        "@loaders.gl/draco": "3.4.0",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/textures": "3.4.0",
         "@math.gl/core": "^3.5.1"
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.3.3.tgz",
-      "integrity": "sha512-IFRs3TuqaBI4crY9x3BhD+FbayiwQww7zH4PUs3vpMRQYVf593+wngW1rMbl7zgNnkFbudzxaTr8MW8VaWriCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.0.tgz",
+      "integrity": "sha512-cDQitjdmvfFGacpo69GY57f6F7z7NDdA/qXRapjwmCsjeVIPxSbcgEiwqRQj/1GEbz7X6BFvZSRoxlcnGl6XfQ==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.3.3"
+        "@loaders.gl/loader-utils": "3.4.0"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.3.3.tgz",
-      "integrity": "sha512-QHwc8dw5kn2KyoEQGqPvmuHRSEo+UeKOgUFwRM7FjNgkFySr+Wc1HMCCPH+VBCvdzGp0aIH+WWQB1Ug2yaQZeg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.0.tgz",
+      "integrity": "sha512-GSZoYVBh4dejNlu8OPzTrhSZ9R7euIq4kC2mgBzCG7x+ogBinu59HH1L84/UmCfzRQ1xJhFOguSCO5cBsh5s4Q==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.3.3",
-        "@probe.gl/stats": "^3.5.0"
+        "@loaders.gl/worker-utils": "3.4.0",
+        "@probe.gl/stats": "^4.0.1"
+      }
+    },
+    "node_modules/@loaders.gl/loader-utils/node_modules/@probe.gl/stats": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.3.tgz",
+      "integrity": "sha512-8BNKDmgwNqvcBNEcsIavtEWQp1WvBfryLodAv1YX8/Swg60Ky3ElDNNpSDuIVMnFDvI/De0zXiuXXydtn86/vA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@loaders.gl/math": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.3.3.tgz",
-      "integrity": "sha512-8K7M3dGJxH6y25NZQt9BSxx3XaRiPLxn/bTp3UrdALm1H+wa77M2yUDyFR3F978aLyCSJ8BcQmp2zOk/8iInTQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.4.0.tgz",
+      "integrity": "sha512-1VvfPfk+Ieq/dep8oJSQKOWfCZoVeuGYGaVJ2PG66vZ5vhJmFOfQz9P/oGJIdaaUhVukPaWUXKdA1EV2FRwKlg==",
       "dependencies": {
-        "@loaders.gl/images": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
         "@math.gl/core": "^3.5.1"
       }
     },
     "node_modules/@loaders.gl/mvt": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.3.3.tgz",
-      "integrity": "sha512-UlOV8cS/4jWy1ZKEI6hxfkki1NIULeUX+jEhyDnXZHB8NmXx/bOjtDzY93NIYDRiusZ4BzOUWGVhoGCX+FJAVQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.4.0.tgz",
+      "integrity": "sha512-/VDAH2WvV9jwZAZ8B+vvLFTPjDGbY/G1//Y7WMxdtNNIMsTNBo/K7qbD6D/gWy7MKa9uTAed83ZvN4DSPuFUIA==",
       "dependencies": {
-        "@loaders.gl/gis": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
+        "@loaders.gl/gis": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.3.3.tgz",
-      "integrity": "sha512-l06pdG9pn2SABUgFm7N1JmfddU7KlBvGaxXlLbPhun+02Z0m2ExASHy0mEU7DVsdbfsbCyYDYqxuvn1O7yHX+A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.0.tgz",
+      "integrity": "sha512-OUNZUXPtuUNhczglZr+Eff/5YcuvnRChPWuz9n+nJX5hxbdnvomsFOO1Up1ErneBw2wsLgt25SYLbcPbRxw9tw==",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
       }
     },
     "node_modules/@loaders.gl/terrain": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.3.3.tgz",
-      "integrity": "sha512-k0PQhg4E4O9hsgN5hgrDuHozGKWJW4Yc2YnOxL2O3NXCEkqlr5kD5gBd2CDghzUTpw/RbjbQvqR2isaiAvQlkw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.4.0.tgz",
+      "integrity": "sha512-xsotBDEdFCqGrXsDoz3GuiZedCeIVtqyJVEMWSZ1v5KUeiByiZW3wt0hL7V8GG38lv3IZb5teDU2MUtMBHs3Tg==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
         "@mapbox/martini": "^0.2.0"
       }
     },
     "node_modules/@loaders.gl/textures": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.3.3.tgz",
-      "integrity": "sha512-0osXsVIfjjWni/IvNSykZX/x3i0pQLo32/APV7mgP/1B3R6mbZfEl2Y1ESVdlVuqQoGGXWIEYyFnBF8NKPJyuA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.0.tgz",
+      "integrity": "sha512-3L/MbPJ+llTyAG8zWM3vh8Wf0fAsdm3vnR73jW6bznboyHEvZpPGhXSya9q0+KfmumPUSmDzQArG7oilTt+H5w==",
       "dependencies": {
-        "@loaders.gl/images": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
-        "@loaders.gl/worker-utils": "3.3.3",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
+        "@loaders.gl/worker-utils": "3.4.0",
         "ktx-parse": "^0.0.4",
         "texture-compressor": "^1.0.2"
       }
     },
     "node_modules/@loaders.gl/tiles": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.3.3.tgz",
-      "integrity": "sha512-DYtZvdcp07jQ/MnjGCsQAIQw/j3FJXN09VJAV/G6ls1gLFjNKv969yBH+vApyFeZsKs6GbI0zR2lqu3woflS9A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.4.0.tgz",
+      "integrity": "sha512-4h1Zww9zviGqqt7J9CqHgMIH7KFIO4SmF5oMx0FXij8uS/UBXVA37Gch7CenV5Av52ZFza/ZuWQuxVjeycxFIA==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/math": "3.3.3",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/math": "3.4.0",
         "@math.gl/core": "^3.5.1",
         "@math.gl/culling": "^3.5.1",
         "@math.gl/geospatial": "^3.5.1",
         "@math.gl/web-mercator": "^3.5.1",
-        "@probe.gl/stats": "^3.5.0"
+        "@probe.gl/stats": "^4.0.1"
       },
       "peerDependencies": {
         "@loaders.gl/core": "^3.2.0"
       }
     },
+    "node_modules/@loaders.gl/tiles/node_modules/@probe.gl/stats": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.3.tgz",
+      "integrity": "sha512-8BNKDmgwNqvcBNEcsIavtEWQp1WvBfryLodAv1YX8/Swg60Ky3ElDNNpSDuIVMnFDvI/De0zXiuXXydtn86/vA==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.3.3.tgz",
-      "integrity": "sha512-mTQqbuAtFCgR2yu//7Rrt9pwhnDh0H2t69vOJ65Eh2YA0q4c58Kqd+260WxoPps3A0aiYNyA2099AHze7fI+Jg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.0.tgz",
+      "integrity": "sha512-xSopQni1V1qSGCvng71WzN5SQWOYL14wMAR3voGrNcThla/A+eJa0+0G8P2C4ilkEOem+jxigs0NSVlh7dfiJw==",
       "dependencies": {
         "@babel/runtime": "^7.3.1"
       }
@@ -5286,13 +5326,13 @@
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.50.0.tgz",
-      "integrity": "sha512-4TQ4vN0aMBWsUXfJWk2xbe4x7fKfwCXgXKTtHC/ocwwKM+0EefV5Iw9YFG8IrIQN4vMtuRzktqcs9q0/Sbv7tg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.1.tgz",
+      "integrity": "sha512-6N99rE+Ek0LgbqSzI/XpsKSLUyJjQ9nychViy+MP60p1x+hllukfTsDbNtUNrPlW0Bx+vqUrWKkAqmTFad94TQ==",
       "dependencies": {
-        "@sentry/core": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry/core": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -5300,15 +5340,15 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.50.0.tgz",
-      "integrity": "sha512-a+UYbP89+SAvW47/p9wxEi9eWlyp/SkYl52OCdZNXnplQY4kQIOVyiaIs5nnCxIxZgXKrhAX4eo1E9ykleFuNQ==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.52.1.tgz",
+      "integrity": "sha512-HrCOfieX68t+Wj42VIkraLYwx8kN5311SdBkHccevWs2Y2dZU7R9iLbI87+nb5kpOPQ7jVWW7d6QI/yZmliYgQ==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.50.0",
-        "@sentry/core": "7.50.0",
-        "@sentry/replay": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry-internal/tracing": "7.52.1",
+        "@sentry/core": "7.52.1",
+        "@sentry/replay": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -5316,12 +5356,12 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.50.0.tgz",
-      "integrity": "sha512-6oD1a3fYs4aiNK7tuJSd88LHjYJAetd7ZK/AfJniU7zWKj4jxIYfO8nhm0qdnhEDs81RcweVDmPhWm3Kwrzzsg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.1.tgz",
+      "integrity": "sha512-36clugQu5z/9jrit1gzI7KfKbAUimjRab39JeR0mJ6pMuKLTTK7PhbpUAD4AQBs9qVeXN2c7h9SVZiSA0UDvkg==",
       "dependencies": {
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -5329,13 +5369,13 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.50.0.tgz",
-      "integrity": "sha512-V/KfIhwLezefnRz0y9pGJn5x0RBL8Q1347LowcOZWoNiDoaaLI9hRBTqJGyvCstG5NNhsLTKMM3UDk0WNXflPg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.52.1.tgz",
+      "integrity": "sha512-RRH+GJE5TNg5QS86bSjSZuR2snpBTOO5/SU9t4BOqZMknzhMVTClGMm84hffJa9pMPMJPQ2fWQAbhrlD8RcF6w==",
       "dependencies": {
-        "@sentry/browser": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry/browser": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       },
@@ -5347,43 +5387,43 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.50.0.tgz",
-      "integrity": "sha512-EYRk+DTZ5luwfkiCaDpBC3YBKIEdkReTUNZtWDVUytSVjsCnttkAipx/y6bxy3HN+rSXungMd3XKQT5RNMRUNA==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.52.1.tgz",
+      "integrity": "sha512-A+RaUmpU9/yBHnU3ATemc6wAvobGno0yf5R6fZYkAFoo2FCR2YG6AXxkTazymIf8v2DnLGaSDORYDPdhQClU9A==",
       "dependencies": {
-        "@sentry/core": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0"
+        "@sentry/core": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/tracing": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.50.0.tgz",
-      "integrity": "sha512-avbIgDA/Bktci5OeWb5T6JCS5edWHeket92KeFNpMH79NfF46csA5yBgM+q0X9/R4swZd5fuTQwh4y6BHA4lEQ==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.52.1.tgz",
+      "integrity": "sha512-1afFeb0X6YcMK8mcsGXpO9rNFEF4Kd3mAUF22hXyFNWVoPNQsvdh/WxG2t3U+hLhehQ1ps3iJ0jxFRGF5zSboA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.50.0"
+        "@sentry-internal/tracing": "7.52.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.50.0.tgz",
-      "integrity": "sha512-Zo9vyI98QNeYT0K0y57Rb4JRWDaPEgmp+QkQ4CRQZFUTWetO5fvPZ4Gb/R7TW16LajuHZlbJBHmvmNj2pkL2kw==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.1.tgz",
+      "integrity": "sha512-OMbGBPrJsw0iEXwZ2bJUYxewI1IEAU2e1aQGc0O6QW5+6hhCh+8HO8Xl4EymqwejjztuwStkl6G1qhK+Q0/Row==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.50.0.tgz",
-      "integrity": "sha512-iyPwwC6fwJsiPhH27ZbIiSsY5RaccHBqADS2zEjgKYhmP4P9WGgHRDrvLEnkOjqQyKNb6c0yfmv83n0uxYnolw==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.1.tgz",
+      "integrity": "sha512-MPt1Xu/jluulknW8CmZ2naJ53jEdtdwCBSo6fXJvOTI0SDqwIPbXDVrsnqLAhVJuIN7xbkj96nuY/VBR6S5sWg==",
       "dependencies": {
-        "@sentry/types": "7.50.0",
+        "@sentry/types": "7.52.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -6146,9 +6186,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q=="
+      "version": "20.1.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.7.tgz",
+      "integrity": "sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg=="
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.0",
@@ -6172,9 +6212,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.58",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
-      "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
+      "version": "17.0.59",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.59.tgz",
+      "integrity": "sha512-gSON5zWYIGyoBcycCE75E9+r6dCC2dHdsrVkOEiIYNU5+Q28HcBAuqvDuxHcCbMfHBHdeT5Tva/AFn3rnMKE4g==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6191,9 +6231,9 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
+      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -7483,9 +7523,9 @@
       }
     },
     "node_modules/acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -8356,9 +8396,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1371.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1371.0.tgz",
-      "integrity": "sha512-dIts8xcmi7MFN1THOOcjiyqdvTqSVnsA4iIIerfyvpeYNobIi9pqBjCX9m8tfJ0pXQnymd4kp0xK9Y+i5dFfEQ==",
+      "version": "2.1379.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1379.0.tgz",
+      "integrity": "sha512-kziOtAtJxdgYJwhzY+uhNi/AGPrDEMHd0dEz46YR1AB5bVqjS9/SjOZHemB88QfpW11IVB/FoiIusXlGEvgq9Q==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -9285,9 +9325,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001482",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
-      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ==",
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
       "funding": [
         {
           "type": "opencollective",
@@ -10127,9 +10167,9 @@
       "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.1.tgz",
-      "integrity": "sha512-d690npR7MC6P0gq4npTl5n2VQeNAmUrJ90n+MHiKS7W2+xno4o3F5GDEuylSdi6EJ3VssibSGXOa1r3YXD3Mhw==",
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
+      "integrity": "sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.21.5"
@@ -10140,9 +10180,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.1.tgz",
-      "integrity": "sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg==",
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.2.tgz",
+      "integrity": "sha512-p/npFUJXXBkCCTIlEGBdghofn00jWG6ZOtdoIXSJmAu2QBvN0IqpZXWweOytcwE6cfx8ZvVUy1vw8zxhe4Y2vg==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -10456,9 +10496,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "14.18.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-      "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+      "version": "14.18.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
+      "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==",
       "optional": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -10568,9 +10608,9 @@
       }
     },
     "node_modules/cypress/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11601,9 +11641,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.382",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.382.tgz",
-      "integrity": "sha512-czMavlW52VIPgutbVL9JnZIZuFijzsG1ww/1z2Otu1r1q+9Qe2bTsH3My3sZarlvwyqHM6+mnZfEnt2Vr4dsIg=="
+      "version": "1.4.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.397.tgz",
+      "integrity": "sha512-jwnPxhh350Q/aMatQia31KAIQdhEsYS0fFZ0BQQlN9tfvOEwShu6ZNwI4kL/xBabjcB/nTy6lSt17kNIluJZ8Q=="
     },
     "node_modules/element-resize-event": {
       "version": "2.0.9",
@@ -11678,9 +11718,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-      "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
+      "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -12022,15 +12062,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
-      "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
+      "integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.2",
-        "@eslint/js": "8.39.0",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.40.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -12041,8 +12081,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.0",
-        "espree": "^9.5.1",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -12261,9 +12301,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -12394,14 +12434,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -12411,9 +12451,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -13600,12 +13640,13 @@
       "dev": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -16450,9 +16491,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -20252,9 +20293,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -20681,9 +20722,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
+      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
     },
     "node_modules/js-cookie": {
       "version": "2.2.1",
@@ -22069,9 +22110,9 @@
       }
     },
     "node_modules/micro-meta-app-react/node_modules/@types/react": {
-      "version": "16.14.40",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.40.tgz",
-      "integrity": "sha512-elQj2VQHDuJ5xuEcn5Wxh/YQFNbEuPJFRKSdyG866awDm5dmtoqsMmuAJWb/l/qd2kDkZMfOTKygVfMIdBBPKg==",
+      "version": "16.14.41",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.41.tgz",
+      "integrity": "sha512-h+joCKF2r5rdECoM1U8WCEIHBp5/0TSR5Nyq8gtnnYY1n2WqGuj3indYqTjMb2/b5g2rfxJV6u4jUFq95lbT6Q==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -22701,18 +22742,27 @@
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
+      "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^2.0.0"
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -24142,9 +24192,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
-      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -24394,9 +24444,9 @@
       }
     },
     "node_modules/react-app-polyfill/node_modules/core-js": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.1.tgz",
-      "integrity": "sha512-ZNS5nbiSwDTq4hFosEDqm65izl2CWmLz0hARJMyNQBgkUZMIF51cQiMvIQKA6hvuaeWxQDP3hEedM1JZIgTldQ==",
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.2.tgz",
+      "integrity": "sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -24669,9 +24719,9 @@
       }
     },
     "node_modules/react-jsx-parser/node_modules/core-js": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.1.tgz",
-      "integrity": "sha512-ZNS5nbiSwDTq4hFosEDqm65izl2CWmLz0hARJMyNQBgkUZMIF51cQiMvIQKA6hvuaeWxQDP3hEedM1JZIgTldQ==",
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.2.tgz",
+      "integrity": "sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -27009,9 +27059,9 @@
       }
     },
     "node_modules/superagent/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -27124,9 +27174,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-      "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+      "version": "5.17.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.4.tgz",
+      "integrity": "sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -27141,15 +27191,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
-      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
+      "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.1",
-        "terser": "^5.16.5"
+        "terser": "^5.16.8"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -28495,9 +28545,9 @@
       }
     },
     "node_modules/vega-lite": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.8.0.tgz",
-      "integrity": "sha512-b2X/YEa9Tdhxgk+kwepUk0Nriu9l8WnJl0kTHTCDqc/BvBIEJ3d12PI20Pb0m39xTw02mQL9uW3IGgFyBqhuSw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.9.2.tgz",
+      "integrity": "sha512-HLzsDCzZQGabicmnG8weS26xMXssvrTbyKcCKFXSnO2RBffD5Q6W2Mvyz5+VVVk9JjEW+Im04cB9y4QQwtDEOQ==",
       "dependencies": {
         "@types/clone": "~2.1.1",
         "clone": "~2.1.2",
@@ -28508,7 +28558,7 @@
         "vega-event-selector": "~3.0.1",
         "vega-expression": "~5.1.0",
         "vega-util": "~1.17.2",
-        "yargs": "~17.7.1"
+        "yargs": "~17.7.2"
       },
       "bin": {
         "vl2pdf": "bin/vl2pdf",
@@ -31302,9 +31352,9 @@
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
           "dev": true
         }
       }
@@ -31316,14 +31366,14 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
-      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.1",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -31365,9 +31415,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
-      "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
+      "integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==",
       "dev": true
     },
     "@fortawesome/fontawesome-free": {
@@ -32705,156 +32755,204 @@
       }
     },
     "@loaders.gl/3d-tiles": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.3.3.tgz",
-      "integrity": "sha512-fQqUFgsrWIeckQVzOYfGJPtvPNErGhuxrj96fPxMFA+AAhnEeC+rlrzQkLRCANDTmHKD/5/cvPtXEqkVE6IHUg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.4.0.tgz",
+      "integrity": "sha512-LszVEkFknDWsl/93qQkqkDBIg3cf02N8Yo8escUiNuxIgr2dU3hZ/QOBaHpy3p8JrY7410fieEtVVGeXUs5e6Q==",
       "requires": {
-        "@loaders.gl/draco": "3.3.3",
-        "@loaders.gl/gltf": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/math": "3.3.3",
-        "@loaders.gl/tiles": "3.3.3",
+        "@loaders.gl/draco": "3.4.0",
+        "@loaders.gl/gltf": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/math": "3.4.0",
+        "@loaders.gl/tiles": "3.4.0",
         "@math.gl/core": "^3.5.1",
-        "@math.gl/geospatial": "^3.5.1"
+        "@math.gl/geospatial": "^3.5.1",
+        "long": "^5.2.1"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        }
       }
     },
     "@loaders.gl/core": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.3.3.tgz",
-      "integrity": "sha512-kModKGZ3V1AYue8eQxM9H19PZQt9HxtVJUvAMmOeFiXZmhIiEO8gf5+c7Ph6C/+whPff8cRbMd06P93PJD5PlA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-Zxg2ECGT94jX0e3XJ1Alj5j/0wXMIK2+O0derEm8QOAy2hiwjefE2QsbgyDfC2eI1t//c7r9m/4079mzh/6qyA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/worker-utils": "3.3.3",
-        "@probe.gl/log": "^3.5.0"
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/worker-utils": "3.4.0",
+        "@probe.gl/log": "^4.0.1"
+      },
+      "dependencies": {
+        "@probe.gl/env": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.0.3.tgz",
+          "integrity": "sha512-Iz2/xPHMa5adDBw/m7nyQ0bKgLXZqMauPfV2ePU9ZOfkt6NnWMzQAjBeeXufujE6vndJUAALgpweO/YjYkKo+Q==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        },
+        "@probe.gl/log": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.0.3.tgz",
+          "integrity": "sha512-GAvGo87nYAcS/sLs00qts+thzlYPXLzkAG1xdtY3NxeI9oJAo+EU/sw+qcnfews4HO/u60QLMHrQJgSSbCGmjQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@probe.gl/env": "4.0.3"
+          }
+        }
       }
     },
     "@loaders.gl/draco": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.3.3.tgz",
-      "integrity": "sha512-26r253By6Q9n2xQWG2Dht+VDCqQGVGetM1lJXa3GLrWxNNz4m7et/q9v8TC270/65BgB7Uz58NlZdpweeeIEqA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.0.tgz",
+      "integrity": "sha512-HPVqhEri1TZUQpOViaLYHDpz8buWG1VXiBz9GzMuID+Bc1eaNjU/UdTWzOWDMu6KQDGmQnMxbT6DAJmiI7sNiA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
-        "@loaders.gl/worker-utils": "3.3.3",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
+        "@loaders.gl/worker-utils": "3.4.0",
         "draco3d": "1.5.5"
       }
     },
     "@loaders.gl/gis": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.3.3.tgz",
-      "integrity": "sha512-/lv8KYQxGDeSYmYgkR7zxKWtva8jLVLsQFcCCLhkmcEQY3rUrIjaXL0twZRNRrLMqFMvOFZScVvF4oA/9uXTlA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.0.tgz",
+      "integrity": "sha512-VJpAB7dJmVdKEPVh8Dy90K9w/aRIoBxx4yv7ZmdjazPoNl3S1P1iHR6lMlXuPj1FBFzKS+gZrWkhhqvIQG7Plg==",
       "requires": {
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "@loaders.gl/gltf": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.3.3.tgz",
-      "integrity": "sha512-qE2IqWTGJ+36om90t8GJQneGNfYdi/u7R4twM3IpmOVP5zH5Oh4JpJY4JPy8cGmni77UVVZqahNa/czCOIeXJw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.0.tgz",
+      "integrity": "sha512-YqJOiR6vu0BnOvvifIGgLUaAsyw7e1BrTJL/XTJ9bECSlabB4ZZ5bGtic3fgKPiBhRIZDq/7+uvonNAwUvMbYA==",
       "requires": {
-        "@loaders.gl/draco": "3.3.3",
-        "@loaders.gl/images": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/textures": "3.3.3",
+        "@loaders.gl/draco": "3.4.0",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/textures": "3.4.0",
         "@math.gl/core": "^3.5.1"
       }
     },
     "@loaders.gl/images": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.3.3.tgz",
-      "integrity": "sha512-IFRs3TuqaBI4crY9x3BhD+FbayiwQww7zH4PUs3vpMRQYVf593+wngW1rMbl7zgNnkFbudzxaTr8MW8VaWriCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.0.tgz",
+      "integrity": "sha512-cDQitjdmvfFGacpo69GY57f6F7z7NDdA/qXRapjwmCsjeVIPxSbcgEiwqRQj/1GEbz7X6BFvZSRoxlcnGl6XfQ==",
       "requires": {
-        "@loaders.gl/loader-utils": "3.3.3"
+        "@loaders.gl/loader-utils": "3.4.0"
       }
     },
     "@loaders.gl/loader-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.3.3.tgz",
-      "integrity": "sha512-QHwc8dw5kn2KyoEQGqPvmuHRSEo+UeKOgUFwRM7FjNgkFySr+Wc1HMCCPH+VBCvdzGp0aIH+WWQB1Ug2yaQZeg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.0.tgz",
+      "integrity": "sha512-GSZoYVBh4dejNlu8OPzTrhSZ9R7euIq4kC2mgBzCG7x+ogBinu59HH1L84/UmCfzRQ1xJhFOguSCO5cBsh5s4Q==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.3.3",
-        "@probe.gl/stats": "^3.5.0"
+        "@loaders.gl/worker-utils": "3.4.0",
+        "@probe.gl/stats": "^4.0.1"
+      },
+      "dependencies": {
+        "@probe.gl/stats": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.3.tgz",
+          "integrity": "sha512-8BNKDmgwNqvcBNEcsIavtEWQp1WvBfryLodAv1YX8/Swg60Ky3ElDNNpSDuIVMnFDvI/De0zXiuXXydtn86/vA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        }
       }
     },
     "@loaders.gl/math": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.3.3.tgz",
-      "integrity": "sha512-8K7M3dGJxH6y25NZQt9BSxx3XaRiPLxn/bTp3UrdALm1H+wa77M2yUDyFR3F978aLyCSJ8BcQmp2zOk/8iInTQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.4.0.tgz",
+      "integrity": "sha512-1VvfPfk+Ieq/dep8oJSQKOWfCZoVeuGYGaVJ2PG66vZ5vhJmFOfQz9P/oGJIdaaUhVukPaWUXKdA1EV2FRwKlg==",
       "requires": {
-        "@loaders.gl/images": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
         "@math.gl/core": "^3.5.1"
       }
     },
     "@loaders.gl/mvt": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.3.3.tgz",
-      "integrity": "sha512-UlOV8cS/4jWy1ZKEI6hxfkki1NIULeUX+jEhyDnXZHB8NmXx/bOjtDzY93NIYDRiusZ4BzOUWGVhoGCX+FJAVQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.4.0.tgz",
+      "integrity": "sha512-/VDAH2WvV9jwZAZ8B+vvLFTPjDGbY/G1//Y7WMxdtNNIMsTNBo/K7qbD6D/gWy7MKa9uTAed83ZvN4DSPuFUIA==",
       "requires": {
-        "@loaders.gl/gis": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
+        "@loaders.gl/gis": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "@loaders.gl/schema": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.3.3.tgz",
-      "integrity": "sha512-l06pdG9pn2SABUgFm7N1JmfddU7KlBvGaxXlLbPhun+02Z0m2ExASHy0mEU7DVsdbfsbCyYDYqxuvn1O7yHX+A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.0.tgz",
+      "integrity": "sha512-OUNZUXPtuUNhczglZr+Eff/5YcuvnRChPWuz9n+nJX5hxbdnvomsFOO1Up1ErneBw2wsLgt25SYLbcPbRxw9tw==",
       "requires": {
         "@types/geojson": "^7946.0.7"
       }
     },
     "@loaders.gl/terrain": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.3.3.tgz",
-      "integrity": "sha512-k0PQhg4E4O9hsgN5hgrDuHozGKWJW4Yc2YnOxL2O3NXCEkqlr5kD5gBd2CDghzUTpw/RbjbQvqR2isaiAvQlkw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.4.0.tgz",
+      "integrity": "sha512-xsotBDEdFCqGrXsDoz3GuiZedCeIVtqyJVEMWSZ1v5KUeiByiZW3wt0hL7V8GG38lv3IZb5teDU2MUtMBHs3Tg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
         "@mapbox/martini": "^0.2.0"
       }
     },
     "@loaders.gl/textures": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.3.3.tgz",
-      "integrity": "sha512-0osXsVIfjjWni/IvNSykZX/x3i0pQLo32/APV7mgP/1B3R6mbZfEl2Y1ESVdlVuqQoGGXWIEYyFnBF8NKPJyuA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.0.tgz",
+      "integrity": "sha512-3L/MbPJ+llTyAG8zWM3vh8Wf0fAsdm3vnR73jW6bznboyHEvZpPGhXSya9q0+KfmumPUSmDzQArG7oilTt+H5w==",
       "requires": {
-        "@loaders.gl/images": "3.3.3",
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/schema": "3.3.3",
-        "@loaders.gl/worker-utils": "3.3.3",
+        "@loaders.gl/images": "3.4.0",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/schema": "3.4.0",
+        "@loaders.gl/worker-utils": "3.4.0",
         "ktx-parse": "^0.0.4",
         "texture-compressor": "^1.0.2"
       }
     },
     "@loaders.gl/tiles": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.3.3.tgz",
-      "integrity": "sha512-DYtZvdcp07jQ/MnjGCsQAIQw/j3FJXN09VJAV/G6ls1gLFjNKv969yBH+vApyFeZsKs6GbI0zR2lqu3woflS9A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.4.0.tgz",
+      "integrity": "sha512-4h1Zww9zviGqqt7J9CqHgMIH7KFIO4SmF5oMx0FXij8uS/UBXVA37Gch7CenV5Av52ZFza/ZuWQuxVjeycxFIA==",
       "requires": {
-        "@loaders.gl/loader-utils": "3.3.3",
-        "@loaders.gl/math": "3.3.3",
+        "@loaders.gl/loader-utils": "3.4.0",
+        "@loaders.gl/math": "3.4.0",
         "@math.gl/core": "^3.5.1",
         "@math.gl/culling": "^3.5.1",
         "@math.gl/geospatial": "^3.5.1",
         "@math.gl/web-mercator": "^3.5.1",
-        "@probe.gl/stats": "^3.5.0"
+        "@probe.gl/stats": "^4.0.1"
+      },
+      "dependencies": {
+        "@probe.gl/stats": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.3.tgz",
+          "integrity": "sha512-8BNKDmgwNqvcBNEcsIavtEWQp1WvBfryLodAv1YX8/Swg60Ky3ElDNNpSDuIVMnFDvI/De0zXiuXXydtn86/vA==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        }
       }
     },
     "@loaders.gl/worker-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.3.3.tgz",
-      "integrity": "sha512-mTQqbuAtFCgR2yu//7Rrt9pwhnDh0H2t69vOJ65Eh2YA0q4c58Kqd+260WxoPps3A0aiYNyA2099AHze7fI+Jg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.0.tgz",
+      "integrity": "sha512-xSopQni1V1qSGCvng71WzN5SQWOYL14wMAR3voGrNcThla/A+eJa0+0G8P2C4ilkEOem+jxigs0NSVlh7dfiJw==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -33669,80 +33767,80 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.50.0.tgz",
-      "integrity": "sha512-4TQ4vN0aMBWsUXfJWk2xbe4x7fKfwCXgXKTtHC/ocwwKM+0EefV5Iw9YFG8IrIQN4vMtuRzktqcs9q0/Sbv7tg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.1.tgz",
+      "integrity": "sha512-6N99rE+Ek0LgbqSzI/XpsKSLUyJjQ9nychViy+MP60p1x+hllukfTsDbNtUNrPlW0Bx+vqUrWKkAqmTFad94TQ==",
       "requires": {
-        "@sentry/core": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry/core": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/browser": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.50.0.tgz",
-      "integrity": "sha512-a+UYbP89+SAvW47/p9wxEi9eWlyp/SkYl52OCdZNXnplQY4kQIOVyiaIs5nnCxIxZgXKrhAX4eo1E9ykleFuNQ==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.52.1.tgz",
+      "integrity": "sha512-HrCOfieX68t+Wj42VIkraLYwx8kN5311SdBkHccevWs2Y2dZU7R9iLbI87+nb5kpOPQ7jVWW7d6QI/yZmliYgQ==",
       "requires": {
-        "@sentry-internal/tracing": "7.50.0",
-        "@sentry/core": "7.50.0",
-        "@sentry/replay": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry-internal/tracing": "7.52.1",
+        "@sentry/core": "7.52.1",
+        "@sentry/replay": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.50.0.tgz",
-      "integrity": "sha512-6oD1a3fYs4aiNK7tuJSd88LHjYJAetd7ZK/AfJniU7zWKj4jxIYfO8nhm0qdnhEDs81RcweVDmPhWm3Kwrzzsg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.1.tgz",
+      "integrity": "sha512-36clugQu5z/9jrit1gzI7KfKbAUimjRab39JeR0mJ6pMuKLTTK7PhbpUAD4AQBs9qVeXN2c7h9SVZiSA0UDvkg==",
       "requires": {
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/react": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.50.0.tgz",
-      "integrity": "sha512-V/KfIhwLezefnRz0y9pGJn5x0RBL8Q1347LowcOZWoNiDoaaLI9hRBTqJGyvCstG5NNhsLTKMM3UDk0WNXflPg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.52.1.tgz",
+      "integrity": "sha512-RRH+GJE5TNg5QS86bSjSZuR2snpBTOO5/SU9t4BOqZMknzhMVTClGMm84hffJa9pMPMJPQ2fWQAbhrlD8RcF6w==",
       "requires": {
-        "@sentry/browser": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0",
+        "@sentry/browser": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/replay": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.50.0.tgz",
-      "integrity": "sha512-EYRk+DTZ5luwfkiCaDpBC3YBKIEdkReTUNZtWDVUytSVjsCnttkAipx/y6bxy3HN+rSXungMd3XKQT5RNMRUNA==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.52.1.tgz",
+      "integrity": "sha512-A+RaUmpU9/yBHnU3ATemc6wAvobGno0yf5R6fZYkAFoo2FCR2YG6AXxkTazymIf8v2DnLGaSDORYDPdhQClU9A==",
       "requires": {
-        "@sentry/core": "7.50.0",
-        "@sentry/types": "7.50.0",
-        "@sentry/utils": "7.50.0"
+        "@sentry/core": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1"
       }
     },
     "@sentry/tracing": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.50.0.tgz",
-      "integrity": "sha512-avbIgDA/Bktci5OeWb5T6JCS5edWHeket92KeFNpMH79NfF46csA5yBgM+q0X9/R4swZd5fuTQwh4y6BHA4lEQ==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.52.1.tgz",
+      "integrity": "sha512-1afFeb0X6YcMK8mcsGXpO9rNFEF4Kd3mAUF22hXyFNWVoPNQsvdh/WxG2t3U+hLhehQ1ps3iJ0jxFRGF5zSboA==",
       "requires": {
-        "@sentry-internal/tracing": "7.50.0"
+        "@sentry-internal/tracing": "7.52.1"
       }
     },
     "@sentry/types": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.50.0.tgz",
-      "integrity": "sha512-Zo9vyI98QNeYT0K0y57Rb4JRWDaPEgmp+QkQ4CRQZFUTWetO5fvPZ4Gb/R7TW16LajuHZlbJBHmvmNj2pkL2kw=="
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.1.tgz",
+      "integrity": "sha512-OMbGBPrJsw0iEXwZ2bJUYxewI1IEAU2e1aQGc0O6QW5+6hhCh+8HO8Xl4EymqwejjztuwStkl6G1qhK+Q0/Row=="
     },
     "@sentry/utils": {
-      "version": "7.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.50.0.tgz",
-      "integrity": "sha512-iyPwwC6fwJsiPhH27ZbIiSsY5RaccHBqADS2zEjgKYhmP4P9WGgHRDrvLEnkOjqQyKNb6c0yfmv83n0uxYnolw==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.1.tgz",
+      "integrity": "sha512-MPt1Xu/jluulknW8CmZ2naJ53jEdtdwCBSo6fXJvOTI0SDqwIPbXDVrsnqLAhVJuIN7xbkj96nuY/VBR6S5sWg==",
       "requires": {
-        "@sentry/types": "7.50.0",
+        "@sentry/types": "7.52.1",
         "tslib": "^1.9.3"
       }
     },
@@ -34383,9 +34481,9 @@
       }
     },
     "@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q=="
+      "version": "20.1.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.7.tgz",
+      "integrity": "sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg=="
     },
     "@types/offscreencanvas": {
       "version": "2019.7.0",
@@ -34409,9 +34507,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "17.0.58",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
-      "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
+      "version": "17.0.59",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.59.tgz",
+      "integrity": "sha512-gSON5zWYIGyoBcycCE75E9+r6dCC2dHdsrVkOEiIYNU5+Q28HcBAuqvDuxHcCbMfHBHdeT5Tva/AFn3rnMKE4g==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -34428,9 +34526,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
+      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
       "requires": {
         "@types/react": "*"
       }
@@ -35601,9 +35699,9 @@
       }
     },
     "acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "requires": {}
     },
     "acorn-jsx": {
@@ -36280,9 +36378,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-sdk": {
-      "version": "2.1371.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1371.0.tgz",
-      "integrity": "sha512-dIts8xcmi7MFN1THOOcjiyqdvTqSVnsA4iIIerfyvpeYNobIi9pqBjCX9m8tfJ0pXQnymd4kp0xK9Y+i5dFfEQ==",
+      "version": "2.1379.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1379.0.tgz",
+      "integrity": "sha512-kziOtAtJxdgYJwhzY+uhNi/AGPrDEMHd0dEz46YR1AB5bVqjS9/SjOZHemB88QfpW11IVB/FoiIusXlGEvgq9Q==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -37034,9 +37132,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001482",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001482.tgz",
-      "integrity": "sha512-F1ZInsg53cegyjroxLNW9DmrEQ1SuGRTO1QlpA0o2/6OpQ0gFeDRoq1yFmnr8Sakn9qwwt9DmbxHB6w167OSuQ=="
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA=="
     },
     "cartocolor": {
       "version": "4.0.2",
@@ -37703,18 +37801,18 @@
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-js-compat": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.1.tgz",
-      "integrity": "sha512-d690npR7MC6P0gq4npTl5n2VQeNAmUrJ90n+MHiKS7W2+xno4o3F5GDEuylSdi6EJ3VssibSGXOa1r3YXD3Mhw==",
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
+      "integrity": "sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==",
       "dev": true,
       "requires": {
         "browserslist": "^4.21.5"
       }
     },
     "core-js-pure": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.1.tgz",
-      "integrity": "sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg=="
+      "version": "3.30.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.2.tgz",
+      "integrity": "sha512-p/npFUJXXBkCCTIlEGBdghofn00jWG6ZOtdoIXSJmAu2QBvN0IqpZXWweOytcwE6cfx8ZvVUy1vw8zxhe4Y2vg=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -37985,9 +38083,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.43",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-          "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+          "version": "14.18.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
+          "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==",
           "optional": true
         },
         "ansi-styles": {
@@ -38061,9 +38159,9 @@
           }
         },
         "semver": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
           "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -38858,9 +38956,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.382",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.382.tgz",
-      "integrity": "sha512-czMavlW52VIPgutbVL9JnZIZuFijzsG1ww/1z2Otu1r1q+9Qe2bTsH3My3sZarlvwyqHM6+mnZfEnt2Vr4dsIg=="
+      "version": "1.4.397",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.397.tgz",
+      "integrity": "sha512-jwnPxhh350Q/aMatQia31KAIQdhEsYS0fFZ0BQQlN9tfvOEwShu6ZNwI4kL/xBabjcB/nTy6lSt17kNIluJZ8Q=="
     },
     "element-resize-event": {
       "version": "2.0.9",
@@ -38928,9 +39026,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-      "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
+      "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -39207,15 +39305,15 @@
       }
     },
     "eslint": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
-      "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
+      "integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.2",
-        "@eslint/js": "8.39.0",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.40.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -39226,8 +39324,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.0",
-        "espree": "^9.5.1",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -39311,9 +39409,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
           "dev": true
         },
         "find-up": {
@@ -39471,20 +39569,20 @@
       "dev": true
     },
     "espree": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+          "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
           "dev": true
         }
       }
@@ -40432,12 +40530,13 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -42714,9 +42813,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -45611,9 +45710,9 @@
           }
         },
         "semver": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -45939,9 +46038,9 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "jquery": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-      "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
+      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
     },
     "js-cookie": {
       "version": "2.2.1",
@@ -47077,9 +47176,9 @@
       },
       "dependencies": {
         "@types/react": {
-          "version": "16.14.40",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.40.tgz",
-          "integrity": "sha512-elQj2VQHDuJ5xuEcn5Wxh/YQFNbEuPJFRKSdyG866awDm5dmtoqsMmuAJWb/l/qd2kDkZMfOTKygVfMIdBBPKg==",
+          "version": "16.14.41",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.41.tgz",
+          "integrity": "sha512-h+joCKF2r5rdECoM1U8WCEIHBp5/0TSR5Nyq8gtnnYY1n2WqGuj3indYqTjMb2/b5g2rfxJV6u4jUFq95lbT6Q==",
           "requires": {
             "@types/prop-types": "*",
             "@types/scheduler": "*",
@@ -47591,20 +47690,31 @@
           }
         },
         "@sinonjs/fake-timers": {
-          "version": "10.0.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-          "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz",
+          "integrity": "sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^2.0.0"
+            "@sinonjs/commons": "^3.0.0"
+          },
+          "dependencies": {
+            "@sinonjs/commons": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+              "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+              "dev": true,
+              "requires": {
+                "type-detect": "4.0.8"
+              }
+            }
           }
         }
       }
     },
     "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -48750,9 +48860,9 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "qs": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
-      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -48955,9 +49065,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.30.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.1.tgz",
-          "integrity": "sha512-ZNS5nbiSwDTq4hFosEDqm65izl2CWmLz0hARJMyNQBgkUZMIF51cQiMvIQKA6hvuaeWxQDP3hEedM1JZIgTldQ=="
+          "version": "3.30.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.2.tgz",
+          "integrity": "sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg=="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -49175,9 +49285,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.30.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.1.tgz",
-          "integrity": "sha512-ZNS5nbiSwDTq4hFosEDqm65izl2CWmLz0hARJMyNQBgkUZMIF51cQiMvIQKA6hvuaeWxQDP3hEedM1JZIgTldQ=="
+          "version": "3.30.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.30.2.tgz",
+          "integrity": "sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg=="
         }
       }
     },
@@ -51015,9 +51125,9 @@
           }
         },
         "semver": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -51101,9 +51211,9 @@
       }
     },
     "terser": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-      "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+      "version": "5.17.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.4.tgz",
+      "integrity": "sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -51119,15 +51229,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
-      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
+      "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.1",
-        "terser": "^5.16.5"
+        "terser": "^5.16.8"
       },
       "dependencies": {
         "schema-utils": {
@@ -52210,9 +52320,9 @@
       }
     },
     "vega-lite": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.8.0.tgz",
-      "integrity": "sha512-b2X/YEa9Tdhxgk+kwepUk0Nriu9l8WnJl0kTHTCDqc/BvBIEJ3d12PI20Pb0m39xTw02mQL9uW3IGgFyBqhuSw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.9.2.tgz",
+      "integrity": "sha512-HLzsDCzZQGabicmnG8weS26xMXssvrTbyKcCKFXSnO2RBffD5Q6W2Mvyz5+VVVk9JjEW+Im04cB9y4QQwtDEOQ==",
       "requires": {
         "@types/clone": "~2.1.1",
         "clone": "~2.1.2",
@@ -52223,7 +52333,7 @@
         "vega-event-selector": "~3.0.1",
         "vega-expression": "~5.1.0",
         "vega-util": "~1.17.2",
-        "yargs": "~17.7.1"
+        "yargs": "~17.7.2"
       },
       "dependencies": {
         "cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4424,14 +4424,6 @@
         "@babel/runtime": "^7.0.0"
       }
     },
-    "node_modules/@loaders.gl/tiles/node_modules/@probe.gl/stats": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.3.tgz",
-      "integrity": "sha512-8BNKDmgwNqvcBNEcsIavtEWQp1WvBfryLodAv1YX8/Swg60Ky3ElDNNpSDuIVMnFDvI/De0zXiuXXydtn86/vA==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
-    },
     "node_modules/@loaders.gl/worker-utils": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.0.tgz",
@@ -25795,9 +25787,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.2.2.tgz",
-      "integrity": "sha512-nrIdVAAte3B9icfBiGWvmMhT/D+eCDwnk+yA7VE/76dp/WkHX+i44Q/pfo71NYbwj0Ap+PGsn0ekOuU1WFJ2AA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.0.tgz",
+      "integrity": "sha512-LeWNswSEujsZnwdn9AuA+Q5wZEAFlU+eORQsDKp35OtGAfFxYxpfk/Ylon+TGGkazSqxi2EHDTqdr3di8r7nCg==",
       "dev": true,
       "dependencies": {
         "klona": "^2.0.6",
@@ -25812,7 +25804,7 @@
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
         "webpack": "^5.0.0"
@@ -27199,9 +27191,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.4.tgz",
-      "integrity": "sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==",
+      "version": "5.17.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.5.tgz",
+      "integrity": "sha512-NqFkzBX34WExkCbk3K5urmNCpEWqMPZnwGI1pMHwqvJ/zDlXC75u3NI7BrzoR8/pryy8Abx2e1i8ChrWkhH1Hg==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -50255,9 +50247,9 @@
       }
     },
     "sass-loader": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.2.2.tgz",
-      "integrity": "sha512-nrIdVAAte3B9icfBiGWvmMhT/D+eCDwnk+yA7VE/76dp/WkHX+i44Q/pfo71NYbwj0Ap+PGsn0ekOuU1WFJ2AA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.0.tgz",
+      "integrity": "sha512-LeWNswSEujsZnwdn9AuA+Q5wZEAFlU+eORQsDKp35OtGAfFxYxpfk/Ylon+TGGkazSqxi2EHDTqdr3di8r7nCg==",
       "dev": true,
       "requires": {
         "klona": "^2.0.6",
@@ -51253,9 +51245,9 @@
       }
     },
     "terser": {
-      "version": "5.17.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.4.tgz",
-      "integrity": "sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==",
+      "version": "5.17.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.5.tgz",
+      "integrity": "sha512-NqFkzBX34WExkCbk3K5urmNCpEWqMPZnwGI1pMHwqvJ/zDlXC75u3NI7BrzoR8/pryy8Abx2e1i8ChrWkhH1Hg==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "5.3.4"
+version = "5.3.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Trello: https://trello.com/c/qIw1omhJ

New Cypress test added for /browse page:

- it toggles between included and excluded properties in facets
- it excludes a `award.project` term and compares the exact Exp Set’s before and after counts
- it removes the excluded item's selection, then includes it, and compares the before and after counts.