### PR TITLE
Fix Cypress 03d Test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ fourfront
 Change Log
 ----------
 
+7.5.6
+=====
+
+`fix cypress 03d  <https://github.com/4dn-dcic/fourfront/pull/1893>`_
+
+* fixes cypress 03d's failing "Select All" step
+* adds OPF coun into Chart's files agg
+
+
 7.5.5
 =====
 

--- a/deploy/post_deploy_testing/cypress/e2e/03d_browse_views_files_selection.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03d_browse_views_files_selection.cy.js
@@ -102,7 +102,8 @@ describe('Browse Views - Files Selection', function () {
                 return cy.getDownloadButton().invoke('text').then((downloadButtonTextContent) => {
                     let foundNum = downloadButtonTextContent.match(/\d/g);
                     foundNum = parseInt(foundNum.join(''));
-                    expect(foundNum).to.equal(counts.files);
+                    expect(foundNum).to.equal(counts.files - counts.files_opf); // since "Select All" does not include OPFs, we subtract opf counts
+                    // expect(foundNum).to.equal(counts.files);
                 });
             });
         });

--- a/deploy/post_deploy_testing/cypress/support/commands.js
+++ b/deploy/post_deploy_testing/cypress/support/commands.js
@@ -203,7 +203,12 @@ Cypress.Commands.add('getQuickInfoBarCounts', function(options = { shouldNotEqua
                     const experiment_sets = parseInt(expsetCountElemText);
                     const experiments = parseInt(expCountElem.text());
                     const files = parseInt(fileCountElem.text());
-                    return { experiment_sets, experiments, files };
+                    const files_opf = parseInt(fileCountElem.attr('data-current_opf') || fileCountElem.attr('data-total_opf'));
+                    Cypress.log({
+                        'name' : "QuickInfoBar Counts",
+                        'message' : JSON.stringify({ experiment_sets, experiments, files, files_opf })
+                    });
+                    return { experiment_sets, experiments, files, files_opf };
                 });
             });
         });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "7.5.5"
+version = "7.5.6"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/viz/BarPlot/Chart.js
+++ b/src/encoded/static/components/viz/BarPlot/Chart.js
@@ -80,8 +80,10 @@ export function genChartBarDims(
                         'height'    : barHeight
                     },
                     'experiment_sets' : termObj.experiment_sets,
-                    'experiments' : termObj.experiments,
-                    'files'     : termObj.files
+                    'experiments'       : termObj.experiments,
+                    'files'             : termObj.files,
+                    'files_opf'         : termObj.files_opf,
+                    'files_all'         : termObj.files_all
                 };
                 if (typeof termObj.field === 'string') {
                     barNode.bars = genBarData(termObj, { 'height' : barHeight }, barNode);
@@ -246,7 +248,7 @@ export class Chart extends React.PureComponent {
         'width'         : PropTypes.number,
         'useOnlyPopulatedFields' : PropTypes.bool,
         'showType'      : PropTypes.oneOf(['all', 'filtered', 'both']),
-        'aggregateType' : PropTypes.oneOf(['experiment_sets', 'experiments', 'files']),
+        'aggregateType' : PropTypes.oneOf(['experiment_sets', 'experiments', 'files_all']),
         'windowWidth'   : PropTypes.number,
         'href'          : PropTypes.string,
         'cursorDetailActions' : PopoverViewContainer.propTypes.cursorDetailActions

--- a/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
+++ b/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
@@ -44,7 +44,7 @@ export class UIControlsWrapper extends React.PureComponent {
             // Aggr type
             'experiment_sets'   : "Experiment Sets",
             'experiments'       : 'Experiments',
-            'files'             : "Files",
+            'files_all'         : "Files",
 
             // Show state
             'all'               : 'All',
@@ -393,7 +393,7 @@ export class UIControlsWrapper extends React.PureComponent {
                                     onSelect={this.handleAggregateTypeSelect}
                                     title={this.titleMap(aggregateType)}
                                     onToggle={this.handleDropDownYAxisFieldToggle}>
-                                    { this.renderDropDownMenuItems(['experiment_sets','experiments','files'], aggregateType) }
+                                    { this.renderDropDownMenuItems(['experiment_sets','experiments','files_all'], aggregateType) }
                                 </DropdownButton>
                             </div>
                         </div>

--- a/src/encoded/static/components/viz/ChartDetailCursor/ChartDetailCursor.js
+++ b/src/encoded/static/components/viz/ChartDetailCursor/ChartDetailCursor.js
@@ -226,7 +226,7 @@ export default class ChartDetailCursor extends React.PureComponent {
             'experiments'         : d.experiments || 0,
             'experiments_active'  : d.active || 0,
             'experiment_sets'     : d.experiment_sets || 0,
-            'files'               : d.activeFiles || d.files || 0
+            'files'               : d.files_all || 0 //d.activeFiles || d.files || 0
         };
     }
 

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -274,8 +274,8 @@ const StatsCol = React.memo(function StatsCol(props){
     const expSetFilters = QuickInfoBar.expSetFilters((context && context.filters) || null, navigate.getBrowseBaseParams(browseBaseState));
 
     // file counts including OPF
-    const totalFiles = (total.files || 0) + (total.files_opf || 0);
-    const currentFiles = current ? (current.files || 0) + (current.files_opf || 0) : 0;
+    const totalFiles = total.files_all || 0;
+    const currentFiles = current ? (current.files_all || 0) : 0;
     // file counts (only OPF)
     const totalOtherProcessedFiles = (total.files_opf || 0);
     const currentOtherProcessedFiles = current && typeof current.files_opf === 'number' ? (current.files_opf || 0) : 0;

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -273,28 +273,35 @@ const StatsCol = React.memo(function StatsCol(props){
     const { total, current } = QuickInfoBar.getCountsFromProps(props);
     const expSetFilters = QuickInfoBar.expSetFilters((context && context.filters) || null, navigate.getBrowseBaseParams(browseBaseState));
 
-    const totalFilesIncludingOPF = (total.files || 0) + (total.files_opf || 0);
-    const currentFilesIncludingOPF = current ? (current.files || 0) + (current.files_opf || 0) : 0;
+    // file counts including OPF
+    const totalFiles = (total.files || 0) + (total.files_opf || 0);
+    const currentFiles = current ? (current.files || 0) + (current.files_opf || 0) : 0;
+    // file counts (only OPF)
+    const totalOPFFiles = (total.files_opf || 0);
+    const currentOPFFiles = current && typeof current.files_opf === 'number' ? (current.files_opf || 0) : 0;
+
     let stats;
     if (current && (typeof current.experiment_sets === 'number' || typeof current.experiments === 'number' || typeof current.files === 'number')) {
         stats = {
             'experiment_sets'   : <span>{ current.experiment_sets }<small> / { total.experiment_sets || 0 }</small></span>,
             'experiments'       : <span>{ current.experiments }<small> / {total.experiments || 0}</small></span>,
-            'files'             : <span>{ currentFilesIncludingOPF }<small> / { totalFilesIncludingOPF }</small></span>
+            'files'             : <span>{ currentFiles }<small> / { totalFiles }</small></span>
         };
     } else {
         stats = {
             'experiment_sets'   : total.experiment_sets || 0,
             'experiments'       : total.experiments || 0,
-            'files'             : totalFilesIncludingOPF
+            'files'             : totalFiles
         };
     }
+    // OPF extra stats are for Cypress 03d_browse_views_files_selection, we pass them as attributes like data-total_opf, data-current_opf
+    const files_extra = { 'total_opf': totalOPFFiles, 'current_opf': current && typeof current.files_opf === 'number' ? currentOPFFiles : null };
     const statProps = _.extend(_.pick(props, 'id', 'href', 'isLoadingChartData', 'browseBaseState'), { 'expSetFilters' : expSetFilters });
     return (
         <div className="col-8 left-side clearfix">
             <Stat {...statProps} shortLabel="Experiment Sets" longLabel="Experiment Sets" classNameID="expsets" value={stats.experiment_sets} key="expsets" />
             <Stat {...statProps} shortLabel="Experiments" longLabel="Experiments" classNameID="experiments" value={stats.experiments} key="experiments" />
-            <Stat {...statProps} shortLabel="Files" longLabel="Raw, Processed and Supplementary Files in Experiments" classNameID="files" value={stats.files} key="files" />
+            <Stat {...statProps} shortLabel="Files" longLabel="Raw, Processed and Supplementary Files in Experiments" classNameID="files" value={stats.files} extra={files_extra} key="files" />
             <div className={"any-filters glance-label" + (show ? " showing" : "")} data-tip={anyFiltersSet ? "Filtered" : "No Filters Set"}
                 onMouseEnter={onIconMouseEnter}>
                 <i className="icon icon-filter fas" style={{ 'opacity' : anyFiltersSet ? 1 : 0.25 }} />
@@ -380,11 +387,24 @@ class Stat extends React.PureComponent {
         );
     }
 
+    convertToDataAttributes(obj) {
+        const dataAttributes = {};
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key) && typeof obj[key] !== 'undefined' && obj[key] !== null) {
+                dataAttributes[`data-${key}`] = obj[key];
+            }
+        }
+        return dataAttributes;
+    }
+
     render(){
-        var { classNameID, longLabel, value, id, isLoadingChartData } = this.props;
+        var { classNameID, longLabel, value, id, isLoadingChartData, extra } = this.props;
+
+        const extraAttr = extra ? this.convertToDataAttributes(extra) : {};
+
         return (
             <div className={"stat stat-" + classNameID} title={longLabel}>
-                <div id={id + '-stat-' + classNameID} className={"stat-value" + (isLoadingChartData ? ' loading' : '')}>
+                <div id={id + '-stat-' + classNameID} className={"stat-value" + (isLoadingChartData ? ' loading' : '')} {...extraAttr}>
                     { isLoadingChartData ? <i className="icon icon-fw icon-spin icon-circle-notch fas" style={{ opacity : 0.25 }}/> : value }
                 </div>
                 <div className="stat-label">

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -280,19 +280,21 @@ const StatsCol = React.memo(function StatsCol(props){
     const totalOPFFiles = (total.files_opf || 0);
     const currentOPFFiles = current && typeof current.files_opf === 'number' ? (current.files_opf || 0) : 0;
 
-    let stats;
+    let stats, filesLongLabel;
     if (current && (typeof current.experiment_sets === 'number' || typeof current.experiments === 'number' || typeof current.files === 'number')) {
         stats = {
             'experiment_sets'   : <span>{ current.experiment_sets }<small> / { total.experiment_sets || 0 }</small></span>,
             'experiments'       : <span>{ current.experiments }<small> / {total.experiments || 0}</small></span>,
             'files'             : <span>{ currentFiles }<small> / { totalFiles }</small></span>
         };
+        filesLongLabel = `Raw + Processed Files: (${current.files || 0}/${total.files || 0}), Supplementary Files: (${currentOPFFiles}/${totalOPFFiles})`;
     } else {
         stats = {
             'experiment_sets'   : total.experiment_sets || 0,
             'experiments'       : total.experiments || 0,
             'files'             : totalFiles
         };
+        filesLongLabel = `Raw + Processed Files: ${total.files || 0}, Supplementary Files: ${totalOPFFiles}`;
     }
     // OPF extra stats are for Cypress 03d_browse_views_files_selection, we pass them as attributes like data-total_opf, data-current_opf
     const files_extra = { 'total_opf': totalOPFFiles, 'current_opf': current && typeof current.files_opf === 'number' ? currentOPFFiles : null };
@@ -301,7 +303,7 @@ const StatsCol = React.memo(function StatsCol(props){
         <div className="col-8 left-side clearfix">
             <Stat {...statProps} shortLabel="Experiment Sets" longLabel="Experiment Sets" classNameID="expsets" value={stats.experiment_sets} key="expsets" />
             <Stat {...statProps} shortLabel="Experiments" longLabel="Experiments" classNameID="experiments" value={stats.experiments} key="experiments" />
-            <Stat {...statProps} shortLabel="Files" longLabel="Raw, Processed and Supplementary Files in Experiments" classNameID="files" value={stats.files} extra={files_extra} key="files" />
+            <Stat {...statProps} shortLabel="Files" longLabel={filesLongLabel} classNameID="files" value={stats.files} extra={files_extra} key="files" />
             <div className={"any-filters glance-label" + (show ? " showing" : "")} data-tip={anyFiltersSet ? "Filtered" : "No Filters Set"}
                 onMouseEnter={onIconMouseEnter}>
                 <i className="icon icon-filter fas" style={{ 'opacity' : anyFiltersSet ? 1 : 0.25 }} />

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -277,8 +277,8 @@ const StatsCol = React.memo(function StatsCol(props){
     const totalFiles = (total.files || 0) + (total.files_opf || 0);
     const currentFiles = current ? (current.files || 0) + (current.files_opf || 0) : 0;
     // file counts (only OPF)
-    const totalOPFFiles = (total.files_opf || 0);
-    const currentOPFFiles = current && typeof current.files_opf === 'number' ? (current.files_opf || 0) : 0;
+    const totalOtherProcessedFiles = (total.files_opf || 0);
+    const currentOtherProcessedFiles = current && typeof current.files_opf === 'number' ? (current.files_opf || 0) : 0;
 
     let stats, filesLongLabel;
     if (current && (typeof current.experiment_sets === 'number' || typeof current.experiments === 'number' || typeof current.files === 'number')) {
@@ -287,17 +287,17 @@ const StatsCol = React.memo(function StatsCol(props){
             'experiments'       : <span>{ current.experiments }<small> / {total.experiments || 0}</small></span>,
             'files'             : <span>{ currentFiles }<small> / { totalFiles }</small></span>
         };
-        filesLongLabel = `Raw + Processed Files: (${current.files || 0}/${total.files || 0}), Supplementary Files: (${currentOPFFiles}/${totalOPFFiles})`;
+        filesLongLabel = `Raw + Processed Files: (${current.files || 0}/${total.files || 0}), Supplementary Files: (${currentOtherProcessedFiles}/${totalOtherProcessedFiles})`;
     } else {
         stats = {
             'experiment_sets'   : total.experiment_sets || 0,
             'experiments'       : total.experiments || 0,
             'files'             : totalFiles
         };
-        filesLongLabel = `Raw + Processed Files: ${total.files || 0}, Supplementary Files: ${totalOPFFiles}`;
+        filesLongLabel = `Raw + Processed Files: ${total.files || 0}, Supplementary Files: ${totalOtherProcessedFiles}`;
     }
     // OPF extra stats are for Cypress 03d_browse_views_files_selection, we pass them as attributes like data-total_opf, data-current_opf
-    const files_extra = { 'total_opf': totalOPFFiles, 'current_opf': current && typeof current.files_opf === 'number' ? currentOPFFiles : null };
+    const files_extra = { 'total_opf': totalOtherProcessedFiles, 'current_opf': current && typeof current.files_opf === 'number' ? currentOtherProcessedFiles : null };
     const statProps = _.extend(_.pick(props, 'id', 'href', 'isLoadingChartData', 'browseBaseState'), { 'expSetFilters' : expSetFilters });
     return (
         <div className="col-8 left-side clearfix">

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -299,7 +299,8 @@ def bar_plot_chart(context, request):
             "experiment_sets": search_result['total'],
             "experiments": search_result['aggregations']['total_experiments']['value'],
             "files": raw_and_processed_count,
-            "files_opf": opf_count
+            "files_opf": opf_count,
+            "files_all": raw_and_processed_count + opf_count
         },
         "other_doc_count": search_result['aggregations']['field_0'].get('sum_other_doc_count', 0),
         "time_generated": str(datetime.utcnow())
@@ -311,7 +312,8 @@ def bar_plot_chart(context, request):
             'experiment_sets'   : int(bucket_result['doc_count']),
             'experiments'       : int(bucket_result['total_experiments']['value']),
             'files'             : int(bucket_result['total_files']['value']),
-            'files_opf'         : int(bucket_result['total_opf_files']['value'])
+            'files_opf'         : int(bucket_result['total_opf_files']['value']),
+            'files_all'         : int(bucket_result['total_files']['value']) + int(bucket_result['total_opf_files']['value'])
         }
 
         next_field_name = None


### PR DESCRIPTION
- Currently, there is a known difference between QuicknfoBar's file count (raw + processed + of) and  the selected file count after the "Select All" button click (raw + processed). The 03d test was not taking into account this difference, fixed.
- Chart's files aggregation now includes OPF counts.