### PR TITLE
Fix mime order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,12 @@ fourfront
 Change Log
 ----------
 
+6.1.0
+=====
+* Fix for MIME type ordering in renderers.py (differs between cgap and fourfront).
+
 6.0.1
-======
+=====
 
 `GA4 post-migration updates  <https://github.com/4dn-dcic/fourfront/pull/1825>`_
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -940,14 +940,14 @@ tox = ["tox"]
 
 [[package]]
 name = "dcicsnovault"
-version = "9.0.0.1b2"
+version = "9.1.0"
 description = "Storage support for 4DN Data Portals."
 category = "main"
 optional = false
 python-versions = ">=3.8.1,<3.10"
 files = [
-    {file = "dcicsnovault-9.0.0.1b2-py3-none-any.whl", hash = "sha256:57baab99885379181997cf4f0a8d1cc643c17a601b5318f357ae9236f7423557"},
-    {file = "dcicsnovault-9.0.0.1b2.tar.gz", hash = "sha256:285c636b68da1e8b87c5f64fe863fc02102b5da3ac50a3e3c99df9ce97af538c"},
+    {file = "dcicsnovault-9.1.0-py3-none-any.whl", hash = "sha256:e21558f5c9152f120ca4eca67d2846a4668b6fc915b070fbba35436d258460f3"},
+    {file = "dcicsnovault-9.1.0.tar.gz", hash = "sha256:d703b893719ec5c35d390ad4e986066acbc250ad5dcb5f4e09621e33156a2066"},
 ]
 
 [package.dependencies]
@@ -3652,4 +3652,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.10"
-content-hash = "93d8ff9fd34d8cd0c6aae7590d0af44be06fb13160b85d3461d5219c7f27d1d6"
+content-hash = "4bb05401124ce15c450a6e05b44864f37d66f2a01210560ab9811f23d15f4ece"

--- a/poetry.lock
+++ b/poetry.lock
@@ -944,13 +944,56 @@ version = "9.0.0.1b1"
 description = "Storage support for 4DN Data Portals."
 category = "main"
 optional = false
-python-versions = "*"
-files = []
-develop = true
+python-versions = ">=3.8.1,<3.10"
+files = [
+    {file = "dcicsnovault-9.0.0.1b1-py3-none-any.whl", hash = "sha256:003d18e6d3efa3362a05a80687b595a3b282182953ad956b4ff8d4d44cb81f2a"},
+    {file = "dcicsnovault-9.0.0.1b1.tar.gz", hash = "sha256:99483c87a8a257b578cea9cccbc24b9e49c08757b15d2964a71b708f37815f70"},
+]
 
-[package.source]
-type = "directory"
-url = "../snovault"
+[package.dependencies]
+aws_requests_auth = ">=0.4.1,<0.5.0"
+boto3 = ">=1.26.133"
+botocore = ">=1.26.133"
+dcicutils = ">=7.5.0,<8.0.0"
+elasticsearch = "7.13.4"
+elasticsearch_dsl = ">=7.4.0,<8.0.0"
+future = ">=0.15.2,<1"
+html5lib = ">=1.1"
+humanfriendly = ">=1.44.9,<2.0.0"
+jsonschema_serialize_fork = ">=2.1.1,<3.0.0"
+netaddr = ">=0.8.0,<1"
+passlib = ">=1.7.4,<2.0.0"
+pillow = ">=9.5.0,<10.0.0"
+psutil = ">=5.9.0,<6.0.0"
+psycopg2-binary = ">=2.9.1,<3.0.0"
+PyBrowserID = ">=0.10.0,<1"
+pyjwt = ">=2.6.0,<3.0.0"
+pyramid = "1.10.4"
+pyramid-multiauth = ">=0.9.0,<1"
+pyramid-retry = ">=1.0,<2.0"
+pyramid-tm = ">=2.5,<3.0"
+pyramid-translogger = ">=0.1,<0.2"
+python-dateutil = ">=2.8.2,<3.0.0"
+python_magic = ">=0.4.27"
+pytz = ">=2021.3"
+rdflib = ">=4.2.2,<5.0.0"
+rdflib-jsonld = ">=0.5.0,<1.0.0"
+redis = ">=4.5.1,<5.0.0"
+rutter = ">=0.3,<1"
+simplejson = ">=3.17.6,<4.0.0"
+SPARQLWrapper = ">=1.8.5,<2.0.0"
+SQLAlchemy = ">=1.4.41,<2.0.0"
+structlog = ">=19.2.0,<20"
+subprocess_middleware = ">=0.3,<1"
+transaction = ">=3.0.1,<4.0.0"
+venusian = ">=1.2.0,<2.0.0"
+WebOb = ">=1.8.7,<2.0.0"
+WebTest = ">=2.0.35,<3.0.0"
+WSGIProxy2 = "0.4.2"
+xlrd = ">=1.0.0,<2.0.0"
+"zope.deprecation" = ">=4.4.0,<5.0.0"
+"zope.interface" = ">=4.7.2,<6"
+"zope.sqlalchemy" = "1.6"
 
 [[package]]
 name = "dcicutils"
@@ -1289,6 +1332,28 @@ files = [
 [package.extras]
 docs = ["Sphinx", "docutils (<0.18)"]
 test = ["objgraph", "psutil"]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+description = "HTML parser based on the WHATWG HTML specification"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
+    {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
+]
+
+[package.dependencies]
+six = ">=1.9"
+webencodings = "*"
+
+[package.extras]
+all = ["chardet (>=2.2)", "genshi", "lxml"]
+chardet = ["chardet (>=2.2)"]
+genshi = ["genshi"]
+lxml = ["lxml"]
 
 [[package]]
 name = "humanfriendly"
@@ -3237,6 +3302,18 @@ files = [
 [package.extras]
 docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
 testing = ["coverage (>=5.0)", "pytest", "pytest-cover"]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
 
 [[package]]
 name = "webob"

--- a/poetry.lock
+++ b/poetry.lock
@@ -940,60 +940,17 @@ tox = ["tox"]
 
 [[package]]
 name = "dcicsnovault"
-version = "9.0.0"
+version = "9.0.0.1b1"
 description = "Storage support for 4DN Data Portals."
 category = "main"
 optional = false
-python-versions = ">=3.8.1,<3.10"
-files = [
-    {file = "dcicsnovault-9.0.0-py3-none-any.whl", hash = "sha256:4a685876b2ea724dce3f09d37c99a6482aefc31b75818f07a1ad80c1dab6552e"},
-    {file = "dcicsnovault-9.0.0.tar.gz", hash = "sha256:6dfb23387ae2c25674bc066c1c7a6fb06f8d1e51b3d659367a4fbdc4a297ee9d"},
-]
+python-versions = "*"
+files = []
+develop = true
 
-[package.dependencies]
-aws_requests_auth = ">=0.4.1,<0.5.0"
-boto3 = ">=1.26.133"
-botocore = ">=1.26.133"
-dcicutils = ">=7.5.0,<8.0.0"
-elasticsearch = "7.13.4"
-elasticsearch_dsl = ">=7.4.0,<8.0.0"
-future = ">=0.15.2,<1"
-html5lib = ">=1.1"
-humanfriendly = ">=1.44.9,<2.0.0"
-jsonschema_serialize_fork = ">=2.1.1,<3.0.0"
-netaddr = ">=0.8.0,<1"
-passlib = ">=1.7.4,<2.0.0"
-pillow = ">=9.5.0,<10.0.0"
-psutil = ">=5.9.0,<6.0.0"
-psycopg2-binary = ">=2.9.1,<3.0.0"
-PyBrowserID = ">=0.10.0,<1"
-pyjwt = ">=2.6.0,<3.0.0"
-pyramid = "1.10.4"
-pyramid-multiauth = ">=0.9.0,<1"
-pyramid-retry = ">=1.0,<2.0"
-pyramid-tm = ">=2.5,<3.0"
-pyramid-translogger = ">=0.1,<0.2"
-python-dateutil = ">=2.8.2,<3.0.0"
-python_magic = ">=0.4.27"
-pytz = ">=2021.3"
-rdflib = ">=4.2.2,<5.0.0"
-rdflib-jsonld = ">=0.5.0,<1.0.0"
-redis = ">=4.5.1,<5.0.0"
-rutter = ">=0.3,<1"
-simplejson = ">=3.17.6,<4.0.0"
-SPARQLWrapper = ">=1.8.5,<2.0.0"
-SQLAlchemy = ">=1.4.41,<2.0.0"
-structlog = ">=19.2.0,<20"
-subprocess_middleware = ">=0.3,<1"
-transaction = ">=3.0.1,<4.0.0"
-venusian = ">=1.2.0,<2.0.0"
-WebOb = ">=1.8.7,<2.0.0"
-WebTest = ">=2.0.35,<3.0.0"
-WSGIProxy2 = "0.4.2"
-xlrd = ">=1.0.0,<2.0.0"
-"zope.deprecation" = ">=4.4.0,<5.0.0"
-"zope.interface" = ">=4.7.2,<6"
-"zope.sqlalchemy" = "1.6"
+[package.source]
+type = "directory"
+url = "../snovault"
 
 [[package]]
 name = "dcicutils"
@@ -1332,28 +1289,6 @@ files = [
 [package.extras]
 docs = ["Sphinx", "docutils (<0.18)"]
 test = ["objgraph", "psutil"]
-
-[[package]]
-name = "html5lib"
-version = "1.1"
-description = "HTML parser based on the WHATWG HTML specification"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
-    {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
-]
-
-[package.dependencies]
-six = ">=1.9"
-webencodings = "*"
-
-[package.extras]
-all = ["chardet (>=2.2)", "genshi", "lxml"]
-chardet = ["chardet (>=2.2)"]
-genshi = ["genshi"]
-lxml = ["lxml"]
 
 [[package]]
 name = "humanfriendly"
@@ -3304,18 +3239,6 @@ docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
 testing = ["coverage (>=5.0)", "pytest", "pytest-cover"]
 
 [[package]]
-name = "webencodings"
-version = "0.5.1"
-description = "Character encoding aliases for legacy web content"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
-    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
-]
-
-[[package]]
 name = "webob"
 version = "1.8.7"
 description = "WSGI request and response object"
@@ -3652,4 +3575,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.10"
-content-hash = "61ccd2b3582fe400e7a92c01e5c49f7fcf4abed0593cb5535b8989d51bf7e133"
+content-hash = "0d69e59feb28969973a35012da4e359424b213ced651f3f13090713008baa19a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -940,14 +940,14 @@ tox = ["tox"]
 
 [[package]]
 name = "dcicsnovault"
-version = "9.0.0.1b1"
+version = "9.0.0.1b2"
 description = "Storage support for 4DN Data Portals."
 category = "main"
 optional = false
 python-versions = ">=3.8.1,<3.10"
 files = [
-    {file = "dcicsnovault-9.0.0.1b1-py3-none-any.whl", hash = "sha256:003d18e6d3efa3362a05a80687b595a3b282182953ad956b4ff8d4d44cb81f2a"},
-    {file = "dcicsnovault-9.0.0.1b1.tar.gz", hash = "sha256:99483c87a8a257b578cea9cccbc24b9e49c08757b15d2964a71b708f37815f70"},
+    {file = "dcicsnovault-9.0.0.1b2-py3-none-any.whl", hash = "sha256:57baab99885379181997cf4f0a8d1cc643c17a601b5318f357ae9236f7423557"},
+    {file = "dcicsnovault-9.0.0.1b2.tar.gz", hash = "sha256:285c636b68da1e8b87c5f64fe863fc02102b5da3ac50a3e3c99df9ce97af538c"},
 ]
 
 [package.dependencies]
@@ -3652,4 +3652,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.10"
-content-hash = "0d69e59feb28969973a35012da4e359424b213ced651f3f13090713008baa19a"
+content-hash = "93d8ff9fd34d8cd0c6aae7590d0af44be06fb13160b85d3461d5219c7f27d1d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ colorama = "0.3.3"
 # we get odd 'pyo3_runtime.PanicException: Python API call failed' error on import
 # of cryptography.hazmat.bindings._rust in cryptography package. 2023-04-21.
 cryptography = "39.0.2"
-dcicsnovault = "9.0.0.1b1"
+dcicsnovault = "9.0.0.1b2"
 dcicutils = "^7.5.0"
 elasticsearch = "7.13.4"
 elasticsearch-dsl = "^7.0.0"  # TODO: port code from cgap-portal to get rid of uses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "6.0.1.1b1"  # TODO: To become 6.1.0
+version = "6.1.0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -47,7 +47,7 @@ colorama = "0.3.3"
 # we get odd 'pyo3_runtime.PanicException: Python API call failed' error on import
 # of cryptography.hazmat.bindings._rust in cryptography package. 2023-04-21.
 cryptography = "39.0.2"
-dcicsnovault = "9.0.0.1b2"
+dcicsnovault = "^9.1.0"
 dcicutils = "^7.5.0"
 elasticsearch = "7.13.4"
 elasticsearch-dsl = "^7.0.0"  # TODO: port code from cgap-portal to get rid of uses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "6.0.1"
+version = "6.0.1.1b1"  # TODO: To become 6.1.0
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -47,7 +47,7 @@ colorama = "0.3.3"
 # we get odd 'pyo3_runtime.PanicException: Python API call failed' error on import
 # of cryptography.hazmat.bindings._rust in cryptography package. 2023-04-21.
 cryptography = "39.0.2"
-dcicsnovault = "9.0.0"
+dcicsnovault = "9.0.0.1b1"
 dcicutils = "^7.5.0"
 elasticsearch = "7.13.4"
 elasticsearch-dsl = "^7.0.0"  # TODO: port code from cgap-portal to get rid of uses

--- a/src/encoded/project/renderers.py
+++ b/src/encoded/project/renderers.py
@@ -1,0 +1,7 @@
+from snovault.project.renderers import SnovaultProjectRenderers
+from snovault.mime_types import MIME_TYPE_HTML, MIME_TYPE_JSON, MIME_TYPE_LD_JSON
+
+class FourfrontProjectRenderers(SnovaultProjectRenderers):
+
+    def renderers_mime_types_supported(self):
+        return [MIME_TYPE_HTML, MIME_TYPE_JSON, MIME_TYPE_LD_JSON]

--- a/src/encoded/project_defs.py
+++ b/src/encoded/project_defs.py
@@ -6,6 +6,7 @@ from .project.authentication import FourfrontProjectAuthentication
 from .project.authorization import FourfrontProjectAuthorization
 from .project.ingestion import FourfrontProjectIngestion
 from .project.loadxl import FourfrontProjectLoadxl
+from .project.renderers import FourfrontProjectRenderers
 
 @C4ProjectRegistry.register(APPLICATION_PYPROJECT_NAME)
 class FourfrontProject(FourfrontProjectAccessKey,
@@ -13,6 +14,7 @@ class FourfrontProject(FourfrontProjectAccessKey,
                        FourfrontProjectAuthorization,
                        FourfrontProjectIngestion,
                        FourfrontProjectLoadxl,
+                       FourfrontProjectRenderers,
                        SnovaultProject):
     NAMES = {'NAME': APPLICATION_NAME, 'PYPI_NAME': APPLICATION_PYPROJECT_NAME}
     ACCESSION_PREFIX = "4DN"


### PR DESCRIPTION
New project/renderers.py to customize the initialization of MIME_TYPES_SUPPORTED to be via Kent's project_defs mechanism, i.e. app_project().renderers_mime_types_supported(). See also snovault PR-261.