### PR TITLE
Bug Fix - "Select All" button not turns into "Deselect All" in /browse

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ fourfront
 Change Log
 ----------
 
+7.5.5
+=====
+
+* bug fix - button "Select All" not turns into "Deselect All" in /browse after QuickInfoBar updates in 7.5.0
+
+
 7.5.4
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "7.5.4"
+version = "7.5.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesControls.js
+++ b/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesControls.js
@@ -140,7 +140,9 @@ export class SelectAllFilesButton extends React.PureComponent {
             "mr-05 icon icon-fw icon-" + (selecting ? 'circle-notch icon-spin fas' : (isAllSelected ? 'square far' : 'check-square far'))
         );
         const cls = "btn " + (isAllSelected ? "btn-outline-primary" : "btn-primary");
-        const tooltip = (!isAllSelected && !isEnabled) ? `"Select All" is disabled since the total file count exceeds the upper limit: ${SELECT_ALL_LIMIT}` : null;
+        const tooltip = (!isAllSelected && !isEnabled) ?
+            `"Select All" is disabled since the total file count exceeds the upper limit: ${SELECT_ALL_LIMIT}` :
+            (!isAllSelected ? 'Select all files (Please note that Supplementary files will not be included in the selection)' : null);
 
         return (
             <div className="pull-left box selection-buttons">

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -273,18 +273,20 @@ const StatsCol = React.memo(function StatsCol(props){
     const { total, current } = QuickInfoBar.getCountsFromProps(props);
     const expSetFilters = QuickInfoBar.expSetFilters((context && context.filters) || null, navigate.getBrowseBaseParams(browseBaseState));
 
+    const totalFilesIncludingOPF = (total.files || 0) + (total.files_opf || 0);
+    const currentFilesIncludingOPF = current ? (current.files || 0) + (current.files_opf || 0) : 0;
     let stats;
     if (current && (typeof current.experiment_sets === 'number' || typeof current.experiments === 'number' || typeof current.files === 'number')) {
         stats = {
             'experiment_sets'   : <span>{ current.experiment_sets }<small> / { total.experiment_sets || 0 }</small></span>,
             'experiments'       : <span>{ current.experiments }<small> / {total.experiments || 0}</small></span>,
-            'files'             : <span>{ current.files }<small> / {total.files || 0}</small></span>
+            'files'             : <span>{ currentFilesIncludingOPF }<small> / { totalFilesIncludingOPF }</small></span>
         };
     } else {
         stats = {
             'experiment_sets'   : total.experiment_sets || 0,
             'experiments'       : total.experiments || 0,
-            'files'             : total.files || 0
+            'files'             : totalFilesIncludingOPF
         };
     }
     const statProps = _.extend(_.pick(props, 'id', 'href', 'isLoadingChartData', 'browseBaseState'), { 'expSetFilters' : expSetFilters });
@@ -292,7 +294,7 @@ const StatsCol = React.memo(function StatsCol(props){
         <div className="col-8 left-side clearfix">
             <Stat {...statProps} shortLabel="Experiment Sets" longLabel="Experiment Sets" classNameID="expsets" value={stats.experiment_sets} key="expsets" />
             <Stat {...statProps} shortLabel="Experiments" longLabel="Experiments" classNameID="experiments" value={stats.experiments} key="experiments" />
-            <Stat {...statProps} shortLabel="Files" longLabel="Files in Experiments" classNameID="files" value={stats.files} key="files" />
+            <Stat {...statProps} shortLabel="Files" longLabel="Raw, Processed and Supplementary Files in Experiments" classNameID="files" value={stats.files} key="files" />
             <div className={"any-filters glance-label" + (show ? " showing" : "")} data-tip={anyFiltersSet ? "Filtered" : "No Filters Set"}
                 onMouseEnter={onIconMouseEnter}>
                 <i className="icon icon-filter fas" style={{ 'opacity' : anyFiltersSet ? 1 : 0.25 }} />

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -191,11 +191,18 @@ SUM_FILES_EXPS_AGGREGATION_DEFINITION = {
             "buckets_path": {
                 "expSetProcessedFiles": "total_expset_processed_files",
                 "expProcessedFiles": "total_exp_processed_files",
-                "expSetOtherProcessedFiles": "total_expset_other_processed_files",
-                "expOtherProcessedFiles": "total_exp_other_processed_files",
                 "expRawFiles": "total_exp_raw_files"
             },
-            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expSetOtherProcessedFiles + params.expOtherProcessedFiles + params.expRawFiles"
+            "script" : "params.expSetProcessedFiles + params.expProcessedFiles + params.expRawFiles"
+        }
+    },
+    "total_opf_files" : {
+        "bucket_script" : {
+            "buckets_path": {
+                "expSetOtherProcessedFiles": "total_expset_other_processed_files",
+                "expOtherProcessedFiles": "total_exp_other_processed_files",
+            },
+            "script" : "params.expSetOtherProcessedFiles + params.expOtherProcessedFiles"
         }
     },
     "total_experiments" : {
@@ -252,6 +259,7 @@ def bar_plot_chart(context, request):
 
     primary_agg.update(deepcopy(SUM_FILES_EXPS_AGGREGATION_DEFINITION))
     del primary_agg['total_files']  # "bucket_script" not supported on root-level aggs
+    del primary_agg['total_opf_files']  # "bucket_script" not supported on root-level aggs
 
     # Nest in additional fields, if any
     curr_field_aggs = primary_agg['field_0']['aggs']
@@ -278,19 +286,20 @@ def bar_plot_chart(context, request):
             continue
         del search_result[field_to_delete]
 
+    raw_and_processed_count = (search_result['aggregations']['total_expset_processed_files']['value'] + 
+                           search_result['aggregations']['total_exp_raw_files']['value'] + 
+                           search_result['aggregations']['total_exp_processed_files']['value'])
+    opf_count = (search_result['aggregations']['total_expset_other_processed_files']['value'] +
+                search_result['aggregations']['total_exp_other_processed_files']['value'])
+
     ret_result = {  # We will fill up the "terms" here from our search_result buckets and then return this dictionary.
         "field": fields_to_aggregate_for[0],
         "terms": {},
         "total": {
             "experiment_sets": search_result['total'],
             "experiments": search_result['aggregations']['total_experiments']['value'],
-            "files": (
-                search_result['aggregations']['total_expset_processed_files']['value'] +
-                search_result['aggregations']['total_exp_raw_files']['value'] +
-                search_result['aggregations']['total_exp_processed_files']['value'] +
-                search_result['aggregations']['total_expset_other_processed_files']['value'] +
-                search_result['aggregations']['total_exp_other_processed_files']['value']
-            )
+            "files": raw_and_processed_count,
+            "files_opf": opf_count
         },
         "other_doc_count": search_result['aggregations']['field_0'].get('sum_other_doc_count', 0),
         "time_generated": str(datetime.utcnow())
@@ -301,7 +310,8 @@ def bar_plot_chart(context, request):
         curr_bucket_totals = {
             'experiment_sets'   : int(bucket_result['doc_count']),
             'experiments'       : int(bucket_result['total_experiments']['value']),
-            'files'             : int(bucket_result['total_files']['value'])
+            'files'             : int(bucket_result['total_files']['value']),
+            'files_opf'         : int(bucket_result['total_opf_files']['value'])
         }
 
         next_field_name = None


### PR DESCRIPTION
Trello: https://trello.com/c/p409yflj

Since the count of other processed files is included in QuickInfoBar, the Select All button miscalculates the file count, making switching to Deselect All fail.

