### PR TITLE
Modified the ExperimentMic experiment categorizor calc prop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ fourfront
 Change Log
 ----------
 
+7.5.2
+=====
+
+`calcprop update  <https://github.com/4dn-dcic/fourfront/pull/1890>`_
+
+* Updated experiment_categorizer calcprop for ExperimentMic to deal with many targets in imaging paths
+
+
 7.5.1
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "7.5.1"
+version = "7.5.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Sequential FISH experiments frequently use many regions or features as targets.
Until now this has been dealt with by providing a general name to the target and including multiple regions.
However, a recent dataset has used specific enhancer regions that can be linked to genes and regions so BioFeature targets were created for them all.  However, while there are override properties in the ImagingPaths and BioFeatures that take care of most of the problematic display issues - the experiment_categorizer calcprop was an exception.

This update provides an aggregated generic value for use in this property when there are more than 5 features of a particular type listed as targets for all the paths of an experiment.

Unit tests were added to make sure it is behaving as expected.