### PR TITLE
Home Page QuickInfoBar Links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ fourfront
 Change Log
 ----------
 
+7.5.0
+=====
+
+* changes QuickInfoBar experiment and file links from /browse to /search
+* adds OPF to File counts
+
+
 7.4.2
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ fourfront
 Change Log
 ----------
 
+7.4.2
+=====
+
+* changes QuickInfoBar experiment and file links from /browse to /search 
+
+
 7.4.1
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "7.4.2"
+version = "7.5.0"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "7.4.1"
+version = "7.4.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -317,7 +317,7 @@ class Stat extends React.PureComponent {
         'experiments' : "/search/?type=Experiment&experiment_sets.experimentset_type=replicate&experiment_sets.@type=ExperimentSetReplicate",
         'expsets' : "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate",
         'files' : "/search/?type=File&experiments.experiment_sets.@type=ExperimentSetReplicate&experiments.experiment_sets.experimentset_type=replicate"
-    }
+    };
 
     filtersHrefChunk(){
         const { expSetFilters, classNameID } = this.props;
@@ -330,16 +330,40 @@ class Stat extends React.PureComponent {
         }
     }
 
+    // Version 1: Always goto Browse page for now
+    // label(){
+    //     const { value, shortLabel, expSetFilters, href } = this.props;
+    //     if (!value) {
+    //         return shortLabel;
+    //     }
+
+    //     // Always goto Browse page for now
+    //     var filtersHrefChunk = searchFilters.expSetFiltersToURLQuery(expSetFilters); //this.filtersHrefChunk();
+    //     var targetHref = navigate.getBrowseBaseHref();
+    //     targetHref += (filtersHrefChunk ? navigate.determineSeparatorChar(targetHref) + filtersHrefChunk : '');
+
+    //     if (typeof href === 'string'){
+    //         // Strip hostname/port from this.props.href and compare pathnames to check if we are already on this page.
+    //         if (navigate.isBrowseHref(href)) return <span>{ shortLabel }</span>;
+    //         // eslint-disable-next-line no-useless-escape
+    //         if (href.replace(/(http:|https:)(\/\/)[^\/]+(?=\/)/, '') === targetHref) return <span>{ shortLabel }</span>;
+    //     }
+
+    //     return (
+    //         <a href={targetHref}>{ shortLabel }</a>
+    //     );
+    // }
+
+    // Version 2: Goto ExpSet, Exp, File
     label(){
-        const { value, shortLabel, expSetFilters, href } = this.props;
+        const { value, shortLabel, href, classNameID } = this.props;
         if (!value) {
             return shortLabel;
         }
 
-        // Always goto Browse page for now
-        var filtersHrefChunk = searchFilters.expSetFiltersToURLQuery(expSetFilters); //this.filtersHrefChunk();
-        var targetHref = navigate.getBrowseBaseHref();
-        targetHref += (filtersHrefChunk ? navigate.determineSeparatorChar(targetHref) + filtersHrefChunk : '');
+        const filtersHrefChunk = this.filtersHrefChunk();
+        const sep = filtersHrefChunk && filtersHrefChunk.length > 0 ? '&' : '';
+        const targetHref = Stat.typesPathMap[classNameID] + sep + (filtersHrefChunk || '');
 
         if (typeof href === 'string'){
             // Strip hostname/port from this.props.href and compare pathnames to check if we are already on this page.

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -287,7 +287,7 @@ const StatsCol = React.memo(function StatsCol(props){
             'files'             : total.files || 0
         };
     }
-    const statProps = _.extend(_.pick(props, 'id', 'href', 'isLoadingChartData'), { 'expSetFilters' : expSetFilters });
+    const statProps = _.extend(_.pick(props, 'id', 'href', 'isLoadingChartData', 'browseBaseState'), { 'expSetFilters' : expSetFilters });
     return (
         <div className="col-8 left-side clearfix">
             <Stat {...statProps} shortLabel="Experiment Sets" longLabel="Experiment Sets" classNameID="expsets" value={stats.experiment_sets} key="expsets" />
@@ -356,12 +356,12 @@ class Stat extends React.PureComponent {
 
     // Version 2: Goto ExpSet, Exp, File
     label(){
-        const { value, shortLabel, href, classNameID } = this.props;
+        const { value, shortLabel, href, classNameID, browseBaseState } = this.props;
         if (!value) {
             return shortLabel;
         }
 
-        const filtersHrefChunk = this.filtersHrefChunk();
+        const filtersHrefChunk = (browseBaseState === 'only_4dn' ? 'award.project=4DN' : '');//this.filtersHrefChunk();
         const sep = filtersHrefChunk && filtersHrefChunk.length > 0 ? '&' : '';
         const targetHref = Stat.typesPathMap[classNameID] + sep + (filtersHrefChunk || '');
 

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -316,7 +316,8 @@ class Stat extends React.PureComponent {
     static typesPathMap = {
         'experiments' : "/search/?type=Experiment&experiment_sets.experimentset_type=replicate&experiment_sets.@type=ExperimentSetReplicate",
         'expsets' : "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate",
-        'files' : "/search/?type=File&experiments.experiment_sets.@type=ExperimentSetReplicate&experiments.experiment_sets.experimentset_type=replicate"
+        'files' : "/search/?type=File&track_and_facet_info.replicate_info!=No+value"
+        // 'files' : "/search/?type=File&experiments.experiment_sets.@type=ExperimentSetReplicate&experiments.experiment_sets.experimentset_type=replicate"
     };
 
     filtersHrefChunk(){

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -316,7 +316,7 @@ class Stat extends React.PureComponent {
     static typesPathMap = {
         'experiments' : "/search/?type=Experiment&experiment_sets.experimentset_type=replicate&experiment_sets.@type=ExperimentSetReplicate",
         'expsets' : "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate",
-        'files' : "/search/?type=File&&track_and_facet_info.replicate_info!=No+value"
+        'files' : "/search/?type=File&experiments.experiment_sets.@type=ExperimentSetReplicate&experiments.experiment_sets.experimentset_type=replicate"
     };
 
     filtersHrefChunk(){

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -316,7 +316,7 @@ class Stat extends React.PureComponent {
     static typesPathMap = {
         'experiments' : "/search/?type=Experiment&experiment_sets.experimentset_type=replicate&experiment_sets.@type=ExperimentSetReplicate",
         'expsets' : "/browse/?type=ExperimentSetReplicate&experimentset_type=replicate",
-        'files' : "/search/?type=File&experiments.experiment_sets.@type=ExperimentSetReplicate&experiments.experiment_sets.experimentset_type=replicate"
+        'files' : "/search/?type=File&&track_and_facet_info.replicate_info!=No+value"
     };
 
     filtersHrefChunk(){

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -174,15 +174,11 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
             "precision_threshold" : 10000
         }
     },
-    "total_expset_other_processed_files" : {
+    "total_exp_expset_other_processed_files" : {
         "cardinality" : {
-            "field" : "embedded.other_processed_files.files.accession.raw",
-            "precision_threshold" : 10000
-        }
-    },
-    "total_exp_other_processed_files" : {
-        "cardinality" : {
-            "field" : "embedded.experiments_in_set.other_processed_files.files.accession.raw",
+            "script":{
+		        "source":"return [doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.experiments_in_set.other_processed_files.files.accession.raw']]"
+		    },
             "precision_threshold" : 10000
         }
     },
@@ -191,11 +187,10 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
             "buckets_path": {
                 "expSetProcessedFiles": "total_expset_processed_files",
                 "expProcessedFiles": "total_exp_processed_files",
-                "expSetOtherProcessedFiles": "total_expset_other_processed_files",
-                "expOtherProcessedFiles": "total_exp_other_processed_files",
+                "expExpSetOtherProcessedFiles": "total_exp_expset_other_processed_files",
                 "expRawFiles": "total_exp_raw_files"
             },
-            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expSetOtherProcessedFiles + params.expOtherProcessedFiles + params.expRawFiles"
+            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expExpSetOtherProcessedFiles + params.expRawFiles"
         }
     },
     "total_experiments" : {
@@ -288,8 +283,7 @@ def bar_plot_chart(context, request):
                 search_result['aggregations']['total_expset_processed_files']['value'] +
                 search_result['aggregations']['total_exp_raw_files']['value'] +
                 search_result['aggregations']['total_exp_processed_files']['value'] +
-                search_result['aggregations']['total_exp_other_processed_files']['value'] +
-                search_result['aggregations']['total_expset_other_processed_files']['value']
+                search_result['aggregations']['total_exp_expset_other_processed_files']['value']
             )
         },
         "other_doc_count": search_result['aggregations']['field_0'].get('sum_other_doc_count', 0),

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -174,33 +174,38 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
             "precision_threshold" : 10000
         }
     },
-    "total_exp_expset_other_processed_files" : {
+    "total_expset_other_processed_files" : {
         "cardinality" : {
-            "script":{
-		        "source":"return [doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.other_processed_files.files.accession.raw']]"
-		    },
+            "field": "embedded.other_processed_files.files.accession.raw",
             "precision_threshold" : 10000
         }
     },
-    # "total_files" : {
-    #     "bucket_script" : {
-    #         "buckets_path": {
-    #             "expSetProcessedFiles": "total_expset_processed_files",
-    #             "expProcessedFiles": "total_exp_processed_files",
-    #             "expExpSetOtherProcessedFiles": "total_exp_expset_other_processed_files",
-    #             "expRawFiles": "total_exp_raw_files"
-    #         },
-    #         "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expExpSetOtherProcessedFiles + params.expRawFiles"
-    #     }
-    # },
-    "total_files" : {
+    "total_exp_other_processed_files" : {
         "cardinality" : {
-            "script":{
-		        "source":"return [doc['embedded.experiments_in_set.files.accession.raw'], doc['embedded.processed_files.accession.raw'], doc['embedded.experiments_in_set.processed_files.accession.raw'], doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.other_processed_files.files.accession.raw']]"
-		    },
-            "precision_threshold" : 40000
+            "field": "embedded.experiments_in_set.other_processed_files.files.accession.raw",
+            "precision_threshold" : 10000
         }
     },
+    "total_files" : {
+        "bucket_script" : {
+            "buckets_path": {
+                "expSetProcessedFiles": "total_expset_processed_files",
+                "expProcessedFiles": "total_exp_processed_files",
+                "expSetOtherProcessedFiles": "total_expset_other_processed_files",
+                "expOtherProcessedFiles": "total_exp_other_processed_files",
+                "expRawFiles": "total_exp_raw_files"
+            },
+            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expSetOtherProcessedFiles + params.expOtherProcessedFiles + params.expRawFiles"
+        }
+    },
+    # "total_files" : {
+    #     "cardinality" : {
+    #         "script":{
+	# 	        "source":"return [doc['embedded.experiments_in_set.files.accession.raw'], doc['embedded.processed_files.accession.raw'], doc['embedded.experiments_in_set.processed_files.accession.raw'], doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.other_processed_files.files.accession.raw']]"
+	# 	    },
+    #         "precision_threshold" : 10000
+    #     }
+    # },
     "total_experiments" : {
         "value_count" : {
             "field" : "embedded.experiments_in_set.accession.raw"
@@ -291,7 +296,8 @@ def bar_plot_chart(context, request):
                 search_result['aggregations']['total_expset_processed_files']['value'] +
                 search_result['aggregations']['total_exp_raw_files']['value'] +
                 search_result['aggregations']['total_exp_processed_files']['value'] +
-                search_result['aggregations']['total_exp_expset_other_processed_files']['value']
+                search_result['aggregations']['total_expset_other_processed_files']['value'] +
+                search_result['aggregations']['total_exp_other_processed_files']['value']
             )
         },
         "other_doc_count": search_result['aggregations']['field_0'].get('sum_other_doc_count', 0),

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -174,14 +174,28 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
             "precision_threshold" : 10000
         }
     },
+    "total_expset_other_processed_files" : {
+        "cardinality" : {
+            "field" : "embedded.other_processed_files.accession.raw",
+            "precision_threshold" : 10000
+        }
+    },
+    "total_exp_other_processed_files" : {
+        "cardinality" : {
+            "field" : "embedded.experiments_in_set.other_processed_files.accession.raw",
+            "precision_threshold" : 10000
+        }
+    },
     "total_files" : {
         "bucket_script" : {
             "buckets_path": {
                 "expSetProcessedFiles": "total_expset_processed_files",
                 "expProcessedFiles": "total_exp_processed_files",
+                "expSetOtherProcessedFiles": "total_expset_other_processed_files",
+                "expOtherProcessedFiles": "total_exp_other_processed_files",
                 "expRawFiles": "total_exp_raw_files"
             },
-            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expRawFiles"
+            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expSetOtherProcessedFiles + params.expOtherProcessedFiles + params.expRawFiles"
         }
     },
     "total_experiments" : {

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -176,13 +176,13 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
     },
     "total_expset_other_processed_files" : {
         "cardinality" : {
-            "field" : "embedded.other_processed_files.accession.raw",
+            "field" : "embedded.other_processed_files.files.accession.raw",
             "precision_threshold" : 10000
         }
     },
     "total_exp_other_processed_files" : {
         "cardinality" : {
-            "field" : "embedded.experiments_in_set.other_processed_files.accession.raw",
+            "field" : "embedded.experiments_in_set.other_processed_files.files.accession.raw",
             "precision_threshold" : 10000
         }
     },

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -287,7 +287,9 @@ def bar_plot_chart(context, request):
             "files": (
                 search_result['aggregations']['total_expset_processed_files']['value'] +
                 search_result['aggregations']['total_exp_raw_files']['value'] +
-                search_result['aggregations']['total_exp_processed_files']['value']
+                search_result['aggregations']['total_exp_processed_files']['value'] +
+                search_result['aggregations']['total_exp_other_processed_files']['value'] +
+                search_result['aggregations']['total_expset_other_processed_files']['value']
             )
         },
         "other_doc_count": search_result['aggregations']['field_0'].get('sum_other_doc_count', 0),

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -198,7 +198,7 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
             "script":{
 		        "source":"return [doc['embedded.experiments_in_set.files.accession.raw'], doc['embedded.processed_files.accession.raw'], doc['embedded.experiments_in_set.processed_files.accession.raw'], doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.other_processed_files.files.accession.raw']]"
 		    },
-            "precision_threshold" : 10000
+            "precision_threshold" : 40000
         }
     },
     "total_experiments" : {

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -177,20 +177,28 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
     "total_exp_expset_other_processed_files" : {
         "cardinality" : {
             "script":{
-		        "source":"return [doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.experiments_in_set.other_processed_files.files.accession.raw']]"
+		        "source":"return [doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.other_processed_files.files.accession.raw']]"
 		    },
             "precision_threshold" : 10000
         }
     },
+    # "total_files" : {
+    #     "bucket_script" : {
+    #         "buckets_path": {
+    #             "expSetProcessedFiles": "total_expset_processed_files",
+    #             "expProcessedFiles": "total_exp_processed_files",
+    #             "expExpSetOtherProcessedFiles": "total_exp_expset_other_processed_files",
+    #             "expRawFiles": "total_exp_raw_files"
+    #         },
+    #         "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expExpSetOtherProcessedFiles + params.expRawFiles"
+    #     }
+    # },
     "total_files" : {
-        "bucket_script" : {
-            "buckets_path": {
-                "expSetProcessedFiles": "total_expset_processed_files",
-                "expProcessedFiles": "total_exp_processed_files",
-                "expExpSetOtherProcessedFiles": "total_exp_expset_other_processed_files",
-                "expRawFiles": "total_exp_raw_files"
-            },
-            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expExpSetOtherProcessedFiles + params.expRawFiles"
+        "cardinality" : {
+            "script":{
+		        "source":"return [doc['embedded.experiments_in_set.files.accession.raw'], doc['embedded.processed_files.accession.raw'], doc['embedded.experiments_in_set.processed_files.accession.raw'], doc['embedded.experiments_in_set.other_processed_files.files.accession.raw'], doc['embedded.other_processed_files.files.accession.raw']]"
+		    },
+            "precision_threshold" : 10000
         }
     },
     "total_experiments" : {


### PR DESCRIPTION
Trello: https://trello.com/c/JngcASPz

- Changes `QuickInfoBar` experiment and file links from /browse to /search
- Experiments count link navigates to `/search/?type=Experiment&experiment_sets.experimentset_type=replicate&experiment_sets.@type=ExperimentSetReplicate`
- Files link navigates to ~~`/search/?type=File&experiments.experiment_sets.@type=ExperimentSetReplicate&experiments.experiment_sets.experimentset_type=replicate`~~ `/search/?type=File&track_and_facet_info.replicate_info!=No+value`
- available in [hotseat](http://fourfront-hotseat-1650461284.us-east-1.elb.amazonaws.com/)