### PR TITLE
new enum for imaging labels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Change Log
 ----------
 
 
+8.1.5
+=====
+
+* New enum "ATTO 550" in imaging_path labels.
+
+
 8.1.4
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "8.1.4"
+version = "8.1.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/imaging_path.json
+++ b/src/encoded/schemas/imaging_path.json
@@ -95,6 +95,7 @@
                     "Alexa Fluor 647",
                     "Alexa Fluor 700",
                     "Alexa Fluor 750",
+                    "ATTO 500",
                     "ATTO 565",
                     "ATTO 633",
                     "ATTO 647N",


### PR DESCRIPTION
Added a new suggested enum ATTO 550 under imaging label from Marcello's FISH experiment. Purposely added it under suggested enum as oppose to ignore enum.