### PR TITLE
React 18, Redux and Misc. Npm Packages Upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,16 @@ Change Log
 8.0.0
 =====
 
-* React 18 Migration
+* Upgrade: React v17 to v18
+* Upgrade: Redux v4 to v5 (there are breaking changes in store and dispatchers. SPC is updated to support both new and legacy usage)
+* Upgrade: HiGlass (React 18-compatible)
+* Upgrade: Vitessce (React 18-compatible)
+* Upgrade: MicroMeta App
+* Upgrade: Auth0-Lock v11 to v12
+* Upgrade: Gulp.js v4 to v5
+* Upgrade: React-workflow-viz (animation updates to eliminate findDOMNode errors)
+* Bug Fix: User Content updates to fix markdown, jsx, and HTML static section rendering
+* Feature: Improve ExperimentSetDetailPane's raw/processed/supplementary file panels
 
 
 7.10.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,13 @@ Change Log
 * Upgrade: HiGlass (React 18-compatible)
 * Upgrade: Vitessce (React 18-compatible)
 * Upgrade: MicroMeta App
-* Upgrade: Auth0-Lock v11 to v12
-* Upgrade: Gulp.js v4 to v5
-* Upgrade: React-workflow-viz (animation updates to eliminate findDOMNode errors)
-* Bug Fix: User Content updates to fix markdown, jsx, and HTML static section rendering
+* Upgrade: auth0-Lock v11 to v12
+* Upgrade: gulp.js v4 to v5
+* Upgrade: react-workflow-viz (animation updates to eliminate findDOMNode errors)
+* Fix: User Content updates to fix markdown, jsx, and HTML static section rendering
 * Feature: Improve ExperimentSetDetailPane's raw/processed/supplementary file panels
+* Feature: Display react-workflow-viz version in /health
+* Upgrade: SlideCarousel and BasicCarousel updates upon nuka carousel's breaking changes
 
 
 7.10.1

--- a/deploy/post_deploy_testing/cypress/e2e/04a_search_views_local.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/04a_search_views_local.cy.js
@@ -17,7 +17,7 @@ describe('Deployment/CI Search View Tests', function () {
         });
     }
 
-    context.skip('/search/?type=Item', function () {
+    context('/search/?type=Item', function () {
 
         before(function(){ // beforeAll
             cy.visit('/search/');
@@ -33,7 +33,7 @@ describe('Deployment/CI Search View Tests', function () {
 
     });
 
-    context.skip('/search/?type=Page', function(){
+    context('/search/?type=Page', function(){
 
         before(function(){ // beforeAll
             cy.visit('/pages'); // We should get redirected to ?type=Page
@@ -64,7 +64,7 @@ describe('Deployment/CI Search View Tests', function () {
 
     });
 
-    context.skip('Publications, Files', function(){
+    context('Publications, Files', function(){
         // These are similarly implemently to the BrowseView, we should have specific tests for these
 
         it('/publications/ should redirect to /search/?type=Publication', function(){
@@ -101,7 +101,7 @@ describe('Deployment/CI Search View Tests', function () {
         });
     });
 
-    context.skip('Microscope Configurations Collections', function(){
+    context('Microscope Configurations Collections', function(){
 
         let microscopeDescription;
         const standType = "Inverted";

--- a/deploy/post_deploy_testing/cypress/support/e2e.js
+++ b/deploy/post_deploy_testing/cypress/support/e2e.js
@@ -19,3 +19,16 @@ import './commands';
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
+Cypress.on("uncaught:exception", (err) => {
+    // TODO: Investigate hydration errors occurring during SSR in Cypress tests.
+    // It appears that Cypress injects a prop into the div on the client side, which doesn't exist on the server side, leading to hydration issues.
+    // This suppression is temporary and should be removed once the issue is resolved.
+    // https://github.com/cypress-io/cypress/issues/27204
+    if (
+        /hydrat/i.test(err.message) ||
+        /Minified React error #418/.test(err.message) ||
+        /Minified React error #423/.test(err.message)
+    ) {
+        return false;
+    }
+});

--- a/docs/source/introduction2.rst
+++ b/docs/source/introduction2.rst
@@ -4,5 +4,5 @@ In our database:
 
 * The objects are stored in the `JavaScript Object Notation format <http://www.json.org/>`_.
 * The schemas for the different object types are described in `JSON-LD format <http://json-ld.org/>`_.
-* The json schemas can be found `here <https://github.com/hms-dbmi/fourfront/tree/master/src/encoded/schemas>`_.
-* A documentation of the metadata schema is also available as a google doc `here <https://docs.google.com/document/d/15tuYHENH_xOvtlvToFJZMzm5BgYFjjKJ0-vSP7ODOG0/edit?usp=sharing>`_.
+* The json schemas can be found `here <https://github.com/hms-dbmi/fourfront/tree/master/src/encoded/schemas>`__.
+* A documentation of the metadata schema is also available as a google doc `here <https://docs.google.com/document/d/15tuYHENH_xOvtlvToFJZMzm5BgYFjjKJ0-vSP7ODOG0/edit?usp=sharing>`__.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b5",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b6",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2645,8 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#8e5f4fdc17028c580ae4e5b766716fcc9503d81b",
-      "license": "MIT",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#559c16d15a63c94e449e93d078873ba55bc59fae",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",
         "@sentry/react": "^7.35.0",
@@ -7247,52 +7246,21 @@
       }
     },
     "node_modules/@turf/along/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/along/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/along/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/along/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/area": {
       "version": "6.5.0",
@@ -7307,12 +7275,13 @@
       }
     },
     "node_modules/@turf/bbox": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.0.0.tgz",
-      "integrity": "sha512-IyXG5HAsn6IZLdAtQo7aWYccjU5WsV+uzIzhGaXrh/qTVylSYmRiWgLdiekHZVED9nv9r7D/EJUMOT4zyA6POA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.1.0.tgz",
+      "integrity": "sha512-PdWPz9tW86PD78vSZj2fiRaB8JhUHy6piSa/QXb83lucxPK+HTAdzlDQMTKj5okRCU8Ox/25IR2ep9T8NdopRA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0",
-        "@turf/meta": "^7.0.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -7332,59 +7301,28 @@
       }
     },
     "node_modules/@turf/bbox-polygon/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/bbox-polygon/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/bbox-polygon/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/bbox-polygon/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/bbox/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -7392,59 +7330,30 @@
       }
     },
     "node_modules/@turf/bbox/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/bbox/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/bbox/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/bbox/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/bearing": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.0.0.tgz",
-      "integrity": "sha512-r6eBNqqiC8OtW+xIzu0ZyciAUfM85l2LVN2qpTeEyhnaNmnPw7hDsnqwZcbqoBFSLB66MO+BLH40X5OdaoRmmA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.1.0.tgz",
+      "integrity": "sha512-X5lackrZ6FW+YhgjWxwVFRgWD1j4xm4t5VvE6EE6v/1PVaHQ5OCjf6u1oaLx5LSG+gaHUhjTlAHrn9MYPFaeTA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0",
-        "@turf/invariant": "^7.0.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -7452,52 +7361,21 @@
       }
     },
     "node_modules/@turf/bearing/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/bearing/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/bearing/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/bearing/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/boolean-clockwise": {
       "version": "7.0.0",
@@ -7513,52 +7391,21 @@
       }
     },
     "node_modules/@turf/boolean-clockwise/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/boolean-clockwise/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/boolean-clockwise/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/boolean-clockwise/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/boolean-contains": {
       "version": "6.5.0",
@@ -7727,11 +7574,11 @@
       }
     },
     "node_modules/@turf/buffer/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -7739,15 +7586,21 @@
       }
     },
     "node_modules/@turf/buffer/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
+    },
+    "node_modules/@turf/buffer/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/buffer/node_modules/d3-array": {
       "version": "1.2.4",
@@ -7761,42 +7614,6 @@
       "dependencies": {
         "d3-array": "1"
       }
-    },
-    "node_modules/@turf/buffer/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/buffer/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/@turf/center": {
       "version": "7.0.0",
@@ -7812,52 +7629,21 @@
       }
     },
     "node_modules/@turf/center/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/center/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/center/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/center/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/centroid": {
       "version": "6.5.0",
@@ -7885,52 +7671,21 @@
       }
     },
     "node_modules/@turf/circle/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/circle/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/circle/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/circle/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/clone": {
       "version": "7.0.0",
@@ -7945,60 +7700,30 @@
       }
     },
     "node_modules/@turf/clone/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/clone/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/clone/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/clone/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/destination": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.0.0.tgz",
-      "integrity": "sha512-wXfLd37ul7xuFvv4L7dtNQOZnmYepnrsMZrxbmxvy2SCnF+Rzf1C7D1NQ6+Nx5SInB/SbTfi6SCDgyfB8MOawQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.1.0.tgz",
+      "integrity": "sha512-97XuvB0iaAiMg86hrnZ529WwP44TQAA9mmI5PMlchACiA4LFrEtWjjDzvO6234coieoqhrw6dZYcJvd5O2PwrQ==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0",
-        "@turf/invariant": "^7.0.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8006,52 +7731,21 @@
       }
     },
     "node_modules/@turf/destination/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/destination/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/destination/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/destination/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/difference": {
       "version": "7.0.0",
@@ -8068,11 +7762,11 @@
       }
     },
     "node_modules/@turf/difference/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8080,59 +7774,30 @@
       }
     },
     "node_modules/@turf/difference/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/difference/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/difference/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/difference/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/distance": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.0.0.tgz",
-      "integrity": "sha512-DBPKhHABpPZ0KRduRpEaoi8MB6r1DVuyyps68VFH2Qi5H0ZnFtJFj7nQxBPZR3bVpbUq4zzu7I+MiNAd3ujFWQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.1.0.tgz",
+      "integrity": "sha512-hhNHhxCHB3ddzAGCNY4BtE29OZh+DAJPvUapQz+wOjISnlwvMcwLKvslgHWSYF536QDVe/93FEU2q67+CsZTPA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0",
-        "@turf/invariant": "^7.0.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/invariant": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8140,52 +7805,21 @@
       }
     },
     "node_modules/@turf/distance/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/distance/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/distance/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/distance/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/ellipse": {
       "version": "7.0.0",
@@ -8203,52 +7837,21 @@
       }
     },
     "node_modules/@turf/ellipse/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/ellipse/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/ellipse/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/ellipse/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/helpers": {
       "version": "6.5.0",
@@ -8273,11 +7876,11 @@
       }
     },
     "node_modules/@turf/intersect/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8285,58 +7888,29 @@
       }
     },
     "node_modules/@turf/intersect/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/intersect/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/intersect/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/intersect/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/invariant": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.0.0.tgz",
-      "integrity": "sha512-Kayszfz3W8yJ1/cIA3/aNSzAuw7QgSp+IwsSmhLAfp4DbjV0o6sjxRZXRY2gRstZHqkNHSSEeir8V/icdO8sjA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.1.0.tgz",
+      "integrity": "sha512-OCLNqkItBYIP1nE9lJGuIUatWGtQ4rhBKAyTfFu0z8npVzGEYzvguEeof8/6LkKmTTEHW53tCjoEhSSzdRh08Q==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0",
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8344,52 +7918,21 @@
       }
     },
     "node_modules/@turf/invariant/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/invariant/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/invariant/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/invariant/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/jsts": {
       "version": "2.7.1",
@@ -8573,11 +8116,11 @@
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8585,51 +8128,21 @@
       }
     },
     "node_modules/@turf/point-to-line-distance/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/point-to-line-distance/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/point-to-line-distance/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/point-to-line-distance/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/polygon-to-line": {
       "version": "7.0.0",
@@ -8645,52 +8158,21 @@
       }
     },
     "node_modules/@turf/polygon-to-line/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/polygon-to-line/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/polygon-to-line/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/polygon-to-line/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/projection": {
       "version": "7.0.0",
@@ -8707,11 +8189,11 @@
       }
     },
     "node_modules/@turf/projection/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8719,51 +8201,21 @@
       }
     },
     "node_modules/@turf/projection/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/projection/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/projection/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/projection/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/rewind": {
       "version": "7.0.0",
@@ -8782,11 +8234,11 @@
       }
     },
     "node_modules/@turf/rewind/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -8794,51 +8246,21 @@
       }
     },
     "node_modules/@turf/rewind/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/rewind/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/rewind/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/rewind/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/rhumb-bearing": {
       "version": "7.0.0",
@@ -8854,52 +8276,21 @@
       }
     },
     "node_modules/@turf/rhumb-bearing/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/rhumb-bearing/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/rhumb-bearing/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/rhumb-bearing/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/rhumb-destination": {
       "version": "7.0.0",
@@ -8915,52 +8306,21 @@
       }
     },
     "node_modules/@turf/rhumb-destination/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/rhumb-destination/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/rhumb-destination/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/rhumb-destination/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/rhumb-distance": {
       "version": "7.0.0",
@@ -8976,52 +8336,21 @@
       }
     },
     "node_modules/@turf/rhumb-distance/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/rhumb-distance/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/rhumb-distance/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/rhumb-distance/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/transform-rotate": {
       "version": "7.0.0",
@@ -9042,12 +8371,13 @@
       }
     },
     "node_modules/@turf/transform-rotate/node_modules/@turf/centroid": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.0.0.tgz",
-      "integrity": "sha512-TMKp5yadglNVRxX3xuk1qQDEy5JFHmlYVBamzXuD8DL8rYdVog2x4gQHrwn7xrUyAlKJ4fUZZPkYBWfW6TDWbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.1.0.tgz",
+      "integrity": "sha512-1Y1b2l+ZB1CZ+ITjUCsGqC4/tSjwm/R4OUfDztVqyyCq/VvezkLmTNqvXTGXgfP0GXkpv68iCfxF5M7QdM5pJQ==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0",
-        "@turf/meta": "^7.0.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -9055,11 +8385,11 @@
       }
     },
     "node_modules/@turf/transform-rotate/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -9067,51 +8397,21 @@
       }
     },
     "node_modules/@turf/transform-rotate/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/transform-rotate/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/transform-rotate/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/transform-rotate/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/transform-scale": {
       "version": "7.0.0",
@@ -9134,12 +8434,13 @@
       }
     },
     "node_modules/@turf/transform-scale/node_modules/@turf/centroid": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.0.0.tgz",
-      "integrity": "sha512-TMKp5yadglNVRxX3xuk1qQDEy5JFHmlYVBamzXuD8DL8rYdVog2x4gQHrwn7xrUyAlKJ4fUZZPkYBWfW6TDWbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.1.0.tgz",
+      "integrity": "sha512-1Y1b2l+ZB1CZ+ITjUCsGqC4/tSjwm/R4OUfDztVqyyCq/VvezkLmTNqvXTGXgfP0GXkpv68iCfxF5M7QdM5pJQ==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0",
-        "@turf/meta": "^7.0.0",
+        "@turf/helpers": "^7.1.0",
+        "@turf/meta": "^7.1.0",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -9147,11 +8448,11 @@
       }
     },
     "node_modules/@turf/transform-scale/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -9159,51 +8460,21 @@
       }
     },
     "node_modules/@turf/transform-scale/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/transform-scale/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/transform-scale/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/transform-scale/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/transform-translate": {
       "version": "7.0.0",
@@ -9221,11 +8492,11 @@
       }
     },
     "node_modules/@turf/transform-translate/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -9233,51 +8504,21 @@
       }
     },
     "node_modules/@turf/transform-translate/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/transform-translate/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/transform-translate/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/transform-translate/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@turf/union": {
       "version": "7.0.0",
@@ -9294,11 +8535,11 @@
       }
     },
     "node_modules/@turf/union/node_modules/@turf/helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.0.0.tgz",
-      "integrity": "sha512-vwZvxRuyjGpGXvhXSbT9mX6FK92dBMLWbMbDJ/MXQUPx17ReVPFc+6N6IcxAzZfkiCnqy7vpuq0c+/TTrQxIiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.1.0.tgz",
+      "integrity": "sha512-dTeILEUVeNbaEeoZUOhxH5auv7WWlOShbx7QSd4s0T4Z0/iz90z9yaVCtZOLbU89umKotwKaJQltBNO9CzVgaQ==",
       "dependencies": {
-        "deep-equal": "^2.2.3",
+        "@types/geojson": "^7946.0.10",
         "tslib": "^2.6.2"
       },
       "funding": {
@@ -9306,51 +8547,21 @@
       }
     },
     "node_modules/@turf/union/node_modules/@turf/meta": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.0.0.tgz",
-      "integrity": "sha512-cEXr13uFwhXq5mFBy0IK1U/QepE5qgk3zXpBYsla3lYV7cB83Vh+NNUR+r0/w/QoJqest1TG4H20F9tGYWPi/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.1.0.tgz",
+      "integrity": "sha512-ZgGpWWiKz797Fe8lfRj7HKCkGR+nSJ/5aKXMyofCvLSc2PuYJs/qyyifDPWjASQQCzseJ7AlF2Pc/XQ/3XkkuA==",
       "dependencies": {
-        "@turf/helpers": "^7.0.0"
+        "@turf/helpers": "^7.1.0",
+        "@types/geojson": "^7946.0.10"
       },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
     },
-    "node_modules/@turf/union/node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@turf/union/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    "node_modules/@turf/union/node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
@@ -20195,30 +19406,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-    },
     "node_modules/es-iterator-helpers": {
       "version": "1.0.18",
       "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.18.tgz",
@@ -23752,6 +22939,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -23878,6 +23066,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -24002,6 +23191,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -24024,6 +23214,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
       "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4"
@@ -33255,17 +32446,6 @@
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw=="
     },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dependencies": {
-        "internal-slot": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -36349,6 +35529,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "jose": "^4.14.4",
         "markdown-to-jsx": "^7.1.6",
         "memoize-one": "^5.1.1",
-        "micro-meta-app-react": "git+https://github.com/WU-BIMAC/MicroMetaApp-React#1.7.28-b1-rc1",
+        "micro-meta-app-react": "git+https://github.com/WU-BIMAC/MicroMetaApp-React#1.7.28-b1",
         "nuka-carousel": "^8.0.1",
         "pixi.js": "^6.5.10",
         "prop-types": "^15.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
-        "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b7",
+        "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b8",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2628,9 +2628,9 @@
       }
     },
     "node_modules/@hms-dbmi-bgm/react-workflow-viz": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi-bgm/react-workflow-viz/-/react-workflow-viz-0.1.7.tgz",
-      "integrity": "sha512-DQnL+lU4JIsBDTQoPztSC65LqGo6Xu3KYwNbrhDCeSiGdE9PokgZqcrhWZfJbD0sDCLgMmvtw29sdHPipkGmrQ==",
+      "version": "0.1.11-beta.0",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi-bgm/react-workflow-viz/-/react-workflow-viz-0.1.11-beta.0.tgz",
+      "integrity": "sha512-gvU717UrWIFydCqAZLWGJIaJsystj42vPboS+dqukrylry9CY5AmRyph6PUycBebGUkaL3mZ6UVE/4+jUUOhsQ==",
       "dependencies": {
         "memoize-one": "^5.1.1",
         "underscore": "^1.13.2"
@@ -2645,7 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#dcb19b2953069bfbf979d4ba5d1e00e092137eca",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#faa64b9464818c7e91f7402de85d25669419d487",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "react-dom": "^18.3.1",
         "react-draggable": "^4.4.4",
         "react-json-tree": "^0.19.0",
-        "react-jsx-parser": "^1.25.1",
+        "react-jsx-parser": "^2.0.0",
         "react-redux": "^9.1.2",
         "react-tooltip": "^4.2.21",
         "react-transition-group": "^4.4.2",
@@ -9493,16 +9493,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/jsdom": {
-      "version": "16.2.15",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.15.tgz",
-      "integrity": "sha512-nwF87yjBKuX/roqGYerZZM0Nv1pZDMAT5YhOHYeM/72Fic+VEqJh4nyoqoapzJnW3pUlfxPY5FhgsJtM+dRnQQ==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/parse5": "^6.0.3",
-        "@types/tough-cookie": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -9542,11 +9532,6 @@
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
     },
-    "node_modules/@types/parse5": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
-    },
     "node_modules/@types/prettier": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
@@ -9568,23 +9553,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
-      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "optional": true,
       "dependencies": {
-        "@types/react": "^17"
-      }
-    },
-    "node_modules/@types/react-dom/node_modules/@types/react": {
-      "version": "17.0.80",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-      "integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
-      "optional": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
-        "csstype": "^3.0.2"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-reconciler": {
@@ -9647,11 +9621,6 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~0.18.1"
       }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -17629,9 +17598,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "funding": [
         {
           "type": "opencollective",
@@ -17647,10 +17616,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -17837,9 +17806,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001610",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz",
-      "integrity": "sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==",
+      "version": "1.0.30001649",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
+      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -19977,9 +19946,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.737",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.737.tgz",
-      "integrity": "sha512-QvLTxaLHKdy5YxvixAw/FfHq2eWLUL9KvsPjp0aHK1gI5d3EDuDgITkvj0nFO2c6zUY3ZqVAJQiBYyQP9tQpfw=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz",
+      "integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA=="
     },
     "node_modules/element-resize-event": {
       "version": "2.0.9",
@@ -29604,9 +29573,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -30300,9 +30269,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -31561,35 +31530,23 @@
       }
     },
     "node_modules/react-jsx-parser": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/react-jsx-parser/-/react-jsx-parser-1.29.0.tgz",
-      "integrity": "sha512-u0svZd0UsPffRrIK0sTbox54jhEbTmg6ED9ob5FQahp1DeOpd2Rq+KiSTIFNYkZUL+WZi4Ntia/Oj5T4lDJafQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-jsx-parser/-/react-jsx-parser-2.0.0.tgz",
+      "integrity": "sha512-1siP+vM47gWE+x2VTF0ano5jJPRilOf7sRIoy4dzb1FmNoDpwe3htuzgcEfvzsc7YThzwmMQNUfy4vAv1ATs2g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@types/jsdom": "^16.2.6",
-        "acorn": "^8.0.5",
-        "acorn-jsx": "^5.3.1",
-        "browserslist": "^4.14.5",
-        "core-js": "^3.8.3"
+        "acorn": "^8.12.1",
+        "acorn-jsx": "^5.3.2",
+        "browserslist": "^4.23.1",
+        "core-js": "^3.37.1"
       },
       "optionalDependencies": {
-        "@types/react": "^17.0.1",
-        "@types/react-dom": "^17.0.0"
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0"
       },
       "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17"
-      }
-    },
-    "node_modules/react-jsx-parser/node_modules/@types/react": {
-      "version": "17.0.80",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-      "integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
-      "optional": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
-        "csstype": "^3.0.2"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-jsx-parser/node_modules/core-js": {
@@ -34704,9 +34661,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -34722,8 +34679,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b3",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b4",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2645,7 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#872dfd1dffee90e77f5bb0c81183491e81571a09",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#b24c2f160227d0225cc5c269d8d5c17c4d54741c",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b6",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b7",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2645,7 +2645,8 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#559c16d15a63c94e449e93d078873ba55bc59fae",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#dcb19b2953069bfbf979d4ba5d1e00e092137eca",
+      "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",
         "@sentry/react": "^7.35.0",
@@ -19167,9 +19168,9 @@
       "integrity": "sha512-xiv2qfGeuMfXjxcAd0if4tR7xiqEH4dXkGFAfF7O4nC960JteYrJlbO00PWX1r9J2rxtqs0TdfXe/dH9J8kEZQ=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -28823,9 +28824,9 @@
       }
     },
     "node_modules/numcodecs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.1.tgz",
-      "integrity": "sha512-ywIyGpJ+c6Ojktq9a8jsWSy12ZSUcW/W+I3jlH0q0zv9aR/ZiMsN7IrWaNq9YV2FRdLu6r/M6lp35jMA6fug/A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
       "dependencies": {
         "fflate": "^0.8.0"
       }
@@ -32903,9 +32904,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.5",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
-      "integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
+      "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -33393,11 +33394,11 @@
       }
     },
     "node_modules/tunnel-rat/node_modules/zustand": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
-      "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
       "dependencies": {
-        "use-sync-external-store": "1.2.0"
+        "use-sync-external-store": "1.2.2"
       },
       "engines": {
         "node": ">=12.7.0"
@@ -33968,9 +33969,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -34988,9 +34989,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
-      "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b8",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b9",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2645,7 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#faa64b9464818c7e91f7402de85d25669419d487",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#4f9ecb14bb75a42d1ad29ca9660d54912d4c344a",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",
@@ -2661,7 +2661,7 @@
         "jsdom": "^19.0.0",
         "jsonwebtoken": ">=7.4.0",
         "react-draggable": ">=4.4.5",
-        "react-json-tree": "^0.17.0"
+        "react-json-tree": "^0.19.0"
       },
       "peerDependencies": {
         "auth0-lock": ">=11.26.3",
@@ -8756,9 +8756,9 @@
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.4",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
+      "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -30316,9 +30316,9 @@
       }
     },
     "node_modules/react-app-polyfill/node_modules/core-js": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
-      "integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug==",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -30742,9 +30742,9 @@
       }
     },
     "node_modules/react-jsx-parser/node_modules/core-js": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
-      "integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug==",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
-        "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b10",
+        "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2628,9 +2628,9 @@
       }
     },
     "node_modules/@hms-dbmi-bgm/react-workflow-viz": {
-      "version": "0.1.11-beta.0",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi-bgm/react-workflow-viz/-/react-workflow-viz-0.1.11-beta.0.tgz",
-      "integrity": "sha512-gvU717UrWIFydCqAZLWGJIaJsystj42vPboS+dqukrylry9CY5AmRyph6PUycBebGUkaL3mZ6UVE/4+jUUOhsQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi-bgm/react-workflow-viz/-/react-workflow-viz-0.1.11.tgz",
+      "integrity": "sha512-T1nzLAPMXEZAxSkWnKfs9mJfE2lSkG/klyXuDg4XznYZkwJnrAW2FSUFT2RB1kLWTIk2uYdczB7LM7Dn4u0now==",
       "dependencies": {
         "memoize-one": "^5.1.1",
         "underscore": "^1.13.2"
@@ -2645,7 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#fc6e50d01e3577b02a568557d4a747644a4f5d14",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#fd0221c53416ecd64acf1a1dc2e36f11941de7a9",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",
@@ -28132,9 +28132,9 @@
       "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -28624,12 +28624,12 @@
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
-      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
+      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33723,9 +33723,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.4.tgz",
-      "integrity": "sha512-3OU03GgblDgu0g+sdnsVzhBPxnjV+WJuMmocN1qBBZDQ3ia7jZQSAkePeKbPlYAejGXUTYe1CmSaUeV51mvaIw==",
+      "version": "5.31.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
+      "integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b2",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b3",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2645,7 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#f13f6d3574eb5101e5d2a4ffbb1f8c1a63c81f4d",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#872dfd1dffee90e77f5bb0c81183491e81571a09",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",
@@ -33723,9 +33723,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
-      "integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
+      "version": "5.31.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.4.tgz",
+      "integrity": "sha512-3OU03GgblDgu0g+sdnsVzhBPxnjV+WJuMmocN1qBBZDQ3ia7jZQSAkePeKbPlYAejGXUTYe1CmSaUeV51mvaIw==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b9",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b10",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2645,7 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#4f9ecb14bb75a42d1ad29ca9660d54912d4c344a",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#fc6e50d01e3577b02a568557d4a747644a4f5d14",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b4",
+        "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b5",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.5.0",
@@ -2645,7 +2645,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.89",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#b24c2f160227d0225cc5c269d8d5c17c4d54741c",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#8e5f4fdc17028c580ae4e5b766716fcc9503d81b",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b5",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b6",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b9",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b10",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "jose": "^4.14.4",
     "markdown-to-jsx": "^7.1.6",
     "memoize-one": "^5.1.1",
-    "micro-meta-app-react": "git+https://github.com/WU-BIMAC/MicroMetaApp-React#1.7.28-b1-rc1",
+    "micro-meta-app-react": "git+https://github.com/WU-BIMAC/MicroMetaApp-React#1.7.28-b1",
     "nuka-carousel": "^8.0.1",
     "pixi.js": "^6.5.10",
     "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b4",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b5",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b3",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b4",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b8",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b9",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "react-dom": "^18.3.1",
     "react-draggable": "^4.4.4",
     "react-json-tree": "^0.19.0",
-    "react-jsx-parser": "^1.25.1",
+    "react-jsx-parser": "^2.0.0",
     "react-redux": "^9.1.2",
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b2",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b3",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",
@@ -146,5 +146,10 @@
   },
   "optionalDependencies": {
     "cypress": "^13.7.0"
+  },
+  "overrides": {
+    "@hms-dbmi-bgm/shared-portal-components": {
+      "auth0-lock": "$auth0-lock"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b6",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b7",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
-    "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b10",
+    "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
-    "@hms-dbmi-bgm/react-workflow-viz": "0.1.7",
-    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b7",
+    "@hms-dbmi-bgm/react-workflow-viz": "0.1.11-beta.0",
+    "@hms-dbmi-bgm/shared-portal-components": "git+https://github.com/4dn-dcic/shared-portal-components#0.1.89b8",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.5.0",

--- a/src/encoded/static/browser.js
+++ b/src/encoded/static/browser.js
@@ -7,7 +7,7 @@ import ReactDOM from 'react-dom/client';
 
 import App from './components';
 var domready = require('domready');
-import { store, mapStateToProps } from './store';
+import { store, mapStateToProps, batchDispatch } from './store';
 import { Provider, connect } from 'react-redux';
 import { patchedConsoleInstance as console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util/patched-console';
 import { logger }  from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
@@ -67,18 +67,7 @@ if (typeof window !== 'undefined' && window.document && !window.TEST_RUNNER) {
         var initialReduxStoreState = App.getRenderedProps(document);
         delete initialReduxStoreState.user_details; // Stored into localStorage.
 
-        if (initialReduxStoreState.context) {
-            store.dispatch({ type: 'SET_CONTEXT', payload: initialReduxStoreState.context });
-        }
-        if (initialReduxStoreState.href) {
-            store.dispatch({ type: 'SET_HREF', payload: initialReduxStoreState.href });
-        }
-        if (initialReduxStoreState.lastCSSBuildTime) {
-            store.dispatch({ type: 'SET_LAST_CSS_BUILD_TIME', payload: initialReduxStoreState.lastCSSBuildTime });
-        }
-        if (initialReduxStoreState.alerts) {
-            store.dispatch({ type: 'SET_ALERTS', payload: initialReduxStoreState.alerts });
-        }
+        batchDispatch(store, initialReduxStoreState);
 
         const AppWithReduxProps = connect(mapStateToProps)(App);
         let app;

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -1200,7 +1200,7 @@ export default class App extends React.PureComponent {
             "img-src 'self' https://* data: www.google-analytics.com",
             "child-src blob:",
             "frame-src www.google.com/recaptcha/",
-            "script-src 'self' www.google-analytics.com www.googletagmanager.com https://cdn.auth0.com https://hms-dbmi.auth0.com https://secure.gravatar.com  https://www.gstatic.com/recaptcha/ https://www.google.com/recaptcha/ 'unsafe-eval'", // + (typeof BUILDTYPE === "string" && BUILDTYPE === "quick" ? " 'unsafe-eval'" : ""),
+            "script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://cdn.auth0.com https://hms-dbmi.auth0.com https://secure.gravatar.com  https://www.gstatic.com/recaptcha/ https://www.google.com/recaptcha/ 'unsafe-eval'", // + (typeof BUILDTYPE === "string" && BUILDTYPE === "quick" ? " 'unsafe-eval'" : ""),
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com  https://unpkg.com https://www.googletagmanager.com",
             "font-src 'self' https://fonts.gstatic.com",
             "worker-src 'self' blob:",

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -1784,7 +1784,7 @@ class BodyElement extends React.PureComponent {
 
         return (
             <body data-current-action={currentAction} onClick={onBodyClick} onSubmit={onBodySubmit} data-path={hrefParts.path}
-                data-pathname={hrefParts.pathname} className={this.bodyClassName()}>
+                data-pathname={hrefParts.pathname} className={this.bodyClassName()} suppressHydrationWarning={true}>
 
                 <script data-prop-name="lastCSSBuildTime" type="application/json" dangerouslySetInnerHTML={{ __html: lastCSSBuildTime }}/>
 

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -13,7 +13,7 @@ import { content_views as globalContentViews, portalConfig, getGoogleAnalyticsTr
 import ErrorPage from './static-pages/ErrorPage';
 import { NavigationBar } from './navigation/NavigationBar';
 import { Footer } from './Footer';
-import { store } from './../store';
+import { store, batchDispatch } from './../store';
 // import { NotLoggedInAlert } from './navigation/components/LoginNavItem';
 
 import { Alerts } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts';
@@ -652,15 +652,12 @@ export default class App extends React.PureComponent {
                 this.currentNavigationRequest.abort();
                 this.currentNavigationRequest = null;
             }
-            // store.dispatch({
-            //     type: {
-            //         'href' : windowHref,
-            //         'context' : event.state
-            //     }
-            // });
 
-            store.dispatch({ type: 'SET_HREF', payload: windowHref });
-            store.dispatch({ type: 'SET_CONTEXT', payload: event.state });
+            const dispatchDict = {
+                href: windowHref,
+                context: event.state
+            };
+            batchDispatch(store, dispatchDict);
         }
 
         // Always async update in case of server side changes.
@@ -880,20 +877,8 @@ export default class App extends React.PureComponent {
                 if (!options.skipUpdateHref) {
                     reduxDispatchDict.href = targetHref + hashAppendage;
                 }
-                if (_.keys(reduxDispatchDict).length > 0){
-                    // store.dispatch({ 'type' : reduxDispatchDict });
-                    if (reduxDispatchDict.context) {
-                        store.dispatch({ type: 'SET_CONTEXT', payload: reduxDispatchDict.context });
-                    }
-                    if (reduxDispatchDict.href) {
-                        store.dispatch({ type: 'SET_HREF', payload: reduxDispatchDict.href });
-                    }
-                    if (reduxDispatchDict.lastCSSBuildTime) {
-                        store.dispatch({ type: 'SET_LAST_CSS_BUILD_TIME', payload: reduxDispatchDict.lastCSSBuildTime });
-                    }
-                    if (reduxDispatchDict.alerts) {
-                        store.dispatch({ type: 'SET_ALERTS', payload: reduxDispatchDict.alerts });
-                    }
+                if (_.keys(reduxDispatchDict).length > 0) {
+                    batchDispatch(store, reduxDispatchDict);
                 }
                 return false;
             }
@@ -961,20 +946,8 @@ export default class App extends React.PureComponent {
                     }
 
                     reduxDispatchDict.context = response;
-                    // store.dispatch({ 'type' : _.extend({}, reduxDispatchDict, includeReduxDispatch) });
                     const payloadReduxDispatchDict = _.extend({}, reduxDispatchDict, includeReduxDispatch);
-                    if (payloadReduxDispatchDict.context) {
-                        store.dispatch({ type: 'SET_CONTEXT', payload: payloadReduxDispatchDict.context });
-                    }
-                    if (payloadReduxDispatchDict.href) {
-                        store.dispatch({ type: 'SET_HREF', payload: payloadReduxDispatchDict.href });
-                    }
-                    if (payloadReduxDispatchDict.lastCSSBuildTime) {
-                        store.dispatch({ type: 'SET_LAST_CSS_BUILD_TIME', payload: payloadReduxDispatchDict.lastCSSBuildTime });
-                    }
-                    if (payloadReduxDispatchDict.alerts) {
-                        store.dispatch({ type: 'SET_ALERTS', payload: payloadReduxDispatchDict.alerts });
-                    }
+                    batchDispatch(store, payloadReduxDispatchDict);
                     return response;
                 })
                 .then((response) => { // Finalize - clean up `slowLoad : true` if in state, run callbacks and analytics.

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -1197,11 +1197,11 @@ export default class App extends React.PureComponent {
         // www.google-analytics.com without http(s) makes it available in either data or staging/hotseat ...
         const contentSecurityPolicyStr = [
             "default-src 'self'",
-            "img-src 'self' https://* data: www.google-analytics.com abs.twimg.com https://pbs.twimg.com ton.twimg.com platform.twitter.com https://syndication.twitter.com",
+            "img-src 'self' https://* data: www.google-analytics.com",
             "child-src blob:",
-            "frame-src https://twitter.com platform.twitter.com syndication.twitter.com www.google.com/recaptcha/",
-            "script-src 'self' www.google-analytics.com www.googletagmanager.com https://cdn.auth0.com https://hms-dbmi.auth0.com https://secure.gravatar.com https://cdn.syndication.twimg.com platform.twitter.com https://www.gstatic.com/recaptcha/ https://www.google.com/recaptcha/ 'unsafe-eval'", // + (typeof BUILDTYPE === "string" && BUILDTYPE === "quick" ? " 'unsafe-eval'" : ""),
-            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com  https://unpkg.com https://ton.twimg.com platform.twitter.com https://www.googletagmanager.com",
+            "frame-src www.google.com/recaptcha/",
+            "script-src 'self' www.google-analytics.com www.googletagmanager.com https://cdn.auth0.com https://hms-dbmi.auth0.com https://secure.gravatar.com  https://www.gstatic.com/recaptcha/ https://www.google.com/recaptcha/ 'unsafe-eval'", // + (typeof BUILDTYPE === "string" && BUILDTYPE === "quick" ? " 'unsafe-eval'" : ""),
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com  https://unpkg.com https://www.googletagmanager.com",
             "font-src 'self' https://fonts.gstatic.com",
             "worker-src 'self' blob:",
             "connect-src 'self' * blob: https://raw.githubusercontent.com https://higlass.4dnucleome.org https://*.s3.amazonaws.com https://s3.amazonaws.com/4dn-dcic-public/ https://www.encodeproject.org https://rest.ensembl.org https://www.google-analytics.com https://www.googletagmanager.com https://o427308.ingest.sentry.io https://www.gstatic.com/recaptcha/ https://www.google.com/recaptcha/ 'unsafe-inline' 'unsafe-eval'"

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -305,7 +305,7 @@ const NoResultsView = React.memo(function NoResultsView({ context, href, browseB
 function BrowseTableWithSelectedFilesCheckboxes(props){
     const {
         // Common high-level props from Redux, or App.js, or App.js > BodyElement:
-        context, href, browseBaseState, schemas, navigate: propNavigate,
+        context, href, browseBaseState, schemas, navigate: propNavigate = globalNavigate,
         windowHeight, windowWidth, registerWindowOnScrollHandler,
         toggleFullScreen, isFullscreen, session,
 
@@ -313,7 +313,7 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
         selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount,
 
         // Default prop / hardcoded (may become customizable later)
-        columnExtensionMap,
+        columnExtensionMap = colExtensionMap4DN,
     } = props;
     const { total = 0, notification = null } = context;
 
@@ -453,7 +453,7 @@ function BrowseTableWithSelectedFilesCheckboxes(props){
 BrowseTableWithSelectedFilesCheckboxes.propTypes = {
     // Props' type validation based on contents of this.props during render.
     'href'                      : PropTypes.string.isRequired,
-    'columnExtensionMap'        : PropTypes.object.isRequired,
+    'columnExtensionMap'        : PropTypes.object,
     'context'                   : PropTypes.shape({
         'columns'                   : PropTypes.objectOf(PropTypes.object).isRequired,
         'total'                     : PropTypes.number.isRequired,
@@ -463,18 +463,20 @@ BrowseTableWithSelectedFilesCheckboxes.propTypes = {
         'title'                     : PropTypes.string.isRequired
     })),
     'schemas'                   : PropTypes.object,
+    'navigate'                  : PropTypes.func,
+    'session'                   : PropTypes.bool,
     'browseBaseState'           : PropTypes.string.isRequired,
+    'windowHeight'              : PropTypes.number,
+    'windowWidth'               : PropTypes.number,
     'selectFile'                : PropTypes.func,
     'unselectFile'              : PropTypes.func,
     'selectedFiles'             : PropTypes.objectOf(PropTypes.object),
+    'toggleFullScreen'          : PropTypes.func,
+    'isFullscreen'              : PropTypes.bool,
+    'registerWindowOnScrollHandler': PropTypes.func,
+    'resetSelectedFiles'        : PropTypes.func,
+    'selectedFilesUniqueCount'  : PropTypes.number,
 };
-BrowseTableWithSelectedFilesCheckboxes.defaultProps = {
-    'navigate'  : globalNavigate,
-    'columnExtensionMap' : colExtensionMap4DN
-};
-
-
-
 
 
 const BrowseViewPageTitle = React.memo(function BrowseViewPageTitle(props) {

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -32,11 +32,11 @@ export default function FileSearchView (props){
 function FileTableWithSelectedFilesCheckboxes(props){
     const {
         // Common high-level props from Redux, or App.js, or App.js > BodyElement:
-        context, href, schemas, navigate: propNavigate,
+        context, href, schemas, navigate: propNavigate = navigate,
         windowHeight, windowWidth, registerWindowOnScrollHandler,
         toggleFullScreen, isFullscreen, session,
         selectedFiles, selectFile, unselectFile, resetSelectedFiles, selectedFilesUniqueCount,
-        columnExtensionMap,
+        columnExtensionMap = colExtensionMap4DN,
         currentAction
     } = props;
     const { total = 0 } = context;
@@ -113,10 +113,6 @@ FileTableWithSelectedFilesCheckboxes.propTypes = {
     'selectFile'                : PropTypes.func,
     'unselectFile'              : PropTypes.func,
     'selectedFiles'             : PropTypes.objectOf(PropTypes.object),
-};
-FileTableWithSelectedFilesCheckboxes.defaultProps = {
-    'navigate'  : navigate,
-    'columnExtensionMap' : colExtensionMap4DN
 };
 
 function AboveFacetList({ context, currentAction }){

--- a/src/encoded/static/components/browse/components/ExperimentSetDetailPane.js
+++ b/src/encoded/static/components/browse/components/ExperimentSetDetailPane.js
@@ -29,7 +29,7 @@ export class ExperimentSetDetailPane extends React.PureComponent {
         'containerWidth' : PropTypes.number,
         'paddingWidth' : PropTypes.number,
         'windowWidth' : PropTypes.number,
-        'href' : PropTypes.string.isRequired,
+        'href' : PropTypes.string,
         'minimumWidth' : PropTypes.number,
         'initialStateCache' : PropTypes.object,
         'updateFileSectionStateCache' : PropTypes.func,

--- a/src/encoded/static/components/browse/components/ExperimentSetDetailPane.js
+++ b/src/encoded/static/components/browse/components/ExperimentSetDetailPane.js
@@ -155,14 +155,17 @@ export class ExperimentSetDetailPane extends React.PureComponent {
 }
 
 const RawFilesSection = React.memo(function RawFilesSection(props){
-    const { containerWidth, result, href, minimumWidth, paddingWidth, open = false, onToggle, selectedFilesCount } = props;
+    const { containerWidth, result, href, minimumWidth, paddingWidth, open = false, onToggle, selectFile, selectedFilesCount = 0 } = props;
 
     // For debugging stacked tables
     //const useResult = require('./../../testdata/experiment_set/replicate_4DNESH4MYRID');
 
     const rawFilesCount = expFxn.fileCountFromExperimentSet(result, false, false);
-
     if (rawFilesCount === 0) return null;
+
+    const isTitleMuted = (typeof selectFile === 'function') && selectedFilesCount === 0;
+    const selectedFilesCountText = (selectedFilesCount > 0) ?
+        (<sup className="ml-05">({`${selectedFilesCount} file${selectedFilesCount > 1 ? 's' : ''} selected`})</sup>) : null;
 
     let innerTableContents = null;
     if (open) {
@@ -180,9 +183,10 @@ const RawFilesSection = React.memo(function RawFilesSection(props){
 
     return (
         <div className="raw-files-table-section">
-            <h4 className={"pane-section-title" + (selectedFilesCount > 0 ? "" : " text-muted")} onClick={onToggle}>
+            <h4 className={"pane-section-title" + (!isTitleMuted ? "" : " text-muted")} onClick={onToggle}>
                 <i className={"toggle-open-icon icon icon-fw fas icon-" + (open ? 'minus' : 'plus')} />
                 <i className="icon icon-fw icon-leaf fas"/> <span className="text-400">{ rawFilesCount }</span> Raw Files
+                {selectedFilesCountText}
             </h4>
             { innerTableContents }
         </div>
@@ -191,12 +195,15 @@ const RawFilesSection = React.memo(function RawFilesSection(props){
 });
 
 const ProcessedFilesSection = React.memo(function ProcessedFilesSection(props){
-    const { containerWidth, result, href, minimumWidth, paddingWidth, open = false, onToggle, selectedFilesCount = 0 } = props;
+    const { containerWidth, result, href, minimumWidth, paddingWidth, open = false, onToggle, selectFile, selectedFilesCount = 0 } = props;
     const processedFiles = expFxn.allProcessedFilesFromExperimentSet(result);
 
     if (!Array.isArray(processedFiles) || processedFiles.length === 0){
         return null;
     }
+    const isTitleMuted = (typeof selectFile === 'function') && selectedFilesCount === 0;
+    const selectedFilesCountText = (selectedFilesCount > 0) ?
+        (<sup className="ml-05">({`${selectedFilesCount} file${selectedFilesCount > 1 ? 's' : ''} selected`})</sup>) : null;
 
     let innerTableContents = null;
     if (open) {
@@ -209,9 +216,10 @@ const ProcessedFilesSection = React.memo(function ProcessedFilesSection(props){
 
     return (
         <div className="processed-files-table-section">
-            <h4 className={"pane-section-title" + (selectedFilesCount > 0 ? "" : " text-muted")} onClick={onToggle}>
+            <h4 className={"pane-section-title" + (!isTitleMuted ? "" : " text-muted")} onClick={onToggle}>
                 <i className={"toggle-open-icon icon icon-fw fas icon-" + (open ? 'minus' : 'plus')} />
                 <i className="icon icon-fw icon-microchip fas"/> <span className="text-400">{ processedFiles.length }</span> Processed Files
+                {selectedFilesCountText}
             </h4>
             { innerTableContents }
         </div>
@@ -219,12 +227,15 @@ const ProcessedFilesSection = React.memo(function ProcessedFilesSection(props){
 });
 
 const SupplementaryFilesSection = React.memo(function ProcessedFilesSection(props){
-    const { containerWidth, result, href, minimumWidth, paddingWidth, open = false, onToggle, selectedFilesCount = 0 } = props;
+    const { containerWidth, result, href, minimumWidth, paddingWidth, open = false, onToggle, selectFile, selectedFilesCount = 0 } = props;
     const supplementaryFiles = expFxn.allOtherProcessedFilesFromExperimentSet(result);
 
     if (!Array.isArray(supplementaryFiles) || supplementaryFiles.length === 0){
         return null;
     }
+    const isTitleMuted = (typeof selectFile === 'function') && selectedFilesCount === 0;
+    const selectedFilesCountText = (selectedFilesCount > 0) ?
+        (<sup className="ml-05">({`${selectedFilesCount} file${selectedFilesCount > 1 ? 's' : ''} selected`})</sup>) : null;
 
     let innerTableContents = null;
     if (open) {
@@ -238,9 +249,10 @@ const SupplementaryFilesSection = React.memo(function ProcessedFilesSection(prop
 
     return (
         <div className="processed-files-table-section">
-            <h4 className={"pane-section-title" + (selectedFilesCount > 0 ? "" : " text-muted")} onClick={onToggle}>
+            <h4 className={"pane-section-title" + (!isTitleMuted ? "" : " text-muted")} onClick={onToggle}>
                 <i className={"toggle-open-icon icon icon-fw fas icon-" + (open ? 'minus' : 'plus')} />
                 <i className="icon icon-fw icon-microchip fas"/> <span className="text-400">{ supplementaryFiles.length }</span> Supplementary Files
+                {selectedFilesCountText}
             </h4>
             { innerTableContents }
         </div>

--- a/src/encoded/static/components/browse/components/ExperimentSetDetailPane.js
+++ b/src/encoded/static/components/browse/components/ExperimentSetDetailPane.js
@@ -25,10 +25,10 @@ export class ExperimentSetDetailPane extends React.PureComponent {
 
     static propTypes = {
         'selectAllFilesInitially' : PropTypes.bool,
-        'result' : PropTypes.object.isRequired,
+        'result' : PropTypes.object,
         'containerWidth' : PropTypes.number,
         'paddingWidth' : PropTypes.number,
-        'windowWidth' : PropTypes.number.isRequired,
+        'windowWidth' : PropTypes.number,
         'href' : PropTypes.string.isRequired,
         'minimumWidth' : PropTypes.number,
         'initialStateCache' : PropTypes.object,

--- a/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
+++ b/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
@@ -71,7 +71,6 @@ export const BrowseViewSelectedFilesDownloadButton = React.memo(function BrowseV
 export class SelectedFilesDownloadButton extends React.PureComponent {
 
     static propTypes = {
-        'windowWidth' : PropTypes.number.isRequired,
         'id' : PropTypes.string,
         'selectedFiles' : PropTypes.object.isRequired,
         'filenamePrefix' : PropTypes.string.isRequired,
@@ -112,7 +111,7 @@ export class SelectedFilesDownloadButton extends React.PureComponent {
     render(){
         const {
             selectedFiles, filenamePrefix, children, disabled,
-            windowWidth, context, analyticsAddFilesToCart, action, session,
+            context, analyticsAddFilesToCart, action, session,
             ...btnProps
         } = this.props;
         const { modalOpen } = this.state;

--- a/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
+++ b/src/encoded/static/components/browse/components/above-table-controls/SelectedFilesDownloadButton.js
@@ -214,7 +214,7 @@ class SelectedFilesDownloadModal extends React.PureComponent {
             action += '&' + modifiedSearch;
         }
         return (
-            <Modal show className="batch-files-download-modal" onHide={onHide} bsSize="large">
+            <Modal show className="batch-files-download-modal" onHide={onHide} size="lg">
 
                 <Modal.Header closeButton>
                     <Modal.Title>

--- a/src/encoded/static/components/forms/UserRegistrationForm.js
+++ b/src/encoded/static/components/forms/UserRegistrationForm.js
@@ -354,7 +354,7 @@ class LookupLabField extends React.PureComponent {
     static propTypes = {
         'onSelect' : PropTypes.func.isRequired,
         'onClear' : PropTypes.func.isRequired,
-        'loading' : PropTypes.bool.isRequired
+        'loading' : PropTypes.bool
     };
 
     constructor(props){

--- a/src/encoded/static/components/item-pages/DefaultItemView.js
+++ b/src/encoded/static/components/item-pages/DefaultItemView.js
@@ -797,7 +797,7 @@ export class OverViewBodyItem extends React.PureComponent {
 }
 
 export function WrapInColumn(props){
-    const { children, wrap, className, defaultWrapClassName } = props;
+    const { children, wrap = false, className, defaultWrapClassName = "col-6 col-md-4" } = props;
     if (!wrap) return children;
 
     let wrapClassName;
@@ -805,7 +805,3 @@ export function WrapInColumn(props){
     else if (typeof wrap === 'string')  wrapClassName = wrap;
     return <div className={wrapClassName + (className ? ' ' + className : '')}>{ children }</div>;
 }
-WrapInColumn.defaultProps = {
-    'wrap' : false,
-    'defaultWrapClassName' : "col-6 col-md-4"
-};

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -450,7 +450,7 @@ class SupplementaryFilesOPFCollection extends React.PureComponent {
             return statuses;
         }
         return null;
-    }
+    };
 
     static getStatusAndColHeaders(columnHeaders, files) {
         const status = SupplementaryFilesOPFCollection.collectionStatus(files);

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -336,9 +336,10 @@ class ProcessedFilesStackedTableSection extends React.PureComponent {
                 const nameTitle = (exp && typeof exp.display_title === 'string' && exp.display_title.replace(' - ' + exp.accession, '')) || exp.accession;
                 const experimentAtId = object.atIdFromObject(exp);
                 const replicateNumbersExists = exp && exp.bio_rep_no && exp.tec_rep_no;
+                const key = `${experimentAtId || 'exp-set'}-${replicateNumbersExists ? (exp.bio_rep_no + '-' + exp.tec_rep_no) : 'norep' }`;
 
                 return (
-                    <StackedBlockName className={replicateNumbersExists ? "double-line" : ""}>
+                    <StackedBlockName className={replicateNumbersExists ? "double-line" : ""} key={key}>
                         {replicateNumbersExists ? <div>Bio Rep <b>{exp.bio_rep_no}</b>, Tec Rep <b>{exp.tec_rep_no}</b></div> : <div />}
                         {experimentAtId ? <a href={experimentAtId} className="name-title text-500">{nameTitle}</a> : <div className="name-title">{nameTitle}</div>}
                     </StackedBlockName>
@@ -399,8 +400,8 @@ const ExperimentsWithoutFilesStackedTable = React.memo(function ExperimentsWitho
 
     const tableProps = { 'columnHeaders': ProcessedFilesStackedTableSection.expsNotAssociatedWithFileColumnHeaders };
     const expsWithReplicateExps = expFxn.combineWithReplicateNumbers(context.replicate_exps || [], expsNotAssociatedWithAnyFiles);
-    const experimentBlock = expsWithReplicateExps.map((exp) => {
-        const content = _.map(ProcessedFilesStackedTableSection.expsNotAssociatedWithFileColumnHeaders, function (col, idx) {
+    const experimentBlock = expsWithReplicateExps.map((exp, expIdx) => {
+        const content = _.map(ProcessedFilesStackedTableSection.expsNotAssociatedWithFileColumnHeaders, function (col, colIdx) {
             if (col.render && typeof col.render === 'function') { return col.render(exp); }
             else {
                 /**
@@ -410,15 +411,15 @@ const ExperimentsWithoutFilesStackedTable = React.memo(function ExperimentsWitho
                  * some props from parent element into 'div' element assuming it is a React component, in case it is not.
                  */
                 return (
-                    <React.Fragment>
-                        <div className={"col-" + col.columnClass + " item detail-col" + idx} style={{ flex: '1 0 ' + col.initialWidth + 'px' }}>{'-'}</div>
+                    <React.Fragment key={'no-renderer-' + colIdx}>
+                        <div className={"col-" + col.columnClass + " item detail-col" + colIdx} style={{ flex: '1 0 ' + col.initialWidth + 'px' }}>{'-'}</div>
                     </React.Fragment>
                 );
             }
         });
         return (
             <StackedBlock columnClass="experiment" hideNameOnHover={false}
-                key={exp.accession} label={
+                key={exp.accession + '-' + expIdx} label={
                     <StackedBlockNameLabel title={'Experiment'}
                         accession={exp.accession} subtitleVisible />
                 }>

--- a/src/encoded/static/components/item-pages/ExperimentSetView.js
+++ b/src/encoded/static/components/item-pages/ExperimentSetView.js
@@ -136,10 +136,6 @@ export default class ExperimentSetView extends WorkflowRunTracingView {
 
         // Supplementary Files Tab
         if (ExperimentSetView.shouldShowSupplementaryFilesTabView(context)){
-            //const referenceFiles = SupplementaryFilesTabView.allReferenceFiles(context) || [];
-            //const opfCollections = SupplementaryFilesTabView.combinedOtherProcessedFiles(context) || [];
-            //const allOpfFiles = _.reduce(opfCollections, function (memo, coll) { return memo.concat(coll.files || []); }, []);
-            //const allFiles = referenceFiles.concat(allOpfFiles);
             tabs.push({
                 tab : <span><i className="icon icon-copy far icon-fw"/> Supplementary Files</span>,
                 key : 'supplementary-files',

--- a/src/encoded/static/components/item-pages/FileView.js
+++ b/src/encoded/static/components/item-pages/FileView.js
@@ -230,7 +230,7 @@ export class FileOverviewHeading extends React.PureComponent {
 
 
 export function FileViewDownloadButtonContainer(props){
-    const { className, size, file, context, result, session } = props;
+    const { className, size = null, file, context, result, session } = props;
     const fileToUse = file || context || result;
     return (
         <div className={"file-download-container" + (className ? " " + className : "")}>
@@ -238,7 +238,6 @@ export function FileViewDownloadButtonContainer(props){
         </div>
     );
 }
-FileViewDownloadButtonContainer.defaultProps = { "size" : null };
 
 
 export class ExternalVisualizationButtons extends React.PureComponent {

--- a/src/encoded/static/components/item-pages/HealthView.js
+++ b/src/encoded/static/components/item-pages/HealthView.js
@@ -127,6 +127,10 @@ export default class HealthView extends React.PureComponent {
                 title : "Shared Portal Components Version",
                 description : "Software version of shared-portal-components package being used."
             },
+            'react_workflow_viz_version': {
+                title : "React Workflow Viz",
+                description : "Software version of react-workflow-viz (component for visualizing CWL-like workflows and provenance graphs) package being used."
+            },
             'micro_meta_version': {
                 title : "MicroMeta Version",
                 description : "Software version of MicroMeta package being used."
@@ -231,6 +235,7 @@ export default class HealthView extends React.PureComponent {
         // since dependencies is depracated in npm v9, we extract the pkg versions from packages field - see https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#dependencies
         const { packages: {
             'node_modules/@hms-dbmi-bgm/shared-portal-components': { version: spcVersion } = {},
+            'node_modules/@hms-dbmi-bgm/react-workflow-viz': { version: reactWorkflowVizVersion } = {},
             'node_modules/micro-meta-app-react': { version: microMetaVersion } = {},
             'node_modules/higlass': { version: higlassVersion } = {},
             'node_modules/vitessce': { version: vitessceVersion = {} }
@@ -239,6 +244,7 @@ export default class HealthView extends React.PureComponent {
         const context = {
             ...propContext,
             'spc_version': spcVersion || "-",
+            'react_workflow_viz_version': reactWorkflowVizVersion || "-",
             'micro_meta_version': microMetaVersion || "-",
             'higlass_version': higlassVersion || "-",
             'vitessce_version': vitessceVersion || "-"

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -776,7 +776,7 @@ export class HiGlassViewConfigTabView extends React.PureComponent {
                     <i className={"icon icon-fw icon-" + (releaseLoading ? 'circle-notch fas icon-spin' : 'id-badge far')}/>&nbsp; Manage
                 </React.Fragment>
             ),
-            'pullRight'     : true
+            'align'         : 'end'
         };
 
         return (

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -1142,7 +1142,7 @@ export class HiGlassAdjustableWidthRow extends React.PureComponent {
         'width' : PropTypes.number.isRequired,
         'mounted' : PropTypes.bool.isRequired,
         'renderRightPanel' : PropTypes.func,
-        'windowWidth' : PropTypes.number.isRequired,
+        'windowWidth' : PropTypes.number,
         'higlassItem' : PropTypes.object,
         'minOpenHeight' : PropTypes.number,
         'maxOpenHeight' : PropTypes.number,

--- a/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
+++ b/src/encoded/static/components/item-pages/HiGlassViewConfigView.js
@@ -1277,9 +1277,3 @@ ConfirmModal.propTypes = {
     'confirmButtonVisible': PropTypes.bool,
     'cancelButtonVisible': PropTypes.bool
 };
-ConfirmModal.defaultProps = {
-    'confirmButtonText': 'OK',
-    'cancelButtonText': 'Cancel',
-    'confirmButtonVisible': true,
-    'cancelButtonVisible': true
-};

--- a/src/encoded/static/components/item-pages/MicroscopeConfigurationView.js
+++ b/src/encoded/static/components/item-pages/MicroscopeConfigurationView.js
@@ -562,6 +562,8 @@ export class MicroMetaTabView extends React.PureComponent {
         const width = isFullscreen ? windowWidth - 40 : layout.gridContainerWidth(windowWidth);
         const height = isFullscreen ? Math.max(800, windowHeight - 120) : Math.max(800, windowHeight / 2);
 
+        const microscopeConfig = JSON.parse(JSON.stringify(context.microscope || {}));
+
         return (
             <div className={"tabview-container-fullscreen-capable" + (isFullscreen ? ' full-screen-view' : ' overflow-hidden')}>
                 <h3 className="tab-section-title">
@@ -577,7 +579,7 @@ export class MicroMetaTabView extends React.PureComponent {
                 <div className="microscope-tab-view-contents">
                     <div className="micrometa-container-container" style={{ height }}>
                         <MicroMetaPlainContainer {..._.omit(this.props, 'context', 'microscope')}
-                            {...{ width, height, onSaveMicroscope: this.onSaveMicroscope, microscopeConfig: context.microscope }}
+                            {...{ width, height, onSaveMicroscope: this.onSaveMicroscope, microscopeConfig: microscopeConfig }}
                             ref={this.microMetaToolRef} zoomVisible={false} />
                     </div>
                 </div>

--- a/src/encoded/static/components/item-pages/MicroscopeConfigurationView.js
+++ b/src/encoded/static/components/item-pages/MicroscopeConfigurationView.js
@@ -939,7 +939,7 @@ export class MicroMetaSummaryTabView extends React.PureComponent {
                         {_.map(visibleMatches, function (m, index) {
                             const tooltip = m.Name && m.Name.length > tooltipHeaderLimit ? m.Name : null;
                             return (
-                                <div className={columClassName + " summary-title-column text-truncate"} data-tip={tooltip}>
+                                <div className={columClassName + " summary-title-column text-truncate"} data-tip={tooltip} key={m.ID || m.name}>
                                     {m.Name}
                                 </div>
                             );
@@ -1052,23 +1052,23 @@ const CollapsibleSubCategory = React.memo(function CollapsibleSubCategory(props)
 
     const itemRows = _.map(subCategoryProperties, function ([field, item]) {
         let hasValidColumn = false;
-        const itemCols = _.map(matches, function (match) {
+        const itemCols = _.map(matches, function (match, idx) {
             if (typeof match[field] === 'undefined' || match[field] === null) {
                 return (<div className={columClassName + " summary-item-column"}>&nbsp;</div>);
             }
             hasValidColumn = true;
             const tooltip = typeof match[field] === 'string' && match[field].length >= tooltipLimit ? match[field] : null;
             return (
-                <div className={columClassName + " summary-item-column"}>
+                <div className={columClassName + " summary-item-column"} key={match.ID || match.name || idx}>
                     <div className="text-truncate" data-tip={tooltip}>{match[field].toString()}</div>
                 </div>
             );
         });
 
         return hasValidColumn ? (
-            <div className="row summary-item-row">
+            <div className="row summary-item-row" key={field}>
                 <div className="col-4 col-lg-3 col-xl-3 summary-item-row-header">
-                    <object.TooltipInfoIconContainer title={field} tooltip={item.description} className="text-truncate" />
+                    <object.TooltipInfoIconContainer title={field} tooltip={item.description} className="text-truncate" key={'tooltip-' + field} />
                 </div>
                 {itemCols}
             </div>

--- a/src/encoded/static/components/item-pages/MicroscopeConfigurationView.js
+++ b/src/encoded/static/components/item-pages/MicroscopeConfigurationView.js
@@ -333,7 +333,7 @@ export class MicroMetaTabView extends React.PureComponent {
                     <i className={"icon icon-fw icon-" + (releaseLoading ? 'circle-notch fas icon-spin' : 'id-badge far')}/>&nbsp; Manage
                 </React.Fragment>
             ),
-            'pullRight'     : true
+            'align'         : 'end'
         };
 
         return (

--- a/src/encoded/static/components/item-pages/PublicationView.js
+++ b/src/encoded/static/components/item-pages/PublicationView.js
@@ -87,7 +87,7 @@ class PublicationSummary extends React.PureComponent {
                         <p>
                             { _.map(authors, function(author, i){
                                 return (
-                                    <React.Fragment>
+                                    <React.Fragment key={'author-' + i}>
                                         <span className="text-nowrap">
                                             { author }
                                         </span>

--- a/src/encoded/static/components/item-pages/PublicationView.js
+++ b/src/encoded/static/components/item-pages/PublicationView.js
@@ -358,7 +358,7 @@ const PublicationViewTitle = React.memo(function PublicationViewTitle(props){
 
 function isReplicateExperimentSet(expSet) {
     if (!expSet) { return false; }
-    
+
     const { experimentset_type } = expSet;
     return object.itemUtil.atId(expSet) && schemaTransforms.getBaseItemType(expSet) === 'ExperimentSet' && experimentset_type === 'replicate';
 }

--- a/src/encoded/static/components/item-pages/components/AdjustableDividerRow.js
+++ b/src/encoded/static/components/item-pages/components/AdjustableDividerRow.js
@@ -56,7 +56,7 @@ export class AdjustableDividerRow extends React.PureComponent {
         'renderLeftPanelPlaceHolder'    : PropTypes.func,
         'height'                        : PropTypes.number.isRequired, // Pre-define this.
         'width'                         : PropTypes.number,
-        'windowWidth'                   : PropTypes.number.isRequired
+        'windowWidth'                   : PropTypes.number,
     };
 
     constructor(props){

--- a/src/encoded/static/components/item-pages/components/AdjustableDividerRow.js
+++ b/src/encoded/static/components/item-pages/components/AdjustableDividerRow.js
@@ -9,7 +9,7 @@ import { requestAnimationFrame as raf } from '@hms-dbmi-bgm/shared-portal-compon
 
 
 export const DraggableVerticalBorder = React.memo(function DraggableVerticalBorder(props){
-    const { xOffset, height, left, handleHeight } = props;
+    const { xOffset, height, left, handleHeight = 24 } = props;
     // workaround for "findDOMNode is deprecated in StrictMode" error: https://stackoverflow.com/a/63603903
     const nodeRef = useRef(null);
     return (
@@ -22,9 +22,6 @@ export const DraggableVerticalBorder = React.memo(function DraggableVerticalBord
         </Draggable>
     );
 });
-DraggableVerticalBorder.defaultProps = {
-    'handleHeight' : 24
-};
 
 
 /** This is pretty ugly. @todo refactor, reimplement, something... */

--- a/src/encoded/static/components/item-pages/components/AdjustableDividerRow.js
+++ b/src/encoded/static/components/item-pages/components/AdjustableDividerRow.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import Draggable from 'react-draggable';
@@ -10,9 +10,11 @@ import { requestAnimationFrame as raf } from '@hms-dbmi-bgm/shared-portal-compon
 
 export const DraggableVerticalBorder = React.memo(function DraggableVerticalBorder(props){
     const { xOffset, height, left, handleHeight } = props;
+    // workaround for "findDOMNode is deprecated in StrictMode" error: https://stackoverflow.com/a/63603903
+    const nodeRef = useRef(null);
     return (
-        <Draggable axis="x" position={{ 'x': xOffset, 'y': 0 }} {..._.pick(props, 'onStart', 'onStop', 'onDrag', 'bounds')}>
-            <div className="draggable-border vertical-border" style={{ 'height' : height, 'left': left - 5 }}>
+        <Draggable axis="x" position={{ 'x': xOffset, 'y': 0 }} {..._.pick(props, 'onStart', 'onStop', 'onDrag', 'bounds')} nodeRef={nodeRef}>
+            <div className="draggable-border vertical-border" style={{ 'height' : height, 'left': left - 5 }} ref={nodeRef}>
                 <div className="inner">
                     <div className="drag-handle" style={{ 'height' : handleHeight, 'top' : (Math.max(height - handleHeight, 10) / 2) }}/>
                 </div>

--- a/src/encoded/static/components/item-pages/components/FilesInSetTable.js
+++ b/src/encoded/static/components/item-pages/components/FilesInSetTable.js
@@ -54,7 +54,7 @@ const SubmitterLink = React.memo(function SubmitterLink({ user, labName, showLab
  * @prop {function} onMouseLeave - Callback for cursor leaving icon.
  */
 const LabIcon = React.memo(function LabIcon(props){
-    const { lab, onMouseEnter, onMouseLeave } = props;
+    const { lab, onMouseEnter = null, onMouseLeave = null } = props;
     const atId = lab && object.atIdFromObject(lab);
     if (!atId){
         logger.error("We need lab with @id.");
@@ -71,10 +71,6 @@ const LabIcon = React.memo(function LabIcon(props){
         </a>
     );
 });
-LabIcon.defaultProps = {
-    onMouseEnter : null,
-    onMouseLeave : null
-};
 
 /**
  * Renders a div element with '.row' Bootstrap class, containing details about a file.

--- a/src/encoded/static/components/item-pages/components/FormattedInfoBlock.js
+++ b/src/encoded/static/components/item-pages/components/FormattedInfoBlock.js
@@ -21,7 +21,7 @@ import { generateAddressString, ContactPersonListItem } from './AttributionTabVi
  * @prop {string} [iconClass='book']- CSS class for icon to be displayed. Defaults to 'book'.
  */
 export const FormattedInfoWrapper =  React.memo(function FormattedInfoWrapper(props){
-    const { isSingleItem, className, singularTitle, iconClass, children, noDetails } = props;
+    const { isSingleItem = false, className = null, singularTitle = 'Publication', iconClass = 'book fas', children, noDetails = false } = props;
     const outerClassName = (
         "publications-block formatted-info-panel formatted-wrapper" +
         (isSingleItem ? ' single-item' : '') +
@@ -39,13 +39,6 @@ export const FormattedInfoWrapper =  React.memo(function FormattedInfoWrapper(pr
         </div>
     );
 });
-FormattedInfoWrapper.defaultProps = {
-    'isSingleItem'  : false,
-    'singularTitle' : 'Publication',
-    'iconClass'     : 'book fas',
-    'className'     : null,
-    'noDetails'     : false
-};
 
 
 export const WrappedListBlock = React.memo(function WrappedListBlock(props){

--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
@@ -293,7 +293,7 @@ const HiGlassPlainContainerBody = React.forwardRef(function HiGlassPlainContaine
         hiGlassInstance = (
             <div className="text-center" key={outerKey} style={placeholderStyle}>
                 <h4 className="text-400">Runtime Error</h4>
-                {isDevelopmentEnv() && getReactVersion() >= 18 ? <div>HiGlass may not render appropriately under StrictMode in React 18 and later.</div> : null}
+                {isDevelopmentEnv() && getReactVersion() >= 18 ? <div>HiGlass may not render correctly under StrictMode in React 18 and later.</div> : null}
             </div>
         );
     } else {

--- a/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
+++ b/src/encoded/static/components/item-pages/components/HiGlass/HiGlassPlainContainer.js
@@ -248,6 +248,27 @@ export function scaleHiGlassViewConfig(originalViewConf, targetHeight){
     return viewConf;
 }
 
+/**
+ * Attention! this function works if only process.env.NODE_ENV is set
+ * @todo remove this function when HiGlass works correctly under <StrictMode> in React 18
+ */
+const isDevelopmentEnv = memoize(function (){
+    try {
+        return (process.env.NODE_ENV === 'development') || (process.env.NODE_ENV === 'quick') || false;
+    } catch {
+        return false;
+    }
+});
+/**
+ * @todo remove this function when HiGlass works correctly under <StrictMode> in React 18
+ */
+const getReactVersion = memoize(function () {
+    try {
+        return parseInt((React.version || '-1').split('.')[0]);
+    } catch {
+        return -1;
+    }
+});
 
 const HiGlassPlainContainerBody = React.forwardRef(function HiGlassPlainContainerBody(props, ref){
     const { viewConfig, options, hasRuntimeError, disabled, isValidating, mounted, higlassInitialized, width, height, mountCount, placeholder, style, className, packageLockJson } = props;
@@ -272,6 +293,7 @@ const HiGlassPlainContainerBody = React.forwardRef(function HiGlassPlainContaine
         hiGlassInstance = (
             <div className="text-center" key={outerKey} style={placeholderStyle}>
                 <h4 className="text-400">Runtime Error</h4>
+                {isDevelopmentEnv() && getReactVersion() >= 18 ? <div>HiGlass may not render appropriately under StrictMode in React 18 and later.</div> : null}
             </div>
         );
     } else {

--- a/src/encoded/static/components/item-pages/components/ItemFileAttachment.js
+++ b/src/encoded/static/components/item-pages/components/ItemFileAttachment.js
@@ -86,7 +86,7 @@ export class ItemFileAttachment extends React.PureComponent {
                 <div className={includeTitle ? 'mt-1' : null}>
                     <ViewFileButton filename={download || null}
                         href={object.itemUtil.atId(context) + attachHref} disabled={attachHref.length === 0}
-                        className={ViewFileButton.defaultProps.className + ' btn-block'} />
+                        className="text-truncate mb-1 btn-block" />
                     <div>
                         { this.size() }
                         { this.md5sum() }

--- a/src/encoded/static/components/item-pages/components/LinkBelowHeaderRow.js
+++ b/src/encoded/static/components/item-pages/components/LinkBelowHeaderRow.js
@@ -19,17 +19,14 @@ export const SOPBelowHeaderRow = React.memo(function SOPBelowHeaderRow({ sop }){
 });
 
 
-export const LinkBelowHeaderRow = React.memo(function LinkBelowHeaderRow({ url, title, singularTitle, iconClass }){
-    if (!url) return null;
-    return (
-        <FormattedInfoWrapper isSingleItem {...{ singularTitle, iconClass }}>
-            <h5 className="block-title mt-1">
-                <a href={url} target="_blank" rel="noopener noreferrer">{ title || url }</a>
-            </h5>
-        </FormattedInfoWrapper>
-    );
-});
-LinkBelowHeaderRow.defaultProps = {
-    "singularTitle" : "Reference Protocol",
-    "iconClass" : "file fas"
-};
+export const LinkBelowHeaderRow = React.memo(
+    function LinkBelowHeaderRow({ url, title, singularTitle = "Reference Protocol", iconClass = "file fas" }) {
+        if (!url) return null;
+        return (
+            <FormattedInfoWrapper isSingleItem {...{ singularTitle, iconClass }}>
+                <h5 className="block-title mt-1">
+                    <a href={url} target="_blank" rel="noopener noreferrer">{title || url}</a>
+                </h5>
+            </FormattedInfoWrapper>
+        );
+    });

--- a/src/encoded/static/components/item-pages/components/Publications.js
+++ b/src/encoded/static/components/item-pages/components/Publications.js
@@ -18,7 +18,7 @@ import { FormattedInfoWrapper, WrappedCollapsibleList } from './FormattedInfoBlo
  * @prop {Element|Element[]} children   - React Element(s) to display in detail area under title.
  */
 const DetailBlock = React.memo(function DetailBlock(props){
-    const { publication = null, singularTitle, children } = props;
+    const { publication = null, singularTitle = 'Publication', children } = props;
     const publicationHref = object.itemUtil.atId(publication);
     if (!publication || !publicationHref) return null; // Is case if no view permission for Publiation, as well.
 
@@ -34,9 +34,6 @@ const DetailBlock = React.memo(function DetailBlock(props){
         </FormattedInfoWrapper>
     );
 });
-DetailBlock.defaultProps = {
-    'singularTitle' : 'Publication'
-};
 
 const ShortAttribution = React.memo(function ShortAttribution({ publication : pub }){
     if (!pub || !object.itemUtil.atId(pub)) return null;
@@ -92,22 +89,19 @@ ShortAttribution.propTypes = {
  * Maybe get rid of `<div className={outerClassName}>` completely and allow parent/containing
  * component to create own <div> with whatever className is desired, among other element attributes.
  */
-const PublicationBelowHeaderRow = React.memo(function PublicationBelowHeaderRow({ publication, singularTitle, outerClassName }){
-    if (!publication || !object.itemUtil.atId(publication)) return null;
-    return (
-        <div className={outerClassName}>
-            <DetailBlock publication={publication} singularTitle={singularTitle} >
-                <div className="more-details">
-                    <ShortAttribution publication={publication} />
-                </div>
-            </DetailBlock>
-        </div>
-    );
-});
-PublicationBelowHeaderRow.defaultProps = {
-    'singularTitle' : "Source Publication",
-    'outerClassName' : "mb-2"
-};
+const PublicationBelowHeaderRow = React.memo(
+    function PublicationBelowHeaderRow({ publication, singularTitle = "Source Publication", outerClassName = "mb-2" }) {
+        if (!publication || !object.itemUtil.atId(publication)) return null;
+        return (
+            <div className={outerClassName}>
+                <DetailBlock publication={publication} singularTitle={singularTitle} >
+                    <div className="more-details">
+                        <ShortAttribution publication={publication} />
+                    </div>
+                </DetailBlock>
+            </div>
+        );
+    });
 
 /**
  * Shows publications for current Item. Rendered by AttributionTabView.js.

--- a/src/encoded/static/components/item-pages/components/TabbedView.js
+++ b/src/encoded/static/components/item-pages/components/TabbedView.js
@@ -277,7 +277,9 @@ export class TabbedView extends React.PureComponent {
         const foundContent = Array.isArray(allContentObjs) && _.findWhere(allContentObjs, { 'key' : hash });
 
         if (!foundContent){
-            console.error('Could not find', hash);
+            if (hash) {
+                console.error('Could not find hash:', hash);
+            }
             return false;
         }
 

--- a/src/encoded/static/components/item-pages/components/Vitessce/VitesscePlainContainer.js
+++ b/src/encoded/static/components/item-pages/components/Vitessce/VitesscePlainContainer.js
@@ -185,7 +185,6 @@ const VitesscePlainContainerBody = React.forwardRef(function VitesscePlainContai
      */
     return (
         <div className={"vitessce-view-container" + (className ? ' ' + className : '')} style={style}>
-            {/* { vitessceVersionUsed === null ? null : <link type="text/css" rel="stylesheet" href={`https://unpkg.com/vitessce@${vitessceVersionUsed}/dist/es/production/static/css/index.css`} crossOrigin="true" /> } */}
             <div className="vitessce-wrapper">{ vitessceInstance }</div>
         </div>
     );

--- a/src/encoded/static/components/item-pages/components/WorkflowDetailPane/FileDetailBodyMetricsView.js
+++ b/src/encoded/static/components/item-pages/components/WorkflowDetailPane/FileDetailBodyMetricsView.js
@@ -93,15 +93,11 @@ function MetricsViewItemIcon({ resultStr = "UNKNOWN", extraIconClassName = "" })
     }
 }
 
-export const MetricsView = React.memo(function MetricsView({ metrics }){
-    return (
-        <div className="metrics-view row">
-            { _.map(metrics || [], (m,i) => <MetricsViewItem metric={m} key={m.key || m.title || i} />) }
-        </div>
-    );
-});
-MetricsView.defaultProps = {
-    'metrics' : [
-        { 'key' : 'something', 'title' : 'Some Thing', 'result' : 'PASS' }
-    ]
-};
+export const MetricsView = React.memo(
+    function MetricsView({ metrics = [{ 'key': 'something', 'title': 'Some Thing', 'result': 'PASS' }] }) {
+        return (
+            <div className="metrics-view row">
+                {_.map(metrics || [], (m, i) => <MetricsViewItem metric={m} key={m.key || m.title || i} />)}
+            </div>
+        );
+    });

--- a/src/encoded/static/components/item-pages/components/WorkflowDetailPane/StepDetailBody.js
+++ b/src/encoded/static/components/item-pages/components/WorkflowDetailPane/StepDetailBody.js
@@ -119,7 +119,15 @@ const analysisStepTypesExist = memoize(function(step){
 
 
 
-export const WorkflowStepTitleBox = React.memo(function WorkflowStepTitleBox({ step, node, isFullRow, label }){
+export const WorkflowStepTitleBox = React.memo(function WorkflowStepTitleBox(props){
+    const {
+        step,
+        node,
+        isFullRow = function (step) {
+            return !analysisStepTypesExist(step);
+        },
+        label = "Step Name"
+    } = props;
     const shouldBeFullRow = (typeof isFullRow === 'function' && isFullRow(step)) || (typeof isFullRow === 'boolean' && isFullRow) || false;
     const titleString     = step.display_title || step.name || node.name;
     const stepHref        = object.atIdFromObject(step) || null;
@@ -135,12 +143,6 @@ export const WorkflowStepTitleBox = React.memo(function WorkflowStepTitleBox({ s
         </div>
     );
 });
-WorkflowStepTitleBox.defaultProps = {
-    'isFullRow' : function(step){
-        return !analysisStepTypesExist(step);
-    },
-    'label' : "Step Name"
-};
 
 
 export const StepDetailBody = React.memo(function StepDetailBody({ step, node, minHeight }){

--- a/src/encoded/static/components/item-pages/components/WorkflowDetailPane/WFRStepDetailBody.js
+++ b/src/encoded/static/components/item-pages/components/WorkflowDetailPane/WFRStepDetailBody.js
@@ -92,6 +92,7 @@ export class WFRStepDetailBody extends React.PureComponent {
         this.state = {
             "wfr" : (this.props.step && this.props.step['@id']) || null
         };
+        this.nodeRef = React.createRef();
     }
 
     componentDidMount(){
@@ -175,7 +176,7 @@ export class WFRStepDetailBody extends React.PureComponent {
                 <hr/>
 
 
-                <Fade in={!!(wfr)} key="wfr-detail-container">
+                <Fade in={!!(wfr)} key="wfr-detail-container" nodeRef={this.nodeRef}>
                     <div>
                         <h3 className="tab-section-title">
                             <span>Details of Run</span>

--- a/src/encoded/static/components/item-pages/components/WorkflowGraphSectionControls.js
+++ b/src/encoded/static/components/item-pages/components/WorkflowGraphSectionControls.js
@@ -212,5 +212,5 @@ RowSpacingTypeDropdown.propTypes = {
     'onSelect' : PropTypes.func.isRequired,
     'currentKey' : PropTypes.oneOf([ 'compact', 'wide', 'stacked' ]),
     'id' : PropTypes.string,
-    'titleMap' : PropTypes.objectOf(PropTypes.string).isRequired
+    'titleMap' : PropTypes.objectOf(PropTypes.string)
 };

--- a/src/encoded/static/components/item-pages/components/WorkflowGraphSectionControls.js
+++ b/src/encoded/static/components/item-pages/components/WorkflowGraphSectionControls.js
@@ -184,7 +184,15 @@ export class WorkflowGraphSectionControls extends React.PureComponent {
     }
 }
 
-const RowSpacingTypeDropdown = React.memo(function RowSpacingTypeDropdown({ currentKey, id, onSelect, titleMap }){
+const RowSpacingTypeDropdown = React.memo(function RowSpacingTypeDropdown(props){
+    const {
+        currentKey, id, onSelect,
+        titleMap = {
+            'stacked': 'Stack Nodes',
+            'compact': 'Center Nodes',
+            'wide': 'Spread Nodes'
+        }
+    } = props;
     const menuItems = _.map(_.keys(titleMap), function(k){
         return (
             <DropdownItem key={k} eventKey={k} active={currentKey === k}>
@@ -205,11 +213,4 @@ RowSpacingTypeDropdown.propTypes = {
     'currentKey' : PropTypes.oneOf([ 'compact', 'wide', 'stacked' ]),
     'id' : PropTypes.string,
     'titleMap' : PropTypes.objectOf(PropTypes.string).isRequired
-};
-RowSpacingTypeDropdown.defaultProps = {
-    'titleMap' : {
-        'stacked' : 'Stack Nodes',
-        'compact' : 'Center Nodes',
-        'wide' : 'Spread Nodes'
-    }
 };

--- a/src/encoded/static/components/item-pages/components/tables/ExperimentSetTables.js
+++ b/src/encoded/static/components/item-pages/components/tables/ExperimentSetTables.js
@@ -111,7 +111,7 @@ export class ExperimentSetTables extends React.PureComponent {
     static propTypes = {
         'loading' : PropTypes.bool,
         'windowWidth' : PropTypes.number.isRequired,
-        'title' : PropTypes.string,
+        'title': PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
         'href' : PropTypes.string,
         'results' : PropTypes.arrayOf(PropTypes.object),
         'experiment_sets' : PropTypes.arrayOf(PropTypes.object),

--- a/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
+++ b/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
@@ -360,7 +360,7 @@ export class ItemPageTableIndividualUrlLoader extends React.PureComponent {
     static propTypes = {
         'children' : PropTypes.element.isRequired,
         'itemUrls' : PropTypes.arrayOf(PropTypes.string).isRequired,
-        'windowWidth': PropTypes.number.isRequired,
+        'windowWidth': PropTypes.number,
         'maxToLoad' : PropTypes.number.isRequired
     };
 

--- a/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
+++ b/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
@@ -273,10 +273,11 @@ export class ItemPageTable extends React.Component {
             <div className="item-page-table-container clearfix">
                 <HeadersRow mounted columnDefinitions={columnDefinitions} renderDetailPane={renderDetailPane} width={useWidth} />
                 { _.map(results, (result, rowIndex) => {
-                    var atId = object.atIdFromObject(result);
+                    const atId = object.atIdFromObject(result);
+                    const key = `row-${rowIndex}-${atId || ''}`;
                     return (
                         <ItemPageTableRow {...this.props} {...commonRowProps}
-                            key={atId || rowIndex} result={result} rowNumber={rowIndex} defaultOpen={
+                            key={key} result={result} rowNumber={rowIndex} defaultOpen={
                                 (Array.isArray(defaultOpenIndices) && _.contains(defaultOpenIndices, rowIndex))
                                 || (atId && Array.isArray(defaultOpenIds) && _.contains(defaultOpenIds, atId))
                             } />

--- a/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
+++ b/src/encoded/static/components/item-pages/components/tables/ItemPageTable.js
@@ -141,7 +141,7 @@ SearchTableTitle.propTypes = {
     externalSearchLinkVisible: PropTypes.bool,
     title: PropTypes.string,
     titleSuffix: PropTypes.string,
-    headerElement: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']).isRequired,
+    headerElement: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
 };
 
 /** @deprecated */

--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownContainer.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownContainer.js
@@ -19,6 +19,7 @@ export class BigDropdownContainer extends React.PureComponent {
     constructor(props){
         super(props);
         this.onBackgroundClick = this.onBackgroundClick.bind(this);
+        this.nodeRef = React.createRef(null);
     }
 
     componentDidUpdate(pastProps){
@@ -108,12 +109,12 @@ export class BigDropdownContainer extends React.PureComponent {
         const body = React.Children.map(children, (child) => React.cloneElement(child, passProps));
         const renderedElem = (
             <CSSTransition appear in={open || closing} classNames="big-dropdown-menu-transition" unmountOnExit mountOnEnter
-                timeout={{ appear: 0, exit: otherDropdownOpen ? 0 : 300 }} key="dropdown-transition-container">
+                timeout={{ appear: 0, exit: otherDropdownOpen ? 0 : 300 }} key="dropdown-transition-container" nodeRef={this.nodeRef}>
                 <div className={outerCls} onClick={this.onBackgroundClick} key="dropdown-transition-container-inner"
                     data-is-mobile-view={!isDesktopView}
                     data-is-test-warning-visible={testWarningVisible}
                     data-is-closing={closing}
-                    data-is-other-dropdown-closing={otherDropdownClosing}>
+                    data-is-other-dropdown-closing={otherDropdownClosing} ref={this.nodeRef}>
                     <div className={innerCls} data-open-id={id}>
                         <div className="container">
                             { body }

--- a/src/encoded/static/components/static-pages/HomePage.js
+++ b/src/encoded/static/components/static-pages/HomePage.js
@@ -137,7 +137,7 @@ const DatasetsAndSocialMediaRow = React.memo(function DatasetsAndSocialMediaRow(
                                 </a>
                             </div>
                             <div>
-                                <a href="https://twitter.com/4dn_dcic" target="_blank" rel="noreferrer" className="btn-follow-on-social-media btn btn-primary w-100 mt-1">
+                                <a href="https://x.com/4dn_dcic" target="_blank" rel="noreferrer" className="btn-follow-on-social-media btn btn-primary w-100 mt-1">
                                     <span className="float-left ml-1">Follow 4DN Data Portal on X</span><span className="float-right mr-1"><i className="icon icon-arrow-right fas"></i></span>
                                 </a>
                             </div>

--- a/src/encoded/static/components/static-pages/components/BasicUserContentBody.js
+++ b/src/encoded/static/components/static-pages/components/BasicUserContentBody.js
@@ -89,7 +89,7 @@ export class BasicUserContentBody extends React.PureComponent {
 
 
 export const EmbeddedHiglassActions = React.memo(function EmbeddedHiglassActions(props){
-    const { context, parentComponentType, showDescription, constrainDescription } = props;
+    const { context, parentComponentType = BasicUserContentBody, showDescription = true, constrainDescription = false } = props;
     let cls = "btn btn-outline-dark pull-right extra-info-higlass-btn";
 
     if (parentComponentType === BasicUserContentBody) {
@@ -112,11 +112,6 @@ export const EmbeddedHiglassActions = React.memo(function EmbeddedHiglassActions
         </div>
     );
 });
-EmbeddedHiglassActions.defaultProps = {
-    'parentComponentType' : BasicUserContentBody,
-    'showDescription' : true,
-    'constrainDescription' : false
-};
 
 
 export class ExpandableStaticHeader extends OverviewHeadingContainer {

--- a/src/encoded/static/components/static-pages/components/BasicUserContentBody.js
+++ b/src/encoded/static/components/static-pages/components/BasicUserContentBody.js
@@ -50,7 +50,7 @@ export class BasicUserContentBody extends React.PureComponent {
     render(){
         const { context, markdownCompilerOptions, parentComponentType, windowWidth } = this.props;
         const { hasError } = this.state;
-        const { content, filetype } = context || {};
+        const { content, content_as_html, filetype } = context || {};
         if (hasError){
             return (
                 <div className="error">
@@ -61,7 +61,7 @@ export class BasicUserContentBody extends React.PureComponent {
 
         var itemType = this.itemType();
         if (itemType === 'StaticSection' || itemType === 'CustomSection') {
-            return <BasicStaticSectionBody {...{ content, filetype, markdownCompilerOptions, windowWidth, placeholderReplacementFxn }} />;
+            return <BasicStaticSectionBody {...{ content, content_as_html, filetype, markdownCompilerOptions, windowWidth, placeholderReplacementFxn }} />;
         } else if (itemType === 'HiglassViewConfig') {
             return (
                 <React.Fragment>

--- a/src/encoded/static/components/static-pages/components/UserContentBodyList.js
+++ b/src/encoded/static/components/static-pages/components/UserContentBodyList.js
@@ -9,7 +9,14 @@ import { BasicUserContentBody, ExpandableStaticHeader } from './BasicUserContent
 
 
 export const UserContentBodyList = React.memo(function UserContentBodyList(props){
-    const { contents, headerElement, headerProps, allCollapsible, href, hideTitles } = props;
+    const {
+        contents,
+        headerElement = 'h4',
+        headerProps = { 'className': 'text-500 mt-2' },
+        allCollapsible = null,
+        href,
+        hideTitles = false
+    } = props;
     if (!contents || !Array.isArray(contents) || contents.length === 0) return null;
 
     const renderedContent = _.filter(_.map(contents, function(c,i,all){
@@ -32,11 +39,3 @@ export const UserContentBodyList = React.memo(function UserContentBodyList(props
 
     return <div className="static-content-list">{ renderedContent }</div>;
 });
-UserContentBodyList.defaultProps = {
-    'hideTitles'        : false,
-    'headerElement'     : 'h4',
-    'headerProps'       : {
-        'className'         : 'text-500 mt-2'
-    },
-    'allCollapsible'    : null
-};

--- a/src/encoded/static/components/static-pages/placeholders/BasicCarousel.js
+++ b/src/encoded/static/components/static-pages/placeholders/BasicCarousel.js
@@ -30,7 +30,7 @@ function Arrows() {
             </div>
         </div>
     );
-};
+}
 
 /** @see https://www.npmjs.com/package/nuka-carousel for documentation of all props/options allowed */
 const defaultCarouselOptions = {

--- a/src/encoded/static/components/static-pages/placeholders/ExperimentSetMatrix.js
+++ b/src/encoded/static/components/static-pages/placeholders/ExperimentSetMatrix.js
@@ -159,7 +159,7 @@ export class ExperimentSetMatrix extends React.PureComponent {
         'titleMap': PropTypes.object,
         'columnSubGroupingOrder': PropTypes.arrayOf(PropTypes.string),
         'additionalData': PropTypes.object
-    }
+    };
 
     static convertResult(result, dataSource, fieldChangeMap, valueChangeMap, statusStateTitleMap, fallbackNameForBlankField){
 
@@ -340,42 +340,40 @@ export class ExperimentSetMatrix extends React.PureComponent {
         // const valueChangeMap = propValueChangeMap || { "4DN" : {}, "ENCODE" : {} };
 
         return (sectionKeys.length > 0) ? (
-            <React.Fragment>
-                <div className="static-section joint-analysis-matrix">
-                    <div className="row">
-                        {_.map(sectionKeys, (key) => {
-                            const resultKey = key + "_results";
-                            const url = queries[key] && queries[key].url;
-                            const className =  (sectionStyle && sectionStyle[key] && sectionStyle[key]['sectionClassName']) || "col-md-4";
-                            const rowLabelListingProportion = (sectionStyle && sectionStyle[key] && sectionStyle[key]['rowLabelListingProportion']) || "balanced";
-                            const additional = (additionalData && additionalData[key] );
-                            return (
-                                <div className={'col-12 ' + className}>
-                                    {(headerFor && headerFor[key]) || (<h3 className="mt-2 mb-0 text-300">{key}</h3>)}
-                                    <VisualBody
-                                        {..._.pick(this.props, 'headerColumnsOrder',
-                                            'titleMap', 'statePrioritizationForGroups', 'fallbackNameForBlankField', 'headerPadding')}
-                                        queryUrl={url}
-                                        groupingProperties={groupingProperties[key]}
-                                        fieldChangeMap={fieldChangeMap[key]}
-                                        valueChangeMap={valueChangeMap[key]}
-                                        columnGrouping={columnGrouping[key]}
-                                        additionalData={additional}
-                                        duplicateHeaders={false}
-                                        columnSubGrouping="state"
-                                        rowLabelListingProportion={rowLabelListingProportion}
-                                        // eslint-disable-next-line react/destructuring-assignment
-                                        results={this.state[resultKey]}
-                                        //defaultDepthsOpen={[true, false, false]}
-                                        //keysToInclude={[]}
-                                    />
-                                </div>
-                            );
-                        }
-                        )}
-                    </div>
+            <div className="static-section joint-analysis-matrix">
+                <div className="row">
+                    {_.map(sectionKeys, (key) => {
+                        const resultKey = key + "_results";
+                        const url = queries[key] && queries[key].url;
+                        const className = (sectionStyle && sectionStyle[key] && sectionStyle[key]['sectionClassName']) || "col-md-4";
+                        const rowLabelListingProportion = (sectionStyle && sectionStyle[key] && sectionStyle[key]['rowLabelListingProportion']) || "balanced";
+                        const additional = (additionalData && additionalData[key]);
+                        return (
+                            <div className={'col-12 ' + className}>
+                                {(headerFor && headerFor[key]) || (<h3 className="mt-2 mb-0 text-300">{key}</h3>)}
+                                <VisualBody
+                                    {..._.pick(this.props, 'headerColumnsOrder',
+                                        'titleMap', 'statePrioritizationForGroups', 'fallbackNameForBlankField', 'headerPadding')}
+                                    queryUrl={url}
+                                    groupingProperties={groupingProperties[key]}
+                                    fieldChangeMap={fieldChangeMap[key]}
+                                    valueChangeMap={valueChangeMap[key]}
+                                    columnGrouping={columnGrouping[key]}
+                                    additionalData={additional}
+                                    duplicateHeaders={false}
+                                    columnSubGrouping="state"
+                                    rowLabelListingProportion={rowLabelListingProportion}
+                                    // eslint-disable-next-line react/destructuring-assignment
+                                    results={this.state[resultKey]}
+                                    //defaultDepthsOpen={[true, false, false]}
+                                    //keysToInclude={[]}
+                                />
+                            </div>
+                        );
+                    }
+                    )}
                 </div>
-            </React.Fragment>
+            </div>
         ) : (<em>Not Available</em>);
     }
 

--- a/src/encoded/static/components/static-pages/placeholders/MdSortableTable.js
+++ b/src/encoded/static/components/static-pages/placeholders/MdSortableTable.js
@@ -464,15 +464,17 @@ class SortableTableHeaderItem extends React.PureComponent {
         setHeaderWidths: PropTypes.func.isRequired,
         index: PropTypes.number.isRequired,
         width: PropTypes.number.isRequired,
-    }
+    };
 
     static defaultProps = {
         sortable: true
-    }
+    };
 
     constructor(props){
         super(props);
         _.bindAll(this, 'onDrag', 'onStop');
+        // workaround for "findDOMNode is deprecated in StrictMode" error: https://stackoverflow.com/a/63603903
+        this.nodeRef = React.createRef(null);
     }
 
     onDrag(event, res){
@@ -521,8 +523,8 @@ class SortableTableHeaderItem extends React.PureComponent {
                     <span className="column-title">{header}</span>
                     <span className={"column-sort-icon" + (['asc', 'desc'].indexOf(sorting) > -1 ? ' active' : '')}>{sortIcon}</span>
                 </div>
-                <Draggable position={{ x: width, y: 0 }} axis="x" onDrag={this.onDrag} onStop={this.onStop}>
-                    <div className="width-adjuster" />
+                <Draggable position={{ x: width, y: 0 }} axis="x" onDrag={this.onDrag} onStop={this.onStop} nodeRef={this.nodeRef}>
+                    <div className="width-adjuster" ref={this.nodeRef} />
                 </Draggable>
             </div>
         );

--- a/src/encoded/static/components/static-pages/placeholders/SlideCarousel.js
+++ b/src/encoded/static/components/static-pages/placeholders/SlideCarousel.js
@@ -13,13 +13,14 @@ function Arrows() {
     const enablePrevNavButton = allowWrap || currentPage > 0;
     const enableNextNavButton = allowWrap || currentPage < totalPages - 1;
 
+    // weird but autocomplete="off" fixes the hydration error: https://github.com/vercel/next.js/discussions/21999#discussioncomment-6315670
     return (
         <div>
-            <button type="button" className={`slider-control slider-control-centerleft ${!enablePrevNavButton ? 'slider-control-disabled' : ''}`} onClick={goBack} disabled={!enablePrevNavButton}>Prev</button>
-            <button type="button" className={`slider-control slider-control-centerright ${!enableNextNavButton ? 'slider-control-disabled' : ''}`} onClick={goForward} disabled={!enableNextNavButton}>Next</button>
+            <button type="button" className={`slider-control slider-control-centerleft ${!enablePrevNavButton ? 'slider-control-disabled' : ''}`} onClick={goBack} disabled={!enablePrevNavButton} autoComplete="off">Prev</button>
+            <button type="button" className={`slider-control slider-control-centerright ${!enableNextNavButton ? 'slider-control-disabled' : ''}`} onClick={goForward} disabled={!enableNextNavButton} autoComplete="off">Next</button>
         </div>
     );
-};
+}
 
 export class SlideCarousel extends React.PureComponent {
 

--- a/src/encoded/static/components/util/file.js
+++ b/src/encoded/static/components/util/file.js
@@ -71,7 +71,20 @@ export function extendFile(file, experiment, experimentSet, source){
 
 /** Uses different defaultProps.canDownloadStatuses, specific to project */
 export function FileDownloadButtonAuto(props){
-    const { result, context = null, session = false } = props;
+    const {
+        result,
+        context = null,
+        session = false,
+        canDownloadStatuses = [
+            'uploaded',
+            'pre-release',
+            'released',
+            'replaced',
+            'submission in progress',
+            'released to project',
+            'archived'
+        ]
+    } = props;
     const onClick = useMemo(function(){
         return function(evt){
             if (session){
@@ -82,16 +95,5 @@ export function FileDownloadButtonAuto(props){
         };
     }, [result, context, session]);
     const tooltip = !session ? 'Log in or create an account to download this file' : null;
-    return <FileDownloadButtonAutoOriginal {...props} onClick={onClick} tooltip={tooltip} />;
+    return <FileDownloadButtonAutoOriginal {..._.omit(props, 'canDownloadStatuses')} canDownloadStatuses={canDownloadStatuses} onClick={onClick} tooltip={tooltip} />;
 }
-FileDownloadButtonAuto.defaultProps = {
-    'canDownloadStatuses' : [
-        'uploaded',
-        'pre-release',
-        'released',
-        'replaced',
-        'submission in progress',
-        'released to project',
-        'archived'
-    ]
-};

--- a/src/encoded/static/components/viz/BarPlot/Chart.js
+++ b/src/encoded/static/components/viz/BarPlot/Chart.js
@@ -379,7 +379,7 @@ export class Chart extends React.PureComponent {
             );
         }
 
-    }
+    };
 
     /**
      * Parses props.experiment_sets and/or props.filtered_experiment_sets, depending on props.showType, aggregates experiments into fields,

--- a/src/encoded/static/components/viz/BarPlot/ViewContainer.js
+++ b/src/encoded/static/components/viz/BarPlot/ViewContainer.js
@@ -208,8 +208,8 @@ class Bar extends React.PureComponent {
  */
 export class ViewContainer extends React.Component {
 
-    static Bar = Bar
-    static BarSection = BarSection
+    static Bar = Bar;
+    static BarSection = BarSection;
 
     static defaultProps = {
         'canBeHighlighted' : true
@@ -253,10 +253,10 @@ export class ViewContainer extends React.Component {
                 );
                 console.warn(warnMsg);
             }
-            // error-level message for sentry.io 
+            // error-level message for sentry.io
             const barAggregateTypeCount = _.reduce(bars, function (sum, bar) {
                 if (bar.bars && Array.isArray(bar.bars)) {
-                    _.forEach(bar.bars, (b) => { sum = sum + (b[aggregateType] || 0) });
+                    _.forEach(bar.bars, (b) => { sum = sum + (b[aggregateType] || 0); });
                 }
                 return sum;
             }, 0);

--- a/src/encoded/static/components/viz/BarPlot/ViewContainer.js
+++ b/src/encoded/static/components/viz/BarPlot/ViewContainer.js
@@ -219,6 +219,7 @@ export class ViewContainer extends React.Component {
         super(props);
         this.verifyCounts = this.verifyCounts.bind(this);
         this.renderBars = this.renderBars.bind(this);
+        this.nodeRef = React.createRef();
     }
 
     componentDidMount(){
@@ -282,7 +283,7 @@ export class ViewContainer extends React.Component {
         return _.map(bars.sort(function(a,b){ // key will be term or name, if available
             return (a.term || a.name) < (b.term || b.name) ? -1 : 1;
         }), (d,i,a) =>
-            <CSSTransition classNames="barplot-transition" unmountOnExit timeout={{ enter: 10, exit: 750 }} key={d.term || d.name || i}>
+            <CSSTransition classNames="barplot-transition" unmountOnExit timeout={{ enter: 10, exit: 750 }} key={d.term || d.name || i} nodeRef={this.nodeRef}>
                 <Bar key={d.term || d.name || i} node={d}
                     showBarCount={true}
                     {..._.pick(this.props, 'selectedParentTerm', 'selectedTerm', 'hoverParentTerm', 'hoverTerm', 'styleOptions',

--- a/src/encoded/static/components/viz/BarPlot/ViewContainer.js
+++ b/src/encoded/static/components/viz/BarPlot/ViewContainer.js
@@ -277,15 +277,14 @@ export class ViewContainer extends React.Component {
      * @returns {Component[]} Array of 'Bar' React Components.
      */
     renderBars(){
-        var { bars, onNodeMouseEnter, onNodeMouseLeave, onNodeClick } = this.props,
-            barsToRender, currentBars;
+        const { bars, onNodeMouseEnter, onNodeMouseLeave, onNodeClick } = this.props;
 
         return _.map(bars.sort(function(a,b){ // key will be term or name, if available
             return (a.term || a.name) < (b.term || b.name) ? -1 : 1;
         }), (d,i,a) =>
             <CSSTransition classNames="barplot-transition" unmountOnExit timeout={{ enter: 10, exit: 750 }} key={d.term || d.name || i}>
                 <Bar key={d.term || d.name || i} node={d}
-                    showBarCount={true /*!allExpsBarDataContainer */}
+                    showBarCount={true}
                     {..._.pick(this.props, 'selectedParentTerm', 'selectedTerm', 'hoverParentTerm', 'hoverTerm', 'styleOptions',
                         'aggregateType', 'showType', 'canBeHighlighted')}
                     onBarPartMouseEnter={onNodeMouseEnter} onBarPartMouseLeave={onNodeMouseLeave} onBarPartClick={onNodeClick} />
@@ -294,7 +293,7 @@ export class ViewContainer extends React.Component {
     }
 
     render(){
-        var { topLevelField, width, height, bars } = this.props,
+        var { topLevelField, width, height, leftAxis, bottomAxis } = this.props,
             anyHiddenOtherTerms = topLevelField.other_doc_count || _.any(_.values(topLevelField.terms), function(tV){
                 return tV.other_doc_count;
             });
@@ -324,10 +323,10 @@ export class ViewContainer extends React.Component {
                         <p className="mb-0">* Only up to the top 30 terms are shown.</p>
                     </div>
                     : null }
-                { this.props.leftAxis }
+                { leftAxis }
                 {/* allExpsBarDataContainer && allExpsBarDataContainer.component */}
                 <TransitionGroup>{ this.renderBars() }</TransitionGroup>
-                { this.props.bottomAxis }
+                { bottomAxis }
             </div>
         );
 

--- a/src/encoded/static/components/viz/QuickInfoBar.js
+++ b/src/encoded/static/components/viz/QuickInfoBar.js
@@ -1,11 +1,8 @@
 'use strict';
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import _ from 'underscore';
-import url from 'url';
 import memoize from 'memoize-one';
-import ReactTooltip from 'react-tooltip';
 import { console, searchFilters, analytics, memoizedUrlParse,  } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { ActiveFiltersBar } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/ActiveFiltersBar';
 import { Filters, navigate, Schemas } from './../util';
@@ -205,7 +202,7 @@ export default class QuickInfoBar extends React.PureComponent {
     }
 
     renderHoverBar(){
-        const { context, browseBaseState, href, schemas } = this.props;
+        const { context, schemas } = this.props;
         const { show, reallyShow } = this.state;
         const browseBaseParams = navigate.getBrowseBaseParams();
         const filters = QuickInfoBar.contextFiltersToInclude(context.filters, browseBaseParams);
@@ -255,8 +252,7 @@ export default class QuickInfoBar extends React.PureComponent {
     }
 }
 
-const BrowseBaseStateToggleCol = React.memo(function(props){
-    const { browseBaseState, isLoading, onToggle } = props;
+const BrowseBaseStateToggleCol = React.memo(function({ browseBaseState, isLoading, onToggle }){
     const checked = browseBaseState === 'all';
     return (
         <div className="col-4 text-right browse-base-state-toggle-container">

--- a/src/encoded/static/components/viz/components/Legend.js
+++ b/src/encoded/static/components/viz/components/Legend.js
@@ -100,7 +100,7 @@ class Term extends React.Component {
  * @prop {Object[]} terms - Terms which belong to this field, in the form of objects.
  */
 const Field = React.memo(function Field(props){
-    const { field, title, name, includeFieldTitle, terms } = props;
+    const { field, title, name, includeFieldTitle = true, terms } = props;
     return (
         <div className="field" data-field={field} onMouseLeave={vizUtil.unhighlightTerms.bind(this, field)}>
             { includeFieldTitle ?
@@ -114,7 +114,6 @@ const Field = React.memo(function Field(props){
         </div>
     );
 });
-Field.defaultProps = { 'includeFieldTitle' : true };
 
 
 class LegendViewContainer extends React.Component {

--- a/src/encoded/static/components/viz/components/RotatedLabel.js
+++ b/src/encoded/static/components/viz/components/RotatedLabel.js
@@ -35,8 +35,10 @@ const commonDefaultProps = {
 const RotatedLabelAxis = React.memo(function RotatedLabelAxis(props){
     const {
         placementWidth, placementHeight, angle, lineHeight, extraHeight, maxLabelWidth, append, debug,
-        labels, labelClassName, className, x, y, isMounted, deRotateAppend, term : propTerm, field : propField,
-        appendOffset
+        appendOffset, labelClassName = null, className = null, x, y, isMounted, deRotateAppend, term: propTerm, field: propField,
+        labels = [
+            { name: "Label1" }, { name: "Label 2 Extra Long Ok Maybe Longer", term: 'test2' }
+        ]
     } = props;
     const maxTextHeight = RotatedLabel.maxTextHeight(placementWidth, lineHeight, extraHeight || 0);
     const labelWidth = Math.min(RotatedLabel.maxHypotenuse(placementHeight, angle), maxLabelWidth || 1000);
@@ -68,14 +70,6 @@ const RotatedLabelAxis = React.memo(function RotatedLabelAxis(props){
             }) }
         </div>
     );
-});
-RotatedLabelAxis.defaultProps = _.extend({}, commonDefaultProps, {
-    'labels' : [
-        { name : "Label1" }, { name : "Label 2 Extra Long Ok Maybe Longer", term: 'test2' }
-    ],
-    'labelClassName' : null,
-    //'availWidth' : 200, // ToDo calculate X coord positions on labels along this 0...N range if not present.
-    'className' : null,
 });
 
 

--- a/src/encoded/static/libs/react-middleware.js
+++ b/src/encoded/static/libs/react-middleware.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import fs from 'fs';
-import { store, mapStateToProps } from './../store';
+import { store, mapStateToProps, batchDispatch } from './../store';
 import { Provider, connect } from 'react-redux';
 // We get a different console w. different methods & properties on server-side.
 import { console as browserConsole, object, JWT } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
@@ -48,18 +48,7 @@ export function appRenderFxn(body, res) {
         disp_dict.alerts.push(Alerts.LoggedOut);
     }
     // End JWT token grabbing
-    if (disp_dict.context) {
-        store.dispatch({ type: 'SET_CONTEXT', payload: disp_dict.context });
-    }
-    if (disp_dict.href) {
-        store.dispatch({ type: 'SET_HREF', payload: disp_dict.href });
-    }
-    if (disp_dict.lastCSSBuildTime) {
-        store.dispatch({ type: 'SET_LAST_CSS_BUILD_TIME', payload: disp_dict.lastCSSBuildTime });
-    }
-    if (disp_dict.alerts) {
-        store.dispatch({ type: 'SET_ALERTS', payload: disp_dict.alerts });
-    }
+    batchDispatch(store, disp_dict);
 
     let AppWithReduxProps = connect(mapStateToProps)(App);
     let markup;

--- a/src/encoded/static/scss/encoded/modules/_static-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_static-pages.scss
@@ -842,7 +842,7 @@
     }
 }
 
-.static-section-entry {
+.static-section-entry, .static-content-item {
 
 	&:not([id]) .section-title > i.icon-link {
 		display: none;

--- a/src/encoded/static/scss/encoded/modules/_static-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_static-pages.scss
@@ -870,6 +870,7 @@
 	// since rst-to-html non-customizable,
 	// tweak some css rules to display h3/h4 like h4/h5 respectively
 	// use the same styles for raw HTML
+	.markdown-container,
 	.rst-container,
 	.html-container {
 		h3 {

--- a/src/encoded/tests/data/master-inserts/static_section.json
+++ b/src/encoded/tests/data/master-inserts/static_section.json
@@ -395,7 +395,10 @@
         "name" : "help.user-guide.data-organization.introduction",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b011",
         "file" : "/docs/source/introduction.rst",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     }, {
         "name" : "help.user-guide.data-organization.carousel-place-holder",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b012",
@@ -408,7 +411,10 @@
         "name" : "help.user-guide.data-organization.introduction2",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b013",
         "file" : "/docs/source/introduction2.rst",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
 
 
@@ -416,7 +422,10 @@
         "name" : "help.user-guide.account-creation.account_creation",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b014",
         "file" : "/docs/source/account_creation.rst",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
 
 
@@ -424,7 +433,10 @@
         "name" : "help.user-guide.getting-started.getting_started",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b015",
         "file" : "/docs/source/getting_started.md",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
 
 
@@ -432,7 +444,10 @@
         "name" : "help.submitter-guide.biosample-metadata.metadata",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b016",
         "file" : "/docs/source/biosample_metadata.md",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
 
 
@@ -440,7 +455,10 @@
         "name" : "help.submitter-guide.web-submission.web_submission",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b017",
         "file" : "/docs/source/web_submission.md",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
 
 
@@ -448,19 +466,28 @@
         "name" : "help.submitter-guide.spreadsheet.excel_submission",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b018",
         "file" : "/docs/source/excel_submission.md",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
     {
         "name" : "help.submitter-guide.spreadsheet.schema_info",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b019",
         "file" : "/docs/source/schema_info.md",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
     {
         "name" : "help.submitter-guide.rest-api.rest_api_submission",
         "uuid" : "442c8aa0-dc6c-43d7-814a-854af460b020",
         "file" : "/docs/source/rest_api_submission.md",
-        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
+        "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
+        "options": {
+            "convert_ext_links": true
+        }
     },
 
 
@@ -471,7 +498,8 @@
         "title" : "in situ Hi-C / Dilution Hi-C",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -481,7 +509,8 @@
         "title" : "DNase Hi-C / Micro-C",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -491,7 +520,8 @@
         "title" : "CHIA-pet / PLAC-seq",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -501,7 +531,8 @@
         "title" : "CHIP-seq / CUT&RUN",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -511,7 +542,8 @@
         "title" : "ATAC-seq",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -521,7 +553,8 @@
         "title" : "TrAC-loop",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -531,7 +564,8 @@
         "title" : "RNA-seq",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -541,7 +575,8 @@
         "title" : "NAD-seq",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -551,7 +586,8 @@
         "title" : "DAM-ID-seq",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         }
     },
     {
@@ -560,7 +596,8 @@
         "title" : "TSA-seq",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -570,7 +607,8 @@
         "title" : "Repli-seq",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -580,7 +618,8 @@
         "title" : "Capture Hi-C",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -590,7 +629,8 @@
         "title" : "DNA-FiSH",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -600,7 +640,8 @@
         "title" : "sci-Hi-C",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -610,7 +651,8 @@
         "title" : "DNA SPRITE",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -620,7 +662,8 @@
         "title" : "GAM",
         "body" : "Lorem ipsum dolor amet offal plaid readymade unicorn kombucha skateboard. Direct trade pop-up salvia organic. Truffaut lomo food truck man bun gastropub hella portland seitan post-ironic quinoa swag. Franzen flexitarian pour-over fam ennui. Freegan fanny pack tumeric vaporware tacos gluten-free quinoa +1 activated charcoal portland pok pok chartreuse actually. Church-key unicorn brooklyn migas paleo wolf.\n\nTaxidermy celiac scenester sustainable disrupt vaporware. Authentic chicharrones direct trade narwhal VHS iceland. Messenger bag intelligentsia seitan quinoa, hashtag YOLO cornhole VHS bitters. Gochujang sriracha messenger bag, mlkshk lyft authentic sartorial vinyl flexitarian godard green juice vice fam roof party jianbing.",
         "options" : {
-            "filetype" : "md"
+            "filetype" : "md",
+            "convert_ext_links": true
         },
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b"
     },
@@ -635,7 +678,8 @@
         "body" : "There is no account registered with the provided email. Access is restricted to members of the 4DN consortium.<br/><b>New Users:</b> If you would like to get started submitting data, please see this Help section for <b><a href=\"/help/account-creation\">creating an account</a></b>.",
         "award": "b0b9c607-f8b4-4f02-93f4-9895b461334b",
         "options" : {
-            "filetype" : "html"
+            "filetype" : "html",
+            "convert_ext_links": true
         }
     },
 
@@ -695,7 +739,8 @@
         "body" : "<ol class='text-small mb-0'><li><a href='https://data.4dnucleome.org/release-updates?update_tag=2018_01_internal_JA'>First Data Freeze (January 2018)</a></li><li><a href='https://data.4dnucleome.org/release-updates?update_tag=2018_01updates_internal_JA_toJune'>June Interim Update (January-June 2018)</a></li></ol>",
         "status" : "released",
         "options" : {
-            "filetype" : "html"
+            "filetype" : "html",
+            "convert_ext_links": true
         }
     },
 

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -59,6 +59,7 @@ static_content_embed_list = [
     "static_headers.*",            # Type: UserContent, may have differing properties
     "static_content.content.@type",
     "static_content.content.content",
+    "static_content.content.content_as_html",
     "static_content.content.name",
     "static_content.content.title",
     "static_content.content.status",

--- a/src/encoded/types/user_content.py
+++ b/src/encoded/types/user_content.py
@@ -357,13 +357,7 @@ def get_remote_file_contents(uri):
 
 def post_process_markdown_html(markdown_html, convert_links, ref_domain, custom_wrapper = 'div'):
     # default
-    output = markdown_html
-
-    # check content has any header, if yes wrap it with custom tag
-    # TODO: replace Regex pattern with BeautifulSoup methods
-    header_pattern = re.compile(r'<h[1-6]>.*?<\/h[1-6]>', re.IGNORECASE)
-    if header_pattern.search(output):
-        output = f'<{custom_wrapper} class="markdown-container">{output}</{custom_wrapper}>'
+    output = f'<{custom_wrapper} class="markdown-container">{markdown_html}</{custom_wrapper}>'
 
      # Parse the HTML content with BeautifulSoup
     soup = BeautifulSoup(output, 'html.parser')

--- a/src/encoded/types/user_content.py
+++ b/src/encoded/types/user_content.py
@@ -364,7 +364,23 @@ def convert_markdown_to_html(markdown_text, custom_wrapper = 'div'):
     # check content has any header, if yes wrap it with custom tag
     header_pattern = re.compile(r'<h[1-6]>.*?<\/h[1-6]>', re.IGNORECASE)
     if header_pattern.search(html_output):
-        html_output = f'<{custom_wrapper}>{html_output}</{custom_wrapper}>'
+        html_output = f'<{custom_wrapper} class="markdown-container">{html_output}</{custom_wrapper}>'
+
+     # Parse the HTML content with BeautifulSoup
+    soup = BeautifulSoup(html_output, 'html.parser')
+
+    # Find all <pre><code>XYZ</code></pre> patterns and convert to <pre>XYZ</pre>
+    for code_tag in soup.find_all('code'):
+        # Find the nearest parent <pre> tag
+        pre_tag = code_tag.find_parent('pre')
+    
+        if pre_tag:
+            # Append the content of the <code> tag to the <pre> tag
+            pre_tag.append(code_tag.string)      
+            # Remove the <code> tag
+            code_tag.decompose()
+
+    html_output = str(soup)
 
     return html_output
 


### PR DESCRIPTION
Although this pull request primarily covers the transition from React 17 to React 18, it also includes updates for Redux, Auth0, and other third-party integrations heavily used in the portal to versions compatible with React 18. (Trello [1](https://trello.com/c/WqGmNmPz) & [2](https://trello.com/c/WqGmNmPz))

### Upgrades:

- React v17 to v18
- Redux v4 to v5 (there are breaking changes in store and dispatchers. SPC is updated to support both new and legacy usage - [PR](https://github.com/4dn-dcic/shared-portal-components/pull/259))
- HiGlass (React 18-compatible)
- Vitessce (React 18-compatible)
- MicroMeta App (released a new stable beta version for 4DN)
- Auth0-Lock v11 to v12 (it was on the waitlist for a long time since v12 was not supporting React v17)
- Gulp.js v4 to v5
- React-workflow-viz (animation updates to eliminate findDOMNode errors)

### Misc:

- User Content updates to fix markdown, jsx, and HTML static section rendering ([Trello](https://trello.com/c/WqGmNmPz))
- Improve ExperimentSetDetailPane's raw/processed/supplementary file panels ([Trello](https://trello.com/c/F7syVXo8))