### PR TITLE
Bug Fix - Markdown JSON Content in Static Sections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ fourfront
 Change Log
 ----------
 
+6.4.5
+=====
+
+`Bug fix - markdown json content in static sections <https://github.com/4dn-dcic/fourfront/pull/1853>`_
+
+* Json code sections in markdowns static content is not correctly rendered
+
+
 6.4.4
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "6.4.4"
+version = "6.4.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/user_content.py
+++ b/src/encoded/types/user_content.py
@@ -159,7 +159,7 @@ class StaticSection(UserContent):
         elif file_type == 'md':
             # remove new line character
             output = convert_markdown_to_html(content)
-            output = output.replace('\n', '')
+            # output = output.replace('\n', '')
             if output and convert_ext_links:
                 return convert_external_links(output, request.domain)
             return output
@@ -350,7 +350,7 @@ def get_remote_file_contents(uri):
 
 def convert_markdown_to_html(markdown_text, custom_wrapper = 'div'):
     # convert markdown to html including tables
-    html_output = markdown.markdown(markdown_text, extensions=['tables'])
+    html_output = markdown.markdown(markdown_text, extensions=['tables', 'fenced_code'])
 
     # check content has any header, if yes wrap it with custom tag
     header_pattern = re.compile(r'<h[1-6]>.*?<\/h[1-6]>', re.IGNORECASE)


### PR DESCRIPTION
Trello: https://trello.com/c/g4FWO3AK

Json code sections in markdowns static content is not correctly rendered.

Bug:

<img width="874" alt="Screen Shot 2023-09-29 at 13 14 20" src="https://github.com/4dn-dcic/fourfront/assets/49978017/95695d38-056f-4b2e-9656-d641f06c6b98">


Fix:

![Screen Shot 2023-09-25 at 19 21 12](https://github.com/4dn-dcic/fourfront/assets/49978017/ae2b4f23-8320-4061-a9b8-417cc9667cb0)
