### PR TITLE
Fix bar chart's x-axis width issue on mobile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Change Log
 8.4.2
 =====
 
+`Fix x-axis width issue on mobile <https://github.com/4dn-dcic/fourfront/pull/1914>`_
+
 * Fix an issue with the x-axis width affecting mobile layout, ensuring proper scaling and alignment on smaller screens.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,9 +9,9 @@ Change Log
 8.4.2
 =====
 
-`Fix x-axis width issue on mobile <https://github.com/4dn-dcic/fourfront/pull/1914>`_
+`Fix bar chart's x-axis dropdown width issue <https://github.com/4dn-dcic/fourfront/pull/1914>`_
 
-* Fix an issue with the bar chart's x-axis width affecting mobile layout, ensuring proper scaling and alignment on smaller screens.
+* Bug fix: The x-axis dropdown of the bar chart displayed on the home page and browse view is not correctly rendered on small and mid-size screens
 
 
 8.4.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 
 `Fix x-axis width issue on mobile <https://github.com/4dn-dcic/fourfront/pull/1914>`_
 
-* Fix an issue with the x-axis width affecting mobile layout, ensuring proper scaling and alignment on smaller screens.
+* Fix an issue with the bar chart's x-axis width affecting mobile layout, ensuring proper scaling and alignment on smaller screens.
 
 
 8.4.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ fourfront
 Change Log
 ----------
 
+8.4.2
+=====
+
+* Fix an issue with the x-axis width affecting mobile layout, ensuring proper scaling and alignment on smaller screens.
+
+
 8.4.1
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "8.4.1"
+version = "8.4.2"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
+++ b/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
@@ -413,11 +413,11 @@ export class UIControlsWrapper extends React.PureComponent {
                                 showType={showState} />
                         </div>
                         <div className="x-axis-right-label">
-                            <div className="row flex-nowrap">
-                                <div className="col-3" style={{ width : 51 }}>
+                            <div className="row">
+                                <div className="col-12 col-md-3">
                                     <h6 className="dropdown-heading">X Axis</h6>
                                 </div>
-                                <div className="col-9 pull-right" style={{ "width" : (layout.gridContainerWidth(windowWidth) * (windowGridSize !== 'xs' ? 0.25 : 1)) + 5 - 52 }}>
+                                <div className="col-12 col-md-9 pull-right">
                                     <DropdownButton id="select-barplot-field-0" onSelect={this.handleFirstFieldSelect}
                                         disabled={isLoadingChartData} title={xAxisDropdownTitle} variant={btnVariant}
                                         onToggle={this.handleDropDownXAxisFieldToggle}>

--- a/src/encoded/static/scss/encoded/modules/_charts.scss
+++ b/src/encoded/static/scss/encoded/modules/_charts.scss
@@ -553,20 +553,27 @@
         }
         
         .x-axis-right-label {
-            > .row > div {
-                &:last-child {
-                    padding-left: 5px;
-                }
-                &:first-child {
-                    padding-right: 5px;
-                }
+            @include media-breakpoint-up(md){
+                > .row > div {
+                    &:last-child {
+                        padding-left: 5px;
+                    }
+                    &:first-child {
+                        padding-right: 5px;
+                    }
+                }   
             }
+
             .dropdown-heading {
                 margin: 0;
                 line-height: 33px;
                 white-space: nowrap;
                 text-align: right;
                 font-weight: 400;
+
+                @include media-breakpoint-down(md){
+                    text-align: left;
+                }
             }
         }
         .dropdown {


### PR DESCRIPTION
Ticket: [Trello](https://trello.com/c/9baxIotI/367-browse-chart-x-axis-dropdown-not-correctyl-rendered-in-small-size-screens-in-4dn)

This PR addresses the x-axis width issue that was affecting the mobile layout. The changes ensure proper scaling and alignment on smaller screens.

**Before:**

<img width="724" alt="Screen Shot 2024-10-22 at 15 59 33" src="https://github.com/user-attachments/assets/270da310-1b73-43ef-b7db-bc8d8713a844">


**After:**

<img width="721" alt="Screen Shot 2024-10-22 at 16 05 10" src="https://github.com/user-attachments/assets/8e3dd08e-c561-4ac1-96b3-5b3a17fa60e8">
