### PR TITLE
Bug Fix - Pages are not correctly rendering MD image links

### DIFF
--- a/src/encoded/static/components/static-pages/StaticPage.js
+++ b/src/encoded/static/components/static-pages/StaticPage.js
@@ -96,7 +96,7 @@ export const StaticEntryContent = React.memo(function StaticEntryContent(props){
     } else if (typeof content === 'string' && filetype === 'txt' && content.slice(0,12) === 'placeholder:'){
         // Deprecated older method - to be removed once data.4dn uses filetype=jsx everywhere w/ placeholder
         renderedContent = replacePlaceholderString(content.slice(12).trim(), _.omit(props, 'className', 'section', 'content'));
-    } else if (content_as_html && typeof content_as_html === 'string' && filetype === 'rst'){
+    } else if (content_as_html && typeof content_as_html === 'string' && (filetype === 'rst' || filetype === 'md')){
         renderedContent = replacePlaceholderString(content_as_html.trim(), _.omit(props, 'className', 'section', 'content', 'content_as_html'));
     } else {
         renderedContent = content;


### PR DESCRIPTION
Trello: https://trello.com/c/DnFEgbtj

Markdown formatted static sections with images in hyperlinks are not correctly rendered if embedded in Pages. If the static section is rendered standalone, it works well.

![image](https://github.com/4dn-dcic/fourfront/assets/49978017/68c7f896-69c7-42cd-8402-b7e7429c8961)
