### PR TITLE
Ajs rb wfschema v

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ fourfront
 Change Log
 ----------
 
+7.10.1
+=====
+
+* Bug fix to revert schema version of workflow.json back to 7 
+
+
 7.10.0
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "7.10.0"
+version = "7.10.1"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/workflow.json
+++ b/src/encoded/schemas/workflow.json
@@ -27,7 +27,7 @@
     ],
     "properties": {
         "schema_version": {
-            "default": "8"
+            "default": "7"
         },
         "accession": {
             "accessionType": "WF"


### PR DESCRIPTION
Reverted workflow.json schema version back to 7 (from 8) as an upgrader was not added and schema changes were just addition of new properties so upgrade was not truly needed.