### PR TITLE
Small tweak to generate-ontology script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ fourfront
 Change Log
 ----------
 
+5.3.12
+======
+
+* update to generate-ontology script to break up search query for all existing ontology terms into querying by ontology to get around the 100K result limit now that there are more than 100K terms in the db.
 
 5.3.11
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Change Log
 5.3.12
 ======
 
+`Tweak to generate ontology script  <https://github.com/4dn-dcic/fourfront/pull/1818>`_
+
 * update to generate-ontology script to break up search query for all existing ontology terms into querying by ontology to get around the 100K result limit now that there are more than 100K terms in the db.
 
 5.3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "5.3.11"
+version = "5.3.12"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -390,17 +390,21 @@ def get_slim_terms(connection):
     return slim_terms
 
 
-def get_existing_ontology_terms(connection):  # , ontologies=None):
+def get_existing_ontology_terms(connection, ontologies=None):
     """Retrieves all existing ontology terms from the db
     """
     search_suffix = 'search/?type=OntologyTerm&status=released&status=obsolete'  # + ont_list
-    db_terms = search_metadata(search_suffix, connection, page_limit=200, is_generator=True)
+    db_terms = {}
     ignore = [
         "111112bc-8535-4448-903e-854af460a233", "111113bc-8535-4448-903e-854af460a233",
         "111114bc-8535-4448-903e-854af460a233", "111116bc-8535-4448-903e-854af460a233",
         "111117bc-8535-4448-903e-854af460a233"
     ]
-    return {t['term_id']: t for t in db_terms if t['uuid'] not in ignore}
+    for o in ontologies:
+        search_query = f"search/?type=OntologyTerm&status=released&status=obsolete&source_ontologies.uuid={o.get('uuid')}"
+        oterms = search_metadata(search_query, connection, page_limit=200, is_generator=True)
+        db_terms.update({t['term_id']: t for t in oterms if t['uuid'] not in ignore})
+    return db_terms
 
 
 def get_ontologies(connection, ont_list):
@@ -997,6 +1001,11 @@ def write_outfile(to_write, filename, pretty=False):
         else:
             json.dump(to_write, outfile)
 
+def filter_ontologies(ontologies):
+    for i, o in enumerate(ontologies):
+        if o['ontology_name'].startswith('4DN') or o['ontology_name'].startswith('CGAP'):
+            ontologies.pop(i)
+
 
 def parse_args(args):
     parser = argparse.ArgumentParser(  # noqa - PyCharm wrongly thinks the formatter_class is specified wrong here.
@@ -1088,6 +1097,8 @@ def main():
         key = args.key
     connection = connect2server(args.env, key, args)
     print("Pre-processing")
+    all_ontologies = get_ontologies(connection, 'all')
+    filter_ontologies(all_ontologies)
     ontologies = get_ontologies(connection, args.ontology)
     if len(ontologies) > 1 and args.simple:
         print("INVALID USAGE - simple can only be used while processing a single ontology")
@@ -1095,13 +1106,11 @@ def main():
     if len(ontologies) > 1 and args.owlfile:
         print("INVALID USAGE - path to local owlfile can only be used while processing a single ontology")
         sys.exit(1)
-    for i, o in enumerate(ontologies):
-        if o['ontology_name'].startswith('4DN') or o['ontology_name'].startswith('CGAP'):
-            ontologies.pop(i)
+    filter_ontologies(ontologies)
     print('HAVE ONTOLOGY INFO')
     slim_terms = get_slim_terms(connection)
     print('HAVE SLIM TERMS')
-    db_terms = get_existing_ontology_terms(connection)
+    db_terms = get_existing_ontology_terms(connection, ontologies=all_ontologies)
     print('HAVE DB TERMS')
     terms = {}
     deprecated = []

--- a/src/encoded/commands/generate_ontology.py
+++ b/src/encoded/commands/generate_ontology.py
@@ -1003,7 +1003,7 @@ def write_outfile(to_write, filename, pretty=False):
 
 def filter_ontologies(ontologies):
     for i, o in enumerate(ontologies):
-        if o['ontology_name'].startswith('4DN') or o['ontology_name'].startswith('CGAP'):
+        if o['ontology_name'].startswith('4DN'):
             ontologies.pop(i)
 
 


### PR DESCRIPTION
To account for the search limit of 100K items broke up the single query for all existing ontology terms into multiple queries (by ontology) and results to dictionary to avoid terms that are part of multiple ontologies being redundant in the returned result.