### PR TITLE
added new relation type for files and experiments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ fourfront
 Change Log
 ----------
 
+
+7.3.4
+=====
+
+* added new allowed relationship type to both File and Experiment - 'matched with'
+
+
 7.3.3
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "7.3.3"
+version = "7.3.4"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/experiment.json
+++ b/src/encoded/schemas/experiment.json
@@ -106,7 +106,8 @@
                             "derived from",
                             "source for",
                             "input of",
-                            "has input"
+                            "has input",
+                            "matched with"
                         ]
                     },
                     "experiment": {

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -172,7 +172,8 @@
                             "derived from",
                             "parent of",
                             "paired with",
-                            "grouped with"
+                            "grouped with",
+                            "matched with"
                         ]
                     },
                     "file": {

--- a/src/encoded/types/experiment.py
+++ b/src/encoded/types/experiment.py
@@ -406,7 +406,8 @@ class Experiment(Item):
             "control for": "controlled by",
             "source for": "derived from",
             "input of": "has input",
-            "has input": "input of"
+            "has input": "input of",
+            "matched with": "matched with",
         }
         acc = str(self.uuid)
         if 'experiment_relation' in properties.keys():

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -684,6 +684,7 @@ class File(Item):
             "supercedes": "is superceded by",
             "is superceded by": "supercedes",
             "paired with": "paired with",
+            "matched with": "matched with",
             # "grouped with": "grouped with"
         }
 


### PR DESCRIPTION
Added 'matched with' relationship type for both files and experiments to allow linked of in the current case scRNA-seq and scHiC reads generated from the same cells and samples.