### PR TITLE
Enable React Tooltip for Disabled Buttons

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ Change Log
 ----------
 
 
+8.4.4
+=====
+
+`Enable React Tooltip for Disabled Buttons <https://github.com/4dn-dcic/fourfront/pull/1916>`_
+
+* Resolved an issue where **React Tooltip** was not displayed for `button` elements with the `disabled` attribute.
+* Updated CSS for disabled buttons:
+    - `cursor` is now set to `default`.
+    - `pointer-events` is now set to `auto`.
+* Tooltips are now consistently visible for disabled buttons.
+
+
 8.4.3
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "8.4.3"
+version = "8.4.4"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
+++ b/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
@@ -25,6 +25,7 @@
         transform: translate(0,-0.45px);
     }
 
+    &.disabled,
     &:disabled {
         cursor: default;
         pointer-events: auto;

--- a/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
+++ b/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
@@ -24,6 +24,11 @@
         vertical-align: middle;
         transform: translate(0,-0.45px);
     }
+
+    &:disabled {
+        cursor: default;
+        pointer-events: auto;
+    }
 }
 
 .btn.btn-lg {

--- a/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
+++ b/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
@@ -29,6 +29,10 @@
     &:disabled {
         cursor: default;
         pointer-events: auto;
+
+        &:active {
+            pointer-events: none;
+        }
     }
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/QtXRkHEe

This PR addresses an issue where **React Tooltip** was not displayed for `button` elements with the `disabled` attribute. 

By updating the CSS properties for disabled buttons:

- `cursor` is set to `default`.
- `pointer-events` is set to `auto`.

These changes ensure that tooltips are visible even for disabled buttons.