### PR TITLE
Add tests to verify the presence and non-empty content of `<pre>` elements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ fourfront
 Change Log
 ----------
 
+8.4.5
+=====
+
+`PR 1917: Add tests to verify the presence and non-empty content of <pre> elements <https://github.com/4dn-dcic/fourfront/pull/1917>`_
+
+* Update: Added tests to verify the presence and non-empty content of `<pre>` elements inside static section
+
 
 8.4.4
 =====

--- a/deploy/post_deploy_testing/cypress/e2e/01b_static_content.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/01b_static_content.cy.js
@@ -85,14 +85,14 @@ describe('Static Page & Content Tests', function () {
 
                             // Verify the presence of <pre> elements and ensure each one is not empty.
                             cy.document().then((doc) => {
-                                const elements = doc.querySelectorAll('.rst-container > div > pre, .html-container > div > pre');
+                                const elements = doc.querySelectorAll('.rst-container > div > pre, .html-container > div > pre, .markdown-container > div > pre');
                                 if (elements.length > 0) {
-                                    cy.get('.rst-container > div > pre, .html-container > div > pre').each(($pre) => {
+                                    cy.get('.rst-container > div > pre, .html-container > div > pre, .markdown-container > div > pre').each(($pre) => {
                                         const textContent = $pre.text().trim();
                                         expect(textContent).to.not.be.empty;
                                     });
                                 } else {
-                                    cy.log('No <pre> elements found under .rst-container > div or .html-container > div');
+                                    cy.log('No <pre> elements found under .rst-container > div or .html-container > div, .markdown-container > div > pre');
                                 }
                             });
 

--- a/deploy/post_deploy_testing/cypress/e2e/01b_static_content.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/01b_static_content.cy.js
@@ -83,6 +83,19 @@ describe('Static Page & Content Tests', function () {
                             cy.title().should('equal', titleText + ' – 4DN Data Portal').end(); // Ensure <head>...<title>TITLE</title>...</head> matches.
                             prevTitle = titleText;
 
+                            // Verify the presence of <pre> elements and ensure each one is not empty.
+                            cy.document().then((doc) => {
+                                const elements = doc.querySelectorAll('.rst-container > div > pre, .html-container > div > pre');
+                                if (elements.length > 0) {
+                                    cy.get('.rst-container > div > pre, .html-container > div > pre').each(($pre) => {
+                                        const textContent = $pre.text().trim();
+                                        expect(textContent).to.not.be.empty;
+                                    });
+                                } else {
+                                    cy.log('No <pre> elements found under .rst-container > div or .html-container > div');
+                                }
+                            });
+
                             if (!haveWeSeenPageWithTableOfContents) {
                                 cy.window().then((w)=>{
                                     if (w.document.querySelectorAll('div.table-of-contents li.table-content-entry a').length > 0){

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "8.4.4"
+version = "8.4.5"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Trello: https://trello.com/c/v7voLKI8/336-cypress-01bstaticcontent-updates-add-test-to-check-pre-tags-have-visible-content

This PR adds tests to verify the presence of `<pre>` elements and ensure their content is not empty. The following updates have been made:

#### **Target Areas:**

- `.rst-container > div > pre`
- `.html-container > div > pre`
- `.markdown-container > div > pre`

#### **Verifications:**

- Checks if `<pre>` elements are present within the specified containers.
- Verifies that the content of each `<pre>` element is not empty.