### PR TITLE
QC Report Links Updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ fourfront
 Change Log
 ----------
 
+8.5.1
+=====
+
+`PR 1921: QC report links updates <https://github.com/4dn-dcic/fourfront/pull/1921>`_
+
+* Bug fix: Hide QC HTML Report Links of WFR node details upon removal of bulk html reports already generated
+
+
 8.5.0
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Change Log
 * Enhanced table-full-size toggles for usage statistics
 * New histogram interval options for submission statistics
 * Chart section header styles updated
-* Hide QC HTML Report Links after removal of bulk html reports already generated
+* Hide QC HTML Report Links upon removal of bulk html reports already generated
 
 
 8.4.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 # Note: Various modules refer to this system as "encoded", not "fourfront".
 name = "encoded"
-version = "8.5.0"
+version = "8.5.1"
 description = "4DN-DCIC Fourfront"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/components/file-tables.js
+++ b/src/encoded/static/components/browse/components/file-tables.js
@@ -1100,7 +1100,7 @@ export class QCMetricsTable extends React.PureComponent {
     /**
      * Generates column headers for QCMetricsTable including render functions for each column
      * @param {*} fileGroups file groups
-     * @param {*} canShowMetricURL 2025-01-22: added to hide QC HTML Report Links after removal of bulk html reports already generated
+     * @param {*} canShowMetricURL 2025-01-22: hide QC HTML Report Links upon removal of bulk html reports already generated
      * @returns columnHeaders for QCMetricsTable including render functions for each column
      */
     static generateAlignedColumnHeaders(fileGroups, canShowMetricURL = false) {
@@ -1243,7 +1243,7 @@ export function QCMetricFromSummary(props){
     const { title, field } = props;
     const { value, tooltip } = QCMetricFromSummary.formatByNumberType(props);
 
-    // 2025-01-22: added to hide QC HTML Report Links after removal of bulk html reports already generated
+    // 2025-01-22: hide QC HTML Report Links upon removal of bulk html reports already generated
     if (field === 'url') { return null; }
 
     return (

--- a/src/encoded/static/components/item-pages/QualityMetricView.js
+++ b/src/encoded/static/components/item-pages/QualityMetricView.js
@@ -191,7 +191,7 @@ class QCMetricFromEmbed extends React.PureComponent {
         const { metric, qcProperty, schemaItem, schemas, fallbackTitle, tips, percent } = this.props;
         const { open, closing } = this.state;
 
-        // 2025-01-22: added to hide QC HTML Report Links after removal of bulk html reports already generated
+        // 2025-01-22: hide QC HTML Report Links upon removal of bulk html reports already generated
         if (qcProperty === "url") return null;
 
         const { qc_order = null, title = null, description: tip = null } = schemaItem || {};

--- a/src/encoded/static/components/item-pages/components/WorkflowDetailPane/FileDetailBody.js
+++ b/src/encoded/static/components/item-pages/components/WorkflowDetailPane/FileDetailBody.js
@@ -26,7 +26,8 @@ export class FileDetailBody extends React.PureComponent {
         'session' : PropTypes.bool.isRequired,
         'minHeight' : PropTypes.number,
         'keyTitleDescriptionMap' : PropTypes.object,
-        'windowWidth' : PropTypes.number.isRequired
+        'windowWidth' : PropTypes.number.isRequired,
+        'canShowMetricURL' : PropTypes.bool
     };
 
     doesDescriptionOrNotesExist(){
@@ -81,10 +82,13 @@ export class FileDetailBody extends React.PureComponent {
     }
 
     downloadLinkBox(){
-        var { node, file, session } = this.props, content;
+        var { node, file, session, canShowMetricURL = false } = this.props, content;
 
-        if (WorkflowNodeElement.isNodeQCMetric(node)){
-            content = <ViewMetricButton {...{ node, file }}/>;
+        if (WorkflowNodeElement.isNodeQCMetric(node)) {
+            if (canShowMetricURL !== true) {
+                return null;
+            }
+            content = <ViewMetricButton {...{ node, file }} />;
         } else {
             content = <fileUtil.FileDownloadButtonAuto result={file} session={session} />;
         }
@@ -121,8 +125,8 @@ export class FileDetailBody extends React.PureComponent {
     }
 
     qcBox(){
-        var { file, node } = this.props,
-            qc, qcLink;
+        const { file, node, canShowMetricURL = false } = this.props;
+        let qc = null, qcLink = null;
 
         if (!file || Array.isArray(file)){
             return null;
@@ -131,7 +135,7 @@ export class FileDetailBody extends React.PureComponent {
         qc = file && file.quality_metric;
         qcLink = qc && (qc.url || object.itemUtil.atId(qc));
 
-        if (!qcLink) return null;
+        if (!qcLink || !canShowMetricURL) return null;
 
         return (
             <div className="col-sm-6 col-lg-4 right box buttons-container">

--- a/src/encoded/static/components/item-pages/components/WorkflowNodeElement.js
+++ b/src/encoded/static/components/item-pages/components/WorkflowNodeElement.js
@@ -18,7 +18,8 @@ export class WorkflowNodeElement extends React.PureComponent {
         'disabled' : PropTypes.bool,
         'selected' : PropTypes.bool,
         'related'  : PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-        'columnWidth' : PropTypes.number
+        'columnWidth' : PropTypes.number,
+        'canShowMetricURL' : PropTypes.bool // If true, will show a clickable link to QC metric URL.
     };
 
     static ioFileTypes = new Set(['data file', 'QC', 'reference file', 'report']);
@@ -405,7 +406,7 @@ export class WorkflowNodeElement extends React.PureComponent {
      * seems having a link on node would be bit unexpected if clicked accidentally.
      */
     qcMarker(){
-        const { node, selected } = this.props;
+        const { node, selected, canShowMetricURL = false } = this.props;
 
         if (!WorkflowNodeElement.isNodeFile(node) || !WorkflowNodeElement.doesRunDataExist(node)){
             return null;
@@ -432,7 +433,7 @@ export class WorkflowNodeElement extends React.PureComponent {
             else if (qcStatus === 'error') markerProps.className += ' status-error';
         }
 
-        if (selected && qc.url){
+        if (selected && qc.url && canShowMetricURL === true){
             markerProps.className += ' clickable';
             return <a href={qc.url} target="_blank" rel="noreferrer noopener" {...markerProps} onClick={function(e){
                 e.preventDefault();


### PR DESCRIPTION
This pull request includes changes to improve the handling and visibility of QC HTML Report Links across various components. The most important changes include updates to the `FileDetailBody` component and the `QCMetricsTable` component to conditionally hide QC HTML Report Links based on a new `canShowMetricURL` property.

Changes to improve QC HTML Report Links handling:

* [`src/encoded/static/components/item-pages/components/WorkflowDetailPane/FileDetailBody.js`](diffhunk://#diff-85615aed0a86ba3eec6216dd745995bbc0776b9c3d76d636e3ffb0bd1d4134f6L29-R30): Added a new `canShowMetricURL` property and updated multiple methods to conditionally hide QC HTML Report Links based on this property. [[1]](diffhunk://#diff-85615aed0a86ba3eec6216dd745995bbc0776b9c3d76d636e3ffb0bd1d4134f6L29-R30) [[2]](diffhunk://#diff-85615aed0a86ba3eec6216dd745995bbc0776b9c3d76d636e3ffb0bd1d4134f6L84-R90) [[3]](diffhunk://#diff-85615aed0a86ba3eec6216dd745995bbc0776b9c3d76d636e3ffb0bd1d4134f6L124-R129) [[4]](diffhunk://#diff-85615aed0a86ba3eec6216dd745995bbc0776b9c3d76d636e3ffb0bd1d4134f6L134-R138)
* [`src/encoded/static/components/browse/components/file-tables.js`](diffhunk://#diff-c42974e448793f702eae83746e90073ad92e59f836a9c5d1ad718e9b79c7c0a3L1103-R1103): Updated comments and logic in `QCMetricsTable` and `QCMetricFromSummary` to reflect the new behavior of hiding QC HTML Report Links upon removal of bulk HTML reports. [[1]](diffhunk://#diff-c42974e448793f702eae83746e90073ad92e59f836a9c5d1ad718e9b79c7c0a3L1103-R1103) [[2]](diffhunk://#diff-c42974e448793f702eae83746e90073ad92e59f836a9c5d1ad718e9b79c7c0a3L1246-R1246)
* [`src/encoded/static/components/item-pages/QualityMetricView.js`](diffhunk://#diff-e6f4daa16da7a8a5e0ea5093da8b364a5404668794233848a8d4ceb37e1f330aL194-R194): Updated comments in `QCMetricFromEmbed` to reflect the new behavior of hiding QC HTML Report Links upon removal of bulk HTML reports.
* [`CHANGELOG.rst`](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cL21-R21): Updated the change log to reflect the new behavior of hiding QC HTML Report Links upon removal of bulk HTML reports.